### PR TITLE
u-boot: update boot.cmd.pvgeneric to ensure kernel panic triggers reboot

### DIFF
--- a/recipes-bsp/u-boot/files/boot.cmd.pvgeneric
+++ b/recipes-bsp/u-boot/files/boot.cmd.pvgeneric
@@ -3,7 +3,7 @@ echo "Pantavisor Starts"
 if test -z "$pv_platargs"; then
 	setenv pv_platargs "earlyprintk"
 fi
-setenv pv_baseargs "root=/dev/ram rootfstype=ramfs rdinit=/usr/bin/pantavisor"
+setenv pv_baseargs "panic=3 root=/dev/ram rootfstype=ramfs rdinit=/usr/bin/pantavisor"
 setenv pv_ctrl 2
 if test -z "${devtype}"; then
 	setenv devtype mmc


### PR DESCRIPTION
Pantavisor relies on the kernel to reboot in case it panics. This will allow Pantavisor to automatically rollback to previous revision and reboot to ensure device availability in case of a fatal kernel issue