### PR TITLE
.github/workflows: use META_PANTAVISOR_PAT token instead of GITHUB_TOKEN

### DIFF
--- a/.github/configs/release/imx8qxp-mek-scarthgap.yaml
+++ b/.github/configs/release/imx8qxp-mek-scarthgap.yaml
@@ -3,7 +3,7 @@ header:
 _source_dir: .
 repos:
     meta-freescale:
-        commit: b70cec85b6a1a9cad70251623dc17e34f426cdf9
+        commit: cb16b9c0191549925e08458c37b8eaae613b6e4e
         path: layers/meta-freescale
         url: https://github.com/Freescale/meta-freescale.git
     meta-freescale-3rdparty:
@@ -23,7 +23,7 @@ repos:
             meta-python:
         url: https://github.com/openembedded/meta-openembedded.git
         path: layers/meta-openembedded
-        commit: 72018ca1b1a471226917e8246e8bbf9a374ccf97
+        commit: 2e3126c9c16bb3df0560f6b3896d01539a3bfad7
     meta-imx:
         url: https://github.com/nxp-imx/meta-imx.git
         path: layers/meta-imx
@@ -38,7 +38,7 @@ repos:
             meta-imx-sdk:
         commit: 239073c47124f41f46581871afbde643f48d6a3b
     meta-arm:
-        commit: 950a4afce46a359def2958bd9ae33fc08ff9bb0d
+        commit: 60e31ef2c4983c0bdb8682dee6a6ec5f2e9d5f0a
         layers:
             meta-arm:
             meta-arm-toolchain:
@@ -55,9 +55,9 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
 local_conf_header:
@@ -104,6 +104,7 @@ machine: imx8qxp-mek
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/raspberrypi-armv8-scarthgap.yaml
+++ b/.github/configs/release/raspberrypi-armv8-scarthgap.yaml
@@ -25,13 +25,13 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 72018ca1b1a471226917e8246e8bbf9a374ccf97
+        commit: 2e3126c9c16bb3df0560f6b3896d01539a3bfad7
         layers:
             meta-filesystems:
             meta-networking:
@@ -73,6 +73,7 @@ machine: raspberrypi-armv8
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/rockchip-rock64-scarthgap.yaml
+++ b/.github/configs/release/rockchip-rock64-scarthgap.yaml
@@ -2,19 +2,12 @@ header:
     version: 16
 _source_dir: .
 repos:
-    meta-sunxi:
-        commit: 05827e296c2cb09043141b241153468deb4428d0
-        patches:
-            orange-pi-3lts:
-                path: patches/meta-sunxi/0002-orange-pi-3lts-backport.patch
-                repo: meta-pantavisor
-            wks-root-label:
-                path: patches/meta-sunxi/0001-wks-root-label.patch
-                repo: meta-pantavisor
-        path: layers/meta-sunxi
-        url: https://github.com/linux-sunxi/meta-sunxi
+    meta-rockchip:
+        commit: e641dba980efa885df7e992ac5c8783270aa375d
+        path: layers/meta-rockchip-mainline
+        url: https://git.yoctoproject.org/meta-rockchip
     meta-arm:
-        commit: 950a4afce46a359def2958bd9ae33fc08ff9bb0d
+        commit: 60e31ef2c4983c0bdb8682dee6a6ec5f2e9d5f0a
         layers:
             meta-arm:
             meta-arm-toolchain:
@@ -31,13 +24,13 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 72018ca1b1a471226917e8246e8bbf9a374ccf97
+        commit: 2e3126c9c16bb3df0560f6b3896d01539a3bfad7
         layers:
             meta-filesystems:
             meta-networking:
@@ -46,7 +39,7 @@ repos:
         path: layers/meta-openembedded
         url: https://github.com/openembedded/meta-openembedded.git
 local_conf_header:
-    platform-sunxi: |
+    platform-rockchip: |
         PV_UBOOT_AUTOFDT = "1"
     rm_work: |
         INHERIT += "rm_work"
@@ -73,10 +66,11 @@ local_conf_header:
     __voldirs: |-
         SSTATE_DIR="/shared/sstate"
         DL_DIR="/shared/dldir"
-machine: orange-pi-r1
+machine: rock64
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/sunxi-nanopi-r1-scarthgap.yaml
+++ b/.github/configs/release/sunxi-nanopi-r1-scarthgap.yaml
@@ -14,7 +14,7 @@ repos:
         path: layers/meta-sunxi
         url: https://github.com/linux-sunxi/meta-sunxi
     meta-arm:
-        commit: 950a4afce46a359def2958bd9ae33fc08ff9bb0d
+        commit: 60e31ef2c4983c0bdb8682dee6a6ec5f2e9d5f0a
         layers:
             meta-arm:
             meta-arm-toolchain:
@@ -31,13 +31,13 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 72018ca1b1a471226917e8246e8bbf9a374ccf97
+        commit: 2e3126c9c16bb3df0560f6b3896d01539a3bfad7
         layers:
             meta-filesystems:
             meta-networking:
@@ -77,6 +77,7 @@ machine: nanopi-r1
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
+++ b/.github/configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
@@ -14,7 +14,7 @@ repos:
         path: layers/meta-sunxi
         url: https://github.com/linux-sunxi/meta-sunxi
     meta-arm:
-        commit: 950a4afce46a359def2958bd9ae33fc08ff9bb0d
+        commit: 60e31ef2c4983c0bdb8682dee6a6ec5f2e9d5f0a
         layers:
             meta-arm:
             meta-arm-toolchain:
@@ -31,13 +31,13 @@ repos:
             fit-image-multiconfig:
                 path: patches/poky/0001-fit-image-multiconfig.scarthgap.patch
                 repo: meta-pantavisor
-        commit: c799f73a47fa35d6059456291328f7ff10fdb273
+        commit: 200d12b6a58ad961d60a7774ca0f7a9d29498724
     meta-virtualization:
-        commit: e5878c864aacd24fe8f09ab7221f0ada13cd22d3
+        commit: 6f3c1d8f90947408a6587be222fec575a1ca5195
         path: layers/meta-virtualization
         url: git://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 72018ca1b1a471226917e8246e8bbf9a374ccf97
+        commit: 2e3126c9c16bb3df0560f6b3896d01539a3bfad7
         layers:
             meta-filesystems:
             meta-networking:
@@ -77,6 +77,7 @@ machine: orange-pi-3lts
 target:
 - pantavisor-remix
 build_system: oe
+distro: panta-distro
 env:
     PVROOT_IMAGE_BSP:
     PV_BOOT_OEMARGS:

--- a/.github/workflows/buildkas.yaml
+++ b/.github/workflows/buildkas.yaml
@@ -19,6 +19,9 @@ jobs:
         - shared:/shared
       options: --user root
     steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.META_PANTAVISOR_PAT }}
       - name: chown
         run: chown -R builder:builder $RUNNER_WORKSPACE
       - name: chowna

--- a/.github/workflows/onpush.yaml
+++ b/.github/workflows/onpush.yaml
@@ -14,11 +14,11 @@ jobs:
     with:
       configs: .github/configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
       name: sunxi-orange-pi-3lts-scarthgap
-  build-sunxi-orange-pi-r1-scarthgap:
+  build-rockchip-rock64-scarthgap:
     uses: ./.github/workflows/buildkas.yaml
     with:
-      configs: .github/configs/release/sunxi-orange-pi-r1-scarthgap.yaml
-      name: sunxi-orange-pi-r1-scarthgap
+      configs: .github/configs/release/rockchip-rock64-scarthgap.yaml
+      name: rockchip-rock64-scarthgap
   build-sunxi-nanopi-r1-scarthgap:
     uses: ./.github/workflows/buildkas.yaml
     with:

--- a/.github/workflows/updatemachines.yaml
+++ b/.github/workflows/updatemachines.yaml
@@ -19,6 +19,8 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.META_PANTAVISOR_PAT }}
       - run: ls .github/scripts
       - run: pwd
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE


### PR DESCRIPTION
Using a proper PAT token will ensure that pushes done to repo will trigger the on: push: workflows.