### PR TITLE
pantavisor-bsp.bb: add PV_FIT_NAME_SUFFIX and PV_FIT_ITS_SUFFIX

### DIFF
--- a/recipes-pv/images/pantavisor-bsp.bb
+++ b/recipes-pv/images/pantavisor-bsp.bb
@@ -84,8 +84,8 @@ fakeroot do_compile(){
        cp -fL ${DEPLOY_DIR_IMAGE}/${PVBSP_UBOOT_LOGO_BMP} ${PVBSPSTATE}/bsp/uboot-logo.bmp
     fi
     if echo ${KERNEL_IMAGETYPES} | grep -q fitImage > /dev/null; then
-       cp -fL ${DEPLOY_DIR_IMAGE}/fitImage-its-${INITRAMFS_IMAGE_NAME}-${KERNEL_FIT_LINK_NAME} ${PVBSPSTATE}/bsp/pantavisor.its
-       cp -fL ${DEPLOY_DIR_IMAGE}/fitImage-${INITRAMFS_IMAGE_NAME}-${KERNEL_FIT_LINK_NAME} ${PVBSPSTATE}/bsp/pantavisor.fit
+       cp -fL ${DEPLOY_DIR_IMAGE}/fitImage-its-${INITRAMFS_IMAGE_NAME}-${KERNEL_FIT_LINK_NAME}${PV_FIT_ITS_SUFFIX} ${PVBSPSTATE}/bsp/pantavisor.its
+       cp -fL ${DEPLOY_DIR_IMAGE}/fitImage-${INITRAMFS_IMAGE_NAME}-${KERNEL_FIT_LINK_NAME}${PV_FIT_NAME_SUFFIX} ${PVBSPSTATE}/bsp/pantavisor.fit
        basearts='"fit": "pantavisor.fit",'
     else 
        case ${KERNEL_IMAGETYPE} in


### PR DESCRIPTION
If you are an integrator that ships the fitimage with a suffix, you can use these variables to adjust what pantavisor-bsp will copy into the pvr state.