### PR TITLE
mbedtls: fix make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch

### DIFF
--- a/recipes-pv/mbedtls/mbedtls/2.28.0/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.0/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -124,7 +124,7 @@ index 107e912ace..3289e60aea 100644
      ret = mbedtls_ecdsa_read_signature( (mbedtls_ecdsa_context *) ctx,
                                  hash, hash_len, sig, sig_len );
  
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -148,8 +148,8 @@ index 107e912ace..3289e60aea 100644
              hash, hash_len, sig, sig_len,
              (mbedtls_ecdsa_restart_ctx *) rs_ctx );
  
-+    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    // if bad asn error ... we convert asn1 format and try again
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    sig = realloc(sig, sig_len + 5);
 +	    ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +

--- a/recipes-pv/mbedtls/mbedtls/2.28.10/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.10/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -116,7 +116,7 @@ Index: git/library/pk_wrap.c
  
      ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *) ctx,
                                         hash, hash_len, sig, sig_len);
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -139,8 +139,8 @@ Index: git/library/pk_wrap.c
          hash, hash_len, sig, sig_len,
          (mbedtls_ecdsa_restart_ctx *) rs_ctx);
  
-+    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    // if bad asn error ... we convert asn1 format and try again
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +        sig = realloc(sig, sig_len + 5);
 +        ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +

--- a/recipes-pv/mbedtls/mbedtls/2.28.2/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.2/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -124,7 +124,7 @@ index 107e912ace..3289e60aea 100644
      ret = mbedtls_ecdsa_read_signature( (mbedtls_ecdsa_context *) ctx,
                                  hash, hash_len, sig, sig_len );
  
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -149,7 +149,7 @@ index 107e912ace..3289e60aea 100644
              (mbedtls_ecdsa_restart_ctx *) rs_ctx );
  
 +    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    sig = realloc(sig, sig_len + 5);
 +	    ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +

--- a/recipes-pv/mbedtls/mbedtls/2.28.5/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.5/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -124,7 +124,7 @@ index 107e912ace..3289e60aea 100644
      ret = mbedtls_ecdsa_read_signature( (mbedtls_ecdsa_context *) ctx,
                                  hash, hash_len, sig, sig_len );
  
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -148,8 +148,8 @@ index 107e912ace..3289e60aea 100644
              hash, hash_len, sig, sig_len,
              (mbedtls_ecdsa_restart_ctx *) rs_ctx );
  
-+    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    // if bad asn error ... we convert asn1 format and try again
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    sig = realloc(sig, sig_len + 5);
 +	    ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +

--- a/recipes-pv/mbedtls/mbedtls/2.28.7/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.7/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -116,7 +116,7 @@ Index: git/library/pk_wrap.c
  
      ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *) ctx,
                                         hash, hash_len, sig, sig_len);
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -140,7 +140,7 @@ Index: git/library/pk_wrap.c
          (mbedtls_ecdsa_restart_ctx *) rs_ctx);
  
 +    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +        sig = realloc(sig, sig_len + 5);
 +        ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +

--- a/recipes-pv/mbedtls/mbedtls/2.28.8/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.8/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -116,7 +116,7 @@ Index: git/library/pk_wrap.c
  
      ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *) ctx,
                                         hash, hash_len, sig, sig_len);
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -140,7 +140,7 @@ Index: git/library/pk_wrap.c
          (mbedtls_ecdsa_restart_ctx *) rs_ctx);
  
 +    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +        sig = realloc(sig, sig_len + 5);
 +        ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +

--- a/recipes-pv/mbedtls/mbedtls/2.28.9/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
+++ b/recipes-pv/mbedtls/mbedtls/2.28.9/0001-make-pk_wrap.c-support-validating-ANSI-X9.62-FIPS-18.patch
@@ -116,7 +116,7 @@ Index: git/library/pk_wrap.c
  
      ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *) ctx,
                                         hash, hash_len, sig, sig_len);
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) ) {
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +	    unsigned char *asnsig = malloc ((sig_len + 12) * sizeof(unsigned char));
 +	    size_t asnsiglen = sig_len;
 +	    memcpy (asnsig, sig, sig_len);
@@ -139,8 +139,8 @@ Index: git/library/pk_wrap.c
          hash, hash_len, sig, sig_len,
          (mbedtls_ecdsa_restart_ctx *) rs_ctx);
  
-+    // if bad asn tag error ... we convert asn1 format and try again
-+    if ( ret == (MBEDTLS_ERR_ECP_BAD_INPUT_DATA + MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)) {
++    // if bad asn error ... we convert asn1 format and try again
++    if (ret & MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
 +        sig = realloc(sig, sig_len + 5);
 +        ret = pk_ecdsa_sig_asn1_from_psa(sig, &sig_len, sig_len + 5);
 +


### PR DESCRIPTION
this patch missed a fix we maintain in forked mbedtls repo of pantavisor. Instead of adding a new patch we are adding the changes to the patch itself.

See: https://gitlab.com/pantacor/mbedtls/-/commit/12d3b1f16e3ef1c30d99544905084718165b31f5