### PR TITLE
genericarm64: add machine to kas

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -148,6 +148,9 @@ choice
 config MACHINE_FILTER_QEMU
 	bool "qemu"
 
+config MACHINE_FILTER_GENERIC
+	bool "generic"
+
 config MACHINE_FILTER_VARISCITE
 	bool "Variscite"
 
@@ -182,6 +185,9 @@ config MACHINE_FILTER_RADXA
 endchoice
 
 config PLATFORM_CORAL
+	bool
+
+config PLATFORM_GENERIC
 	bool
 
 config PLATFORM_QEMU
@@ -222,6 +228,11 @@ config MACHINE_QEMUARM
 	bool "qemuarm"
 	depends on MACHINE_FILTER_ALL || MACHINE_FILTER_QEMU
 	select PLATFORM_QEMU
+
+config MACHINE_GENERICARM64
+	bool "genericarm64"
+	depends on MACHINE_FILTER_ALL || MACHINE_FILTER_GENERIC
+	select PLATFORM_GENERIC
 
 config MACHINE_QEMUX86_64
 	bool "qemux86-64"
@@ -377,6 +388,10 @@ config KAS_INCLUDE_MACHINE_QEMUMIPS
 	string
 	default "kas/machines/qemumips.yaml" if MACHINE_QEMUMIPS
 
+config KAS_INCLUDE_MACHINE_GENERICARM64
+	string
+	default "kas/machines/genericarm64.yaml" if MACHINE_GENERICARM64
+
 config KAS_INCLUDE_MACHINE_RPI_ARMV8
 	string
 	default "kas/machines/raspberrypi-armv8.yaml" if MACHINE_RPI_ARMV8
@@ -508,3 +523,4 @@ config KAS_INCLUDE_MACHINE_RADXA_ROCK5A
 config KAS_INCLUDE_MACHINE_RADXA_ROCK5B
 	string
 	default "kas/machines/radxa-rock5b.yaml" if MACHINE_RADXA_ROCK5B
+

--- a/classes/pvr-ca.bbclass
+++ b/classes/pvr-ca.bbclass
@@ -1,7 +1,7 @@
 
 PVS_VENDOR_NAME ??= "generic"
-PVS_URI ??= "git://gitlab.com/pantacor/pv-developer-ca;protocol=https;branch=master;rev=2340d747c4acd0a1a702b3d7d5acc014b51daaa7"
-PVS_URI_SHA256 ??= "c5fbca13f400337749766b7daf5233f333b2358afa1fa5eaa4580b91e737daad"
+PVS_URI ??= "https://gitlab.com/pantacor/pv-developer-ca/-/archive/2340d747c4acd0a1a702b3d7d5acc014b51daaa7/pv-developer-ca-master.tar.gz;striplevel=1"
+PVS_URI_SHA256 ??= "9f4c55dad2c121a4ca2ae39e2767eb4a214822ee34041a65692766ae438f96d8"
 
 SRC_URI += "${PVS_URI};name=pv-developer-ca;subdir=pv-developer-ca_${PVS_VENDOR_NAME}"
 SRC_URI[pv-developer-ca.sha256sum] = "${PVS_URI_SHA256}"


### PR DESCRIPTION
Fixup pantavisor-bsp to be able to produce run.json without kernel, modules and firmware

Fix pvr-ca.bbclass to download developer ca through tarball URL to avoid parsing error of build-appliance-image recipe due double use of SCM in SRC_URI