### PR TITLE
pantavisor: add patch to skip install of skel (/etc/resolv.conf)

### DIFF
--- a/recipes-pv/pantavisor/files/0001-CMakeLists.txt-install-skel-only-if-PANTAVISOR_DEFAU.patch
+++ b/recipes-pv/pantavisor/files/0001-CMakeLists.txt-install-skel-only-if-PANTAVISOR_DEFAU.patch
@@ -1,0 +1,27 @@
+From 9198c225ac225a612cba6596ba397408af518ee3 Mon Sep 17 00:00:00 2001
+From: kas User <kas@example.com>
+Date: Fri, 11 Apr 2025 08:55:38 +0000
+Subject: [PATCH] CMakeLists.txt: install skel/ only if
+ PANTAVISOR_DEFAULTS_SKIP_INSTALL is not set
+
+---
+ CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 77eb38c..086f59b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,11 +191,9 @@ IF(PANTAVISOR_DEBUG)
+ target_compile_definitions(pantavisor PRIVATE PANTAVISOR_DEBUG)
+ ENDIF()
+ 
++IF(NOT PANTAVISOR_DEFAULTS_SKIP_INSTALL)
+ ## install basic filesystem skeleton
+ install(DIRECTORY skel/ DESTINATION /)
+-
+-
+-IF(NOT PANTAVISOR_DEFAULTS_SKIP_INSTALL)
+ ### ... insert defaults/
+ install(DIRECTORY defaults DESTINATION /etc/pantavisor)
+ ENDIF()

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -23,9 +23,11 @@ S = "${WORKDIR}/git"
 
 PANTAVISOR_BRANCH ??= "master"
 
-SRC_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https;branch=${PANTAVISOR_BRANCH}"
-SRC_URI += " file://pantavisor-run"
-SRC_URI += " file://rev0json"
+SRC_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https;branch=${PANTAVISOR_BRANCH} \
+           file://pantavisor-run \
+           file://rev0json \
+           file://0001-CMakeLists.txt-install-skel-only-if-PANTAVISOR_DEFAU.patch \
+           "
 
 SRCREV = "8b7f75159bcbb8011fd5478ae58603ebe72dff9d"
 
@@ -43,7 +45,7 @@ EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'usrmerge', '-DPANTAVI
 EXTRA_OECMAKE += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'debug', '-DPANTAVISOR_DEBUG=ON', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'dm-crypt', '-DPANTAVISOR_DM_CRYPT=ON', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'dm-verity', '-DPANTAVISOR_DM_VERITY=ON', '', d)}"
-EXTRA_OECMAKE += "-DPANTAVISOR_PVS_SKIP_INSTALL=ON"
+EXTRA_OECMAKE += "-DPANTAVISOR_PVS_SKIP_INSTALL=ON -DPANTAVISOR_DEFAULTS_SKIP_INSTALL=ON"
 
 OECMAKE_C_FLAGS += "-Wno-unused-result -ldl"
 


### PR DESCRIPTION
pantavisor-config packages currently cannot ship a custom resolv.conf without a package conflict because pantavisor upstream source installed /etc/resolv.conf uncondionally.

The added patch fixes this by making the skel/ install conditional and only install it if PANTAVISOR_DEFAULTS_SKIP_INSTALL=ON is not set as cmake flag