### PR TITLE
image-pvrexport.bbclass: Introduce PV_CONFIG_OVERLAY_DIR variable.

### DIFF
--- a/classes/image-pvrexport.bbclass
+++ b/classes/image-pvrexport.bbclass
@@ -31,6 +31,11 @@ PVR_APP_ADD_GROUP ??= "root"
 
 PVRIMAGE_AUTO_MDEV ??= "1"
 
+# Define a config overlay directory that the image recipe will make available
+# in ${WORKDIR} before the IMAGE_CMD task for ${PN} container.
+# This directory will be added to the pvrexport as _config/${PN}
+PV_CONFIG_OVERLAY_DIR ??= ""
+
 do_image_pvrexportit[dirs] = " ${TOPDIR} ${PVSTATE} ${PVR_CONFIG_DIR} "
 do_image_pvrexportit[cleandirs] = " ${PVSTATE} "
 
@@ -74,6 +79,10 @@ fakeroot IMAGE_CMD:pvrexportit(){
     ]
  }
 EOF1
+    fi
+    if -n "${PV_CONFIG_OVERLAY_DIR}"; then
+        mkdir -p _config
+        cp -rf ${WORKDIR}/${PV_CONFIG_OVERLAY_DIR} _config/${PN}
     fi
     pvr add
     pvr commit


### PR DESCRIPTION
pvrexports produced from image recipes using the image-pvrexport.bbclass lack the ability to easily add a _config/${PN} overlay.

Image recipes can now define PV_CONFIG_OVERLAY_DIR and place such directory inside ${WORKDIR} bofore the do_image task. the image-pvrexport.bbclass will then pick this directory up and include it in the pvrexport package produced