### PR TITLE
Remove unneeded lxc-utilities from image to reduce initramfs size

### DIFF
--- a/recipes-core/lxc-pv/lxc-pv_git.bb
+++ b/recipes-core/lxc-pv/lxc-pv_git.bb
@@ -27,7 +27,16 @@ RDEPENDS_${PN} = " \
 		util-linux-getopt \
 "
 
-FILES:${PN} += " /usr/bin/lxc-*"
+# Split off some essential tools to be installed, do not install the rest of the ${bindir}/lxc* tools
+PACKAGES =+ "${PN}-essentials ${PN}-noinst"
+PACKAGE_EXCLUDE:${PN} = "${PN}-noinst"
+RDEPENDS:${PN} += "${PN}-essentials"
+FILES:${PN}-essentials = "${bindir}/lxc-console"
+FILES:${PN}-essentials += "${bindir}/lxc-info"
+FILES:${PN}-essentials += "${bindir}/lxc-ls"
+FILES:${PN}-essentials += "${bindir}/lxc-top"
+FILES:${PN}-noinst+= " ${bindir}/lxc-*"
+
 FILES:${PN} += " /usr/lib/lxc"
 FILES:${PN} += " /usr/var"
 FILES:${PN} += " /lib"


### PR DESCRIPTION
Removes unneeded lxc tools to save some space in the initramfs. Tools affected by this change:
- lxc-attach 
- lxc-autostart
- lxc-cgroup 
- lxc-checkconfig 
- lxc-checkpoint
- lxc-config 
- lxc-copy 
- lxc-create 
- lxc-destroy 
- lxc-device 
- lxc-execute 
- lxc-freeze 
- lxc-monitor 
- lxc-snapshot 
- lxc-start 
- lxc-stop 
- lxc-unfreeze 
- lxc-unshare 
- lxc-update-config 
- lxc-usernsexec 
- lxc-wait 

Tools that are still packaged:
- lxc-console
- lxc-info
- lxc-ls   
- lxc-top  