### PR TITLE
Inherit rm_work class to preserve space

### DIFF
--- a/kas/bsp-base.yaml
+++ b/kas/bsp-base.yaml
@@ -34,6 +34,8 @@ repos:
       meta-python:
 
 local_conf_header:
+  rm_work: |
+    INHERIT += "rm_work"
   panta-base: |
     TMPDIR = "${TOPDIR}/tmp-${DISTRO_CODENAME}"
   panta-busybox: |


### PR DESCRIPTION
rm_work will remove all intermediate build artifacts which preserver quite some space on disk.