### PR TITLE
linux-%.bbappend: PANTAVISOR_FEATURES 'tailscale'

### DIFF
--- a/kas/bsp-base.yaml
+++ b/kas/bsp-base.yaml
@@ -49,6 +49,8 @@ local_conf_header:
     INITRAMFS_IMAGE = "pantavisor-initramfs"
   pantavisor-runc: |
     PANTAVISOR_FEATURES:append = " runc"
+  pantavisor-tailscale: |
+    PANTAVISOR_FEATURES:append = " tailscale"
   pantavisor-debug: |
     PANTAVISOR_FEATURES:append = " debug"
 env:

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -11,11 +11,32 @@ KERNEL_CLASSES:qemumips += "kernel-uimage"
 KBUILD_DEFCONFIG:qemumips = "malta_defconfig"
 KERNEL_DEVICETREE:qemumips = "mti/malta.dtb"
 
+# Determine which kernel fragment to include based on IMAGE_INSTALL
+# We check if 'nftables' is in IMAGE_INSTALL.
+# If it is, we assume nftables is the desired firewall backend.
+# Otherwise, we default to the iptables-legacy configuration.
+TAILSCALE_KERNEL_SRC_URI = ""
+TAILSCALE_KERNEL_FRAGMENT = ""
+python () {
+    if not bb.utils.contains('PANTAVISOR_FEATURES', 'tailscale', True, False, d):
+        return
+
+    if bb.utils.contains('IMAGE_INSTALL', 'nftables', True, False, d):
+        d.setVar('TAILSCALE_KERNEL_FRAGMENT', '${WORKDIR}/tailscale-nftables.cfg')
+        d.setVar('TAILSCALE_KERNEL_SRC_URI', 'file://tailscale-nftables.cfg')
+    else:
+        # If nftables is NOT in IMAGE_INSTALL, assume iptables-legacy compatibility
+        d.setVar('TAILSCALE_KERNEL_FRAGMENT', '${WORKDIR}/tailscale-iptables.cfg')
+        d.setVar('TAILSCALE_KERNEL_SRC_URI', 'file://tailscale-iptables.cfg')
+}
+
+
 PANTAVISOR_SRC_URI = " \
 	file://overlayfs.cfg \
 	file://pantavisor.cfg \
 	file://pvcrypt.cfg \
 	file://dm.cfg \
+	${TAILSCALE_KERNEL_SRC_URI} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', 'file://pantavisor-lz4.cfg', '', d)} \
 "
 
@@ -25,6 +46,7 @@ PANTAVISOR_KERNEL_FRAGMENTS = " \
 	${WORKDIR}/pvcrypt.cfg \
 	${WORKDIR}/overlayfs.cfg \
 	${WORKDIR}/dm.cfg \
+	${TAILSCALE_KERNEL_FRAGMENT} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', '${WORKDIR}/pantavisor-lz4.cfg', '', d)} \
 "
 


### PR DESCRIPTION
add tailscale iptables/nftables fragments if enabled

enable in kas/bsp-base.yaml by default