### PR TITLE
Update Pantavisor components

### DIFF
--- a/recipes-pv/libthttp/libthttp_git.bb
+++ b/recipes-pv/libthttp/libthttp_git.bb
@@ -14,7 +14,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}_${PV}:"
 PACKAGES += "libthttp-certs"
 
 SRC_URI = "git://gitlab.com/pantacor/libthttp.git;protocol=https;branch=master"
-SRCREV = "a51d14e3ece654013558043a5ae2e1b68b4ef93f"
+SRCREV = "8814b40e2a6564959eead182c17d0fc02e104099"
 
 FILES:${PN}-certs += " /certs/* "
 

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -27,7 +27,7 @@ SRC_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https;branch=${PA
 SRC_URI += " file://pantavisor-run"
 SRC_URI += " file://rev0json"
 
-SRCREV = "de31b9894bd8a0978c16dba85994623715202621"
+SRCREV = "3eb459becb48d1c97650c122fdb89951e99571e7"
 
 FILES:${PN} += " /usr/bin/pantavisor-run"
 FILES:${PN} += " /usr/lib"


### PR DESCRIPTION
Pantavisor:
3eb459b (github/master) fix: update status and retry count not being loaded after processing new updates and rolling back
5838c16 fix: secrets appearing in plain text in logs 6d32762 refactor: use json ser library to form ctrl objects ls output 
0fdd0ca (HEAD, gitlab/master) feat: add process names for log server, ph logger and main loop
6a0f2d3 fix: libthttp size offset overflow and several bad memory allocations
f76c2af fix: libthttp logs inside of ph_logger forks writing garbage
ba93cfc fix: broken pipe signal crashing main loop
506121d fix: device not rebooting after main loop crash
95b527c (bugfix/get-objects-include-zero-size) fix: multiple wrong variable formats in pv_log and sprintf
9cf3f5a avoid running export.sh hook when not defined in run.json
24cd366 print mount table in stdout_direct before rebooting
6898bc6 fix: storage being unmounted but not mounted in appengine
c785f15 fix: /pv/phconfig not being unmounted on shutdown d050036 fix: ctrl object ls logs too verbose
d9ab30f fix: ctrl GET objects not allocating enough memory for some objects
94ce8b7 fix: ctrl GET objects returning malformed JSON when listing a 0 sized object 11d8b9f fix: define MS_NOSYMFOLLOW in remount not supported until Linux 5.10 4ee3297 fix: new remount LXC hook crashing
d3c0515 Improve the creation of "no validate" list 8bf549a refactor: remount lxc hook in C
0a85bff Add support for AB boot using uboot
47ae5a4 fix broken hine file (/pv/{challenge,device-id}) permissions from 044 to 444 6bfe5a5 fix: not loading Pantacor Hub creds between reboots 060d39f ctrl.c: include zero sized objects from pool in GET /objects endpoint

Libthttp:
8814b40 (HEAD, gitlab/master) Merge branch 'fix/object-size' into 'master'
6e4ba94 fix: integer overflow in thttp_request change int to off_t