### PR TITLE
pantavisor-default-skel add files for MACHINEOVERRIDES with 'rpi'

### DIFF
--- a/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/bsp/drivers.json
+++ b/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/bsp/drivers.json
@@ -1,0 +1,18 @@
+{
+    "#spec": "driver-aliases@1",
+    "all": {
+        "bluetooth": [
+            "btbcm",
+            "hci_uart"
+        ],
+        "wifi": [
+            "brcmutil",
+            "brcmfmac"
+        ],
+        "wireguard": [
+            "wireguard"
+        ]
+    },
+    "dtb:all": {}
+}
+

--- a/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
@@ -1,0 +1,53 @@
+{
+    "disks": [
+        {
+	    "name": "dm-internal-secrets",
+	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
+	    "type": "dm-crypt-versatile"
+	}
+    ],
+    "groups": [
+	{
+	    "description": "Containers which volumes we want to mount but not to be started",
+	    "name": "data",
+	    "restart_policy": "system",
+	    "status_goal": "MOUNTED",
+	    "timeout": 30
+	},
+	{
+	    "description": "Container or containers that are in charge of setting network connectivity up for the board",
+	    "name": "root",
+	    "restart_policy": "system",
+	    "status_goal": "STARTED",
+	    "timeout": 30
+	},
+	{
+	    "description": "Middleware and utility containers",
+	    "name": "platform",
+	    "restart_policy": "system",
+	    "status_goal": "STARTED",
+	    "timeout": 30
+	},
+	{
+	    "description": "Application level containers",
+	    "name": "app",
+	    "restart_policy": "container",
+	    "status_goal": "STARTED",
+	    "timeout": 30
+	}
+    ],
+    "volumes": {
+	"pv--devmeta": {
+	    "disk": "dm-internal-secrets",
+	    "persistence": "permanent"
+	},
+	"pv--usrmeta": {
+	    "disk": "dm-internal-secrets",
+	    "persistence": "permanent"
+	},
+        "pv--phconfig": {
+            "disk": "dm-internal-secrets",
+            "persistence": "permanent"
+        }
+    }
+}


### PR DESCRIPTION
This fixes broken raspberry pi module loading