### PR TITLE
remove udev dependencies from lvm2 and cryptsetup with new bbappends

### DIFF
--- a/recipes-crypto/cryptsetup/cryptsetup_%.bbappend
+++ b/recipes-crypto/cryptsetup/cryptsetup_%.bbappend
@@ -1,0 +1,2 @@
+# prevent udev as default dev manager being installed as dependency
+PACKAGECONFIG:remove = "udev"

--- a/recipes-support/lvm2/lvm2_%.bbappend
+++ b/recipes-support/lvm2/lvm2_%.bbappend
@@ -1,0 +1,2 @@
+# prevent udev as default dev manager being installed as dependency
+PACKAGECONFIG:remove = "udev"


### PR DESCRIPTION
Remove udev dependencies from PACKAGECONFIGs of to prevent unneeded udev files to be packaged in the initramfs
