### PR TITLE
== .github/configs/release/imx8qxp-mek-scarthgap.yaml ==

### DIFF
--- a/.github/configs/release/imx8qxp-mek-scarthgap.yaml
+++ b/.github/configs/release/imx8qxp-mek-scarthgap.yaml
@@ -3,7 +3,7 @@ header:
 _source_dir: .
 repos:
     meta-freescale:
-        commit: b70cec85b6a1a9cad70251623dc17e34f426cdf9
+        commit: 53650cefee8914fa9c2736ff9011558f22dbdfe1
         path: layers/meta-freescale
         url: https://github.com/Freescale/meta-freescale.git
     meta-freescale-3rdparty:
@@ -55,9 +55,9 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
 local_conf_header:
@@ -104,6 +104,7 @@ machine: imx8qxp-mek
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/raspberrypi-armv8-scarthgap.yaml
+++ b/.github/configs/release/raspberrypi-armv8-scarthgap.yaml
@@ -25,9 +25,9 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
@@ -73,6 +73,7 @@ machine: raspberrypi-armv8
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/sunxi-nanopi-r1-scarthgap.yaml
+++ b/.github/configs/release/sunxi-nanopi-r1-scarthgap.yaml
@@ -31,9 +31,9 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
@@ -77,6 +77,7 @@ machine: nanopi-r1
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
+++ b/.github/configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
@@ -31,9 +31,9 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
@@ -77,6 +77,7 @@ machine: orange-pi-3lts
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/sunxi-orange-pi-r1-scarthgap.yaml
+++ b/.github/configs/release/sunxi-orange-pi-r1-scarthgap.yaml
@@ -31,9 +31,9 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
@@ -77,6 +77,7 @@ machine: orange-pi-r1
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:


### PR DESCRIPTION
  meta-freescale:

    Changed repo https://github.com/Freescale/meta-freescale.git => https://github.com/Freescale/meta-freescale.git
            commit b70cec85b6a1a9cad70251623dc17e34f426cdf9 => 53650cefee8914fa9c2736ff9011558f22dbdfe1
      * 53650cef Merge pull request #1980 from Freescale/backport-1978-to-scarthgap
      * 598793b6 imx93-11x11: Fix KERNEL_DEVICETREE
      * 0627128b Merge pull request #1977 from Freescale/backport-1976-to-scarthgap
      * 112e490e kernel-module-isp-vvcam: prevent build warning
      * 9f3f9e4b Merge pull request #1974 from Freescale/backport-1973-to-scarthgap
      * b20d5289 linux-fslc: 6.11.0 -> 6.11.3
      * 9d69db63 Merge pull request #1972 from Freescale/backport-1971-to-scarthgap
      * 3252e00e linux-fslc-imx: Use 6.6-2.1.0.x from NXP BSP LF6.6.36_2.1.0
      * 468f298c Merge pull request #1970 from nxp-upstream/cryptodev
      * 36d1556b cryptodev-module: Drop redundant patch
      * e05119f8 Merge pull request #1969 from Freescale/backport-1968-to-scarthgap
      * 0ede6b6f imx-atf: Redefine LD using HOST_PREFIX

  poky:

    Changed repo https://github.com/yoctoproject/poky.git => https://github.com/yoctoproject/poky.git
            commit c799f73a47fa35d6059456291328f7ff10fdb273 => 200d12b6a58ad961d60a7774ca0f7a9d29498724
      * 200d12b6a5 image.bbclass: Drop support for ImageQAFailed exceptions in image_qa
      * 8156bb675c meta-ide-support: Mark recipe as MACHINE-specific
      * 2c09c72cf1 image_qa: fix error handling
      * cbd445e044 libsdl2: Fix non-deterministic configure option for libsamplerate
      * f9fd48d759 recipes-bsp: usbutils: Fix usb-devices command using busybox
      * e6acba1518 uboot-sign: fix counters in do_uboot_assemble_fitimage
      * f43ef3aa92 runqemu: Fix detection of -serial parameter
      * 008e269c6b makedevs: Fix matching uid/gid
      * 9d9325d07b lib/oe/package-manager: skip processing installed-pkgs with empty globs
      * 3d6bbf83ea virglrenderer: Add patch to fix -int-conversion build issue
      * 75ac1f529a license: Fix directory layout issues
      * 302fd9c095 libpcre2: Update base uri PhilipHazel -> PCRE2Project
      * 597c051923 sysvinit: take release tarballs from github
      * d6951e3ce3 ptest-runner: Update 2.4.4 -> 2.4.5
      * 0402f54b66 ruby: upgrade 3.2.2 -> 3.3.5
      * 711c934229 linux-firmware: upgrade 20240312 -> 20240909
      * f88e92a7b3 libarchive: fix CVE-2024-48957 & CVE-2024-48958
      * afbf467405 cups: Backport fix for CVE-2024-47175
      * fc449a98b6 rust: ignore CVE-2024-43402
      * cd44e6bd40 migration-guide: add release notes for 4.0.21
      * 890f63b6bf meta-world-pkgdata: Inherit nopackages
      * a3987f60df populate_sdk_base: inherit nopackages
      * 92d7f055c4 cryptodev: upgrade 1.13 -> 1.14
      * 4639bc9503 webkitgtk: upgrade 2.44.1 -> 2.44.3
      * 2186202022 glibc: stable 2.39 branch updates.
      * c6844e50df wpa-supplicant: Patch security advisory 2024-2
      * eca9779e43 wpa-supplicant: Patch CVE-2024-3596
      * e828e0364a wpa-supplicant: Ignore CVE-2024-5290
      * ff5c6bd86f openssh: Mark CVE-2023-51767 as wont-fix
      * ff0f3fca81 gnupg: Document CVE-2022-3219 and mark wontfix

  meta-virtualization:

    Changed repo git://git.yoctoproject.org/meta-virtualization => git://git.yoctoproject.org/meta-virtualization
            commit e5878c864aacd24fe8f09ab7221f0ada13cd22d3 => 6f3c1d8f90947408a6587be222fec575a1ca5195
      * 6f3c1d8f linux-yocto_virtualization.inc: If using externalsrc adjust dependency
      * 7088ce79 device-tree: Rename EXTRA_OVERLAYS to EXTRA_DT_INCLUDE_FILES

== .github/configs/release/raspberrypi-armv8-scarthgap.yaml ==

  poky:

    Changed repo https://github.com/yoctoproject/poky.git => https://github.com/yoctoproject/poky.git
            commit c799f73a47fa35d6059456291328f7ff10fdb273 => 200d12b6a58ad961d60a7774ca0f7a9d29498724
      * 200d12b6a5 image.bbclass: Drop support for ImageQAFailed exceptions in image_qa
      * 8156bb675c meta-ide-support: Mark recipe as MACHINE-specific
      * 2c09c72cf1 image_qa: fix error handling
      * cbd445e044 libsdl2: Fix non-deterministic configure option for libsamplerate
      * f9fd48d759 recipes-bsp: usbutils: Fix usb-devices command using busybox
      * e6acba1518 uboot-sign: fix counters in do_uboot_assemble_fitimage
      * f43ef3aa92 runqemu: Fix detection of -serial parameter
      * 008e269c6b makedevs: Fix matching uid/gid
      * 9d9325d07b lib/oe/package-manager: skip processing installed-pkgs with empty globs
      * 3d6bbf83ea virglrenderer: Add patch to fix -int-conversion build issue
      * 75ac1f529a license: Fix directory layout issues
      * 302fd9c095 libpcre2: Update base uri PhilipHazel -> PCRE2Project
      * 597c051923 sysvinit: take release tarballs from github
      * d6951e3ce3 ptest-runner: Update 2.4.4 -> 2.4.5
      * 0402f54b66 ruby: upgrade 3.2.2 -> 3.3.5
      * 711c934229 linux-firmware: upgrade 20240312 -> 20240909
      * f88e92a7b3 libarchive: fix CVE-2024-48957 & CVE-2024-48958
      * afbf467405 cups: Backport fix for CVE-2024-47175
      * fc449a98b6 rust: ignore CVE-2024-43402
      * cd44e6bd40 migration-guide: add release notes for 4.0.21
      * 890f63b6bf meta-world-pkgdata: Inherit nopackages
      * a3987f60df populate_sdk_base: inherit nopackages
      * 92d7f055c4 cryptodev: upgrade 1.13 -> 1.14
      * 4639bc9503 webkitgtk: upgrade 2.44.1 -> 2.44.3
      * 2186202022 glibc: stable 2.39 branch updates.
      * c6844e50df wpa-supplicant: Patch security advisory 2024-2
      * eca9779e43 wpa-supplicant: Patch CVE-2024-3596
      * e828e0364a wpa-supplicant: Ignore CVE-2024-5290
      * ff5c6bd86f openssh: Mark CVE-2023-51767 as wont-fix
      * ff0f3fca81 gnupg: Document CVE-2022-3219 and mark wontfix

  meta-virtualization:

    Changed repo git://git.yoctoproject.org/meta-virtualization => git://git.yoctoproject.org/meta-virtualization
            commit e5878c864aacd24fe8f09ab7221f0ada13cd22d3 => 6f3c1d8f90947408a6587be222fec575a1ca5195
      * 6f3c1d8f linux-yocto_virtualization.inc: If using externalsrc adjust dependency
      * 7088ce79 device-tree: Rename EXTRA_OVERLAYS to EXTRA_DT_INCLUDE_FILES

== .github/configs/release/sunxi-nanopi-r1-scarthgap.yaml ==

  poky:

    Changed repo https://github.com/yoctoproject/poky.git => https://github.com/yoctoproject/poky.git
            commit c799f73a47fa35d6059456291328f7ff10fdb273 => 200d12b6a58ad961d60a7774ca0f7a9d29498724
      * 200d12b6a5 image.bbclass: Drop support for ImageQAFailed exceptions in image_qa
      * 8156bb675c meta-ide-support: Mark recipe as MACHINE-specific
      * 2c09c72cf1 image_qa: fix error handling
      * cbd445e044 libsdl2: Fix non-deterministic configure option for libsamplerate
      * f9fd48d759 recipes-bsp: usbutils: Fix usb-devices command using busybox
      * e6acba1518 uboot-sign: fix counters in do_uboot_assemble_fitimage
      * f43ef3aa92 runqemu: Fix detection of -serial parameter
      * 008e269c6b makedevs: Fix matching uid/gid
      * 9d9325d07b lib/oe/package-manager: skip processing installed-pkgs with empty globs
      * 3d6bbf83ea virglrenderer: Add patch to fix -int-conversion build issue
      * 75ac1f529a license: Fix directory layout issues
      * 302fd9c095 libpcre2: Update base uri PhilipHazel -> PCRE2Project
      * 597c051923 sysvinit: take release tarballs from github
      * d6951e3ce3 ptest-runner: Update 2.4.4 -> 2.4.5
      * 0402f54b66 ruby: upgrade 3.2.2 -> 3.3.5
      * 711c934229 linux-firmware: upgrade 20240312 -> 20240909
      * f88e92a7b3 libarchive: fix CVE-2024-48957 & CVE-2024-48958
      * afbf467405 cups: Backport fix for CVE-2024-47175
      * fc449a98b6 rust: ignore CVE-2024-43402
      * cd44e6bd40 migration-guide: add release notes for 4.0.21
      * 890f63b6bf meta-world-pkgdata: Inherit nopackages
      * a3987f60df populate_sdk_base: inherit nopackages
      * 92d7f055c4 cryptodev: upgrade 1.13 -> 1.14
      * 4639bc9503 webkitgtk: upgrade 2.44.1 -> 2.44.3
      * 2186202022 glibc: stable 2.39 branch updates.
      * c6844e50df wpa-supplicant: Patch security advisory 2024-2
      * eca9779e43 wpa-supplicant: Patch CVE-2024-3596
      * e828e0364a wpa-supplicant: Ignore CVE-2024-5290
      * ff5c6bd86f openssh: Mark CVE-2023-51767 as wont-fix
      * ff0f3fca81 gnupg: Document CVE-2022-3219 and mark wontfix

  meta-virtualization:

    Changed repo git://git.yoctoproject.org/meta-virtualization => git://git.yoctoproject.org/meta-virtualization
            commit e5878c864aacd24fe8f09ab7221f0ada13cd22d3 => 6f3c1d8f90947408a6587be222fec575a1ca5195
      * 6f3c1d8f linux-yocto_virtualization.inc: If using externalsrc adjust dependency
      * 7088ce79 device-tree: Rename EXTRA_OVERLAYS to EXTRA_DT_INCLUDE_FILES

== .github/configs/release/sunxi-orange-pi-3lts-scarthgap.yaml ==

  poky:

    Changed repo https://github.com/yoctoproject/poky.git => https://github.com/yoctoproject/poky.git
            commit c799f73a47fa35d6059456291328f7ff10fdb273 => 200d12b6a58ad961d60a7774ca0f7a9d29498724
      * 200d12b6a5 image.bbclass: Drop support for ImageQAFailed exceptions in image_qa
      * 8156bb675c meta-ide-support: Mark recipe as MACHINE-specific
      * 2c09c72cf1 image_qa: fix error handling
      * cbd445e044 libsdl2: Fix non-deterministic configure option for libsamplerate
      * f9fd48d759 recipes-bsp: usbutils: Fix usb-devices command using busybox
      * e6acba1518 uboot-sign: fix counters in do_uboot_assemble_fitimage
      * f43ef3aa92 runqemu: Fix detection of -serial parameter
      * 008e269c6b makedevs: Fix matching uid/gid
      * 9d9325d07b lib/oe/package-manager: skip processing installed-pkgs with empty globs
      * 3d6bbf83ea virglrenderer: Add patch to fix -int-conversion build issue
      * 75ac1f529a license: Fix directory layout issues
      * 302fd9c095 libpcre2: Update base uri PhilipHazel -> PCRE2Project
      * 597c051923 sysvinit: take release tarballs from github
      * d6951e3ce3 ptest-runner: Update 2.4.4 -> 2.4.5
      * 0402f54b66 ruby: upgrade 3.2.2 -> 3.3.5
      * 711c934229 linux-firmware: upgrade 20240312 -> 20240909
      * f88e92a7b3 libarchive: fix CVE-2024-48957 & CVE-2024-48958
      * afbf467405 cups: Backport fix for CVE-2024-47175
      * fc449a98b6 rust: ignore CVE-2024-43402
      * cd44e6bd40 migration-guide: add release notes for 4.0.21
      * 890f63b6bf meta-world-pkgdata: Inherit nopackages
      * a3987f60df populate_sdk_base: inherit nopackages
      * 92d7f055c4 cryptodev: upgrade 1.13 -> 1.14
      * 4639bc9503 webkitgtk: upgrade 2.44.1 -> 2.44.3
      * 2186202022 glibc: stable 2.39 branch updates.
      * c6844e50df wpa-supplicant: Patch security advisory 2024-2
      * eca9779e43 wpa-supplicant: Patch CVE-2024-3596
      * e828e0364a wpa-supplicant: Ignore CVE-2024-5290
      * ff5c6bd86f openssh: Mark CVE-2023-51767 as wont-fix
      * ff0f3fca81 gnupg: Document CVE-2022-3219 and mark wontfix

  meta-virtualization:

    Changed repo git://git.yoctoproject.org/meta-virtualization => git://git.yoctoproject.org/meta-virtualization
            commit e5878c864aacd24fe8f09ab7221f0ada13cd22d3 => 6f3c1d8f90947408a6587be222fec575a1ca5195
      * 6f3c1d8f linux-yocto_virtualization.inc: If using externalsrc adjust dependency
      * 7088ce79 device-tree: Rename EXTRA_OVERLAYS to EXTRA_DT_INCLUDE_FILES

== .github/configs/release/sunxi-orange-pi-r1-scarthgap.yaml ==

  poky:

    Changed repo https://github.com/yoctoproject/poky.git => https://github.com/yoctoproject/poky.git
            commit c799f73a47fa35d6059456291328f7ff10fdb273 => 200d12b6a58ad961d60a7774ca0f7a9d29498724
      * 200d12b6a5 image.bbclass: Drop support for ImageQAFailed exceptions in image_qa
      * 8156bb675c meta-ide-support: Mark recipe as MACHINE-specific
      * 2c09c72cf1 image_qa: fix error handling
      * cbd445e044 libsdl2: Fix non-deterministic configure option for libsamplerate
      * f9fd48d759 recipes-bsp: usbutils: Fix usb-devices command using busybox
      * e6acba1518 uboot-sign: fix counters in do_uboot_assemble_fitimage
      * f43ef3aa92 runqemu: Fix detection of -serial parameter
      * 008e269c6b makedevs: Fix matching uid/gid
      * 9d9325d07b lib/oe/package-manager: skip processing installed-pkgs with empty globs
      * 3d6bbf83ea virglrenderer: Add patch to fix -int-conversion build issue
      * 75ac1f529a license: Fix directory layout issues
      * 302fd9c095 libpcre2: Update base uri PhilipHazel -> PCRE2Project
      * 597c051923 sysvinit: take release tarballs from github
      * d6951e3ce3 ptest-runner: Update 2.4.4 -> 2.4.5
      * 0402f54b66 ruby: upgrade 3.2.2 -> 3.3.5
      * 711c934229 linux-firmware: upgrade 20240312 -> 20240909
      * f88e92a7b3 libarchive: fix CVE-2024-48957 & CVE-2024-48958
      * afbf467405 cups: Backport fix for CVE-2024-47175
      * fc449a98b6 rust: ignore CVE-2024-43402
      * cd44e6bd40 migration-guide: add release notes for 4.0.21
      * 890f63b6bf meta-world-pkgdata: Inherit nopackages
      * a3987f60df populate_sdk_base: inherit nopackages
      * 92d7f055c4 cryptodev: upgrade 1.13 -> 1.14
      * 4639bc9503 webkitgtk: upgrade 2.44.1 -> 2.44.3
      * 2186202022 glibc: stable 2.39 branch updates.
      * c6844e50df wpa-supplicant: Patch security advisory 2024-2
      * eca9779e43 wpa-supplicant: Patch CVE-2024-3596
      * e828e0364a wpa-supplicant: Ignore CVE-2024-5290
      * ff5c6bd86f openssh: Mark CVE-2023-51767 as wont-fix
      * ff0f3fca81 gnupg: Document CVE-2022-3219 and mark wontfix

  meta-virtualization:

    Changed repo git://git.yoctoproject.org/meta-virtualization => git://git.yoctoproject.org/meta-virtualization
            commit e5878c864aacd24fe8f09ab7221f0ada13cd22d3 => 6f3c1d8f90947408a6587be222fec575a1ca5195
      * 6f3c1d8f linux-yocto_virtualization.inc: If using externalsrc adjust dependency
      * 7088ce79 device-tree: Rename EXTRA_OVERLAYS to EXTRA_DT_INCLUDE_FILES