### PR TITLE
feat(auto-recovery): add pv-example-recovery container for testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Yocto/OpenEmbedded layer for building Pantavisor, a container-based embedded Lin
 | [EXAMPLES.md](EXAMPLES.md) | Example containers for pv-xconnect service mesh (Unix, REST, D-Bus, DRM, Wayland) |
 | [TESTPLAN-xconnect.md](TESTPLAN-xconnect.md) | xconnect service mesh tests (unix, dbus, drm) |
 | [TESTPLAN-pvctrl.md](TESTPLAN-pvctrl.md) | pv-ctrl API test plan (all endpoints) |
+| [TESTPLAN-auto-recovery.md](TESTPLAN-auto-recovery.md) | Auto-recovery, stability tracking, and backoff policy tests |
 | [GEMINI.md](GEMINI.md) | Implementation notes, upstream changes, and known pitfalls |
 
 ## Build Commands
@@ -247,6 +248,72 @@ The `pv-examples` containers demonstrate pv-xconnect service mesh patterns:
 | `pv-example-wayland-client` | wayland | consumer | Wayland client |
 
 See [EXAMPLES.md](EXAMPLES.md) for detailed testing instructions.
+
+### Auto-Recovery Example Containers
+
+| Container | Group | auto_recovery | Description |
+|-----------|-------|---------------|-------------|
+| `pv-example-recovery` | root | per-container | Crashes after 10s, on-failure with backoff_policy="10min" |
+| `pv-example-stabilize` | root | per-container | Fails 3x then stabilizes, backoff_policy="reboot" |
+| `pv-example-random` | root | per-container | Random exit timing, always policy, backoff_policy="never" |
+| `pv-example-app-crash` | app | inherited from group | Crashes after 10s, inherits app group's auto_recovery |
+
+See [TESTPLAN-auto-recovery.md](TESTPLAN-auto-recovery.md) for test scenarios.
+
+## Container Auto-Recovery
+
+Containers can be configured for automatic restart on crash. Configuration can be set per-container in `args.json` or inherited from the group in `device.json`.
+
+### Per-Container Configuration
+
+Add `PV_AUTO_RECOVERY` to the container's `args.json`:
+
+```json
+{
+    "PV_AUTO_RECOVERY": {
+        "policy": "on-failure",
+        "max_retries": 5,
+        "retry_delay": 5,
+        "backoff_factor": 2.0,
+        "reset_window": 60,
+        "stable_timeout": 30,
+        "backoff_policy": "10min"
+    },
+    "PV_RESTART_POLICY": "container"
+}
+```
+
+This flows through `pvr app add --arg-json` into `run.json`'s `auto_recovery` object.
+
+### Group-Level Defaults
+
+Groups in `device.json` (and `defaults/groups.json` in pantavisor) can define a default `auto_recovery`. Containers inherit it **all-or-nothing** — if a container has its own `PV_AUTO_RECOVERY`, the group default is ignored entirely.
+
+The default `app` group ships with:
+
+```json
+{
+    "name": "app",
+    "restart_policy": "container",
+    "status_goal": "STARTED",
+    "timeout": 30,
+    "auto_recovery": {
+        "policy": "on-failure",
+        "max_retries": 5,
+        "retry_delay": 5,
+        "backoff_factor": 2.0,
+        "stable_timeout": 30,
+        "backoff_policy": "reboot"
+    }
+}
+```
+
+To place a container in the `app` group, set `PVR_APP_ADD_GROUP = "app"` in the recipe.
+
+### Key Concepts
+
+- **stable_timeout**: Seconds a container must run without crashing after reaching its status goal before being considered stable. Does not block group startup chaining. During TESTING, commit is held until all containers are stable.
+- **backoff_policy**: What happens after `max_retries` is exhausted in steady state: `"reboot"` (default), `"never"` (leave stopped), or a duration like `"10min"` (wait then retry). During TESTING, exhaustion always triggers rollback.
 
 ## Pantavisor Source Development
 

--- a/TESTPLAN-auto-recovery.md
+++ b/TESTPLAN-auto-recovery.md
@@ -204,6 +204,164 @@ docker exec pva-test pvcontrol ls
 
 ---
 
+## Test 4: Group-Level Auto-Recovery Inheritance
+
+**Purpose**: Verify a container without `auto_recovery` in its `run.json` inherits the group's default auto-recovery policy from `device.json`.
+
+### Setup
+
+This test uses a custom `device.json` that adds `auto_recovery` to the `root` group, and a container that has **no** `PV_AUTO_RECOVERY` in its `args.json`.
+
+```bash
+rm -f pvtx.d/*.pvrexport.tgz
+# Use a container without auto_recovery (e.g., a plain busybox container)
+# The group-level auto_recovery in device.json will apply
+```
+
+**device.json group config:**
+```json
+{
+    "name": "root",
+    "restart_policy": "container",
+    "status_goal": "STARTED",
+    "timeout": 30,
+    "auto_recovery": {
+        "policy": "on-failure",
+        "max_retries": 3,
+        "retry_delay": 2,
+        "backoff_factor": 1.5,
+        "stable_timeout": 15,
+        "backoff_policy": "never"
+    }
+}
+```
+
+### Verify
+
+```bash
+# Check pantavisor log for inherited auto-recovery
+docker exec pva-test grep -i "auto-recovery\|attempt\|STABLE" \
+    /var/pantavisor/storage/logs/0/pantavisor/pantavisor.log | tail -10
+
+# Check pvcontrol shows inherited values
+docker exec pva-test pvcontrol ls
+# Expected: auto_recovery.max_retries = 3, stable_timeout = 15
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Container has no auto_recovery in run.json | No `PV_AUTO_RECOVERY` in args.json |
+| Inherited from group | pvcontrol shows max_retries=3, stable_timeout=15 |
+| Recovery works | Container restarts on crash with group's policy |
+| All-or-nothing | All fields come from group, not mixed with defaults |
+
+---
+
+## Test 5: Container Auto-Recovery Overrides Group
+
+**Purpose**: Verify a container with its own `auto_recovery` in `run.json` does NOT inherit from the group — all-or-nothing semantics.
+
+### Setup
+
+Use a group with `auto_recovery` AND a container with its own `PV_AUTO_RECOVERY` (e.g., `pv-example-recovery`).
+
+### Verify
+
+```bash
+docker exec pva-test pvcontrol ls
+# Expected: container's own values (max_retries=5, stable_timeout=30),
+# NOT the group's values
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Container has auto_recovery | Its own values used |
+| Group also has auto_recovery | Group values ignored |
+| max_retries | Container's value (5), not group's |
+
+---
+
+## Test 6: Stable Timeout Prevents Premature Commit
+
+**Purpose**: Verify that during TESTING, the commit is held until all containers with `stable_timeout` have survived their stability window.
+
+### Verify
+
+```bash
+# Check pantavisor log during an update
+docker exec pva-test grep -i "commit held\|STABLE\|commit" \
+    /var/pantavisor/storage/logs/0/pantavisor/pantavisor.log | tail -10
+# Expected: "commit held: waiting for all containers to become stable"
+# followed by "is now STABLE" and then commit
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Commit timer expires | Commit not immediate |
+| stable_timeout pending | "commit held" log message |
+| Container survives window | "is now STABLE" log message |
+| Then commit | `pv_update_set_final()` proceeds |
+
+---
+
+## Test 7: Backoff Policy "never" — Container Stays Stopped
+
+**Purpose**: Verify `backoff_policy: "never"` leaves a container stopped after max_retries without triggering a system reboot.
+
+### Verify
+
+```bash
+# After max_retries exhausted:
+docker exec pva-test grep -i "backoff_policy.*never\|leaving.*stopped\|recovery_failed" \
+    /var/pantavisor/storage/logs/0/pantavisor/pantavisor.log | tail -5
+# Expected: "backoff_policy=never — leaving 'container' stopped"
+
+docker exec pva-test lxc-ls -f
+# Expected: container STOPPED, system still running (no reboot)
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Container status | STOPPED |
+| System state | Still running, no reboot |
+| Log message | "backoff_policy=never" |
+| Other containers | Unaffected, still running |
+
+---
+
+## Test 8: Backoff Policy Duration — Retry Cycle Reset
+
+**Purpose**: Verify `backoff_policy: "10min"` waits the configured duration after max_retries, then resets the retry counter and restarts recovery.
+
+### Verify
+
+```bash
+# After max_retries exhausted:
+docker exec pva-test grep -i "backoff_policy.*600\|scheduling.*retry\|recovery.*timer.*finished" \
+    /var/pantavisor/storage/logs/0/pantavisor/pantavisor.log | tail -5
+# Expected: "backoff_policy=600s — scheduling retry cycle reset"
+# After 600s: "recovery timer finished" and new attempt 1/N
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| After max_retries | "scheduling retry cycle reset" |
+| Container status | RECOVERING (waiting 600s) |
+| After duration | Retry counter resets, new recovery cycle starts |
+| New attempts | "attempt 1/5" logged again |
+
+---
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/TESTPLAN-auto-recovery.md
+++ b/TESTPLAN-auto-recovery.md
@@ -1,0 +1,214 @@
+# Auto-Recovery Test Plan
+
+Tests for container auto-recovery with exponential backoff via the appengine environment.
+
+For xconnect service mesh tests, see [TESTPLAN-xconnect.md](TESTPLAN-xconnect.md).
+For pv-ctrl API tests, see [TESTPLAN-pvctrl.md](TESTPLAN-pvctrl.md).
+
+---
+
+## Prerequisites
+
+### Build Appengine Image and Test Containers
+
+```bash
+./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+    --target pv-example-recovery \
+    --target pv-example-stabilize \
+    --target pv-example-random
+
+docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
+```
+
+### Common Setup
+
+```bash
+docker rm -f pva-test 2>/dev/null
+docker volume rm storage-test 2>/dev/null
+mkdir -p pvtx.d
+```
+
+### Common Teardown
+
+```bash
+docker rm -f pva-test
+docker volume rm storage-test
+```
+
+---
+
+## Test 1: On-Failure Recovery with Exponential Backoff
+
+**Purpose**: Verify a container with `policy: "on-failure"` is automatically restarted with increasing delays.
+
+### Setup
+
+```bash
+rm -f pvtx.d/*.pvrexport.tgz
+cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-recovery.pvrexport.tgz pvtx.d/
+```
+
+### Execute
+
+```bash
+docker rm -f pva-test 2>/dev/null; docker volume rm storage-test 2>/dev/null
+docker run --name pva-test -d --privileged \
+    -v $(pwd)/pvtx.d:/usr/lib/pantavisor/pvtx.d \
+    -v storage-test:/var/pantavisor/storage \
+    --entrypoint /bin/sh pantavisor-appengine:latest -c "sleep infinity"
+
+docker exec pva-test sh -c 'pv-appengine &'
+sleep 15
+```
+
+### Verify
+
+```bash
+# Check container is running (first cycle)
+docker exec pva-test lxc-ls -f
+# Expected: pv-example-recovery RUNNING
+
+# Check auto-recovery config in container status
+docker exec pva-test pvcontrol ls
+# Expected: auto_recovery.type = "on-failure", max_retries = 5
+
+# Wait for first crash and recovery (container exits after ~10s, retry_delay=5s)
+sleep 20
+
+# Check container logs for restart evidence
+docker exec pva-test cat /var/pantavisor/storage/logs/0/pv-example-recovery/lxc/console.log
+# Expected: Multiple "Recovery test container starting..." entries
+
+# Check pantavisor log for recovery messages
+docker exec pva-test grep -i "recover" /var/pantavisor/storage/logs/0/pantavisor/pantavisor.log | tail -10
+# Expected: auto-recovery messages with increasing retry counts
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Container status | RUNNING or RECOVERING |
+| auto_recovery.type | `on-failure` |
+| Console log | Multiple startup lines showing restarts |
+| Retry count | Increments after each crash |
+| Backoff | Delays increase (5s, 10s, 20s with factor 2.0) |
+
+---
+
+## Test 2: Stabilize Pattern (Failing then Stable)
+
+**Purpose**: Verify a container that fails 3 times then stabilizes is restarted correctly and eventually stays running.
+
+### Setup
+
+```bash
+rm -f pvtx.d/*.pvrexport.tgz
+cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-stabilize.pvrexport.tgz pvtx.d/
+```
+
+### Execute
+
+```bash
+docker rm -f pva-test 2>/dev/null; docker volume rm storage-test 2>/dev/null
+docker run --name pva-test -d --privileged \
+    -v $(pwd)/pvtx.d:/usr/lib/pantavisor/pvtx.d \
+    -v storage-test:/var/pantavisor/storage \
+    --entrypoint /bin/sh pantavisor-appengine:latest -c "sleep infinity"
+
+docker exec pva-test sh -c 'pv-appengine &'
+sleep 15
+```
+
+### Verify
+
+```bash
+# Wait for stabilization (3 failures at ~5s each + retry delays, then stable)
+sleep 60
+
+# Check container is RUNNING and staying up
+docker exec pva-test lxc-ls -f
+# Expected: pv-example-stabilize RUNNING
+
+# Check console log for progression
+docker exec pva-test cat /var/pantavisor/storage/logs/0/pv-example-stabilize/lxc/console.log
+# Expected: "Run #1" through "Run #4", with #4 saying "stable phase"
+
+# Check retry count has reset (after reset_window=300s, or still shows retries)
+docker exec pva-test pvcontrol ls
+# Expected: container STARTED, auto_recovery shows current_retries
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Container status | RUNNING (stable after run #4) |
+| Console log runs | Run #1, #2, #3 fail; Run #4+ stays running |
+| Persistent state | Boot count stored in /var/lib/boot_count via lxc-overlay |
+| Final behavior | `sleep infinity` — container stays up |
+
+---
+
+## Test 3: Always-Restart with Random Timing
+
+**Purpose**: Verify `policy: "always"` keeps restarting a container regardless of exit code.
+
+### Setup
+
+```bash
+rm -f pvtx.d/*.pvrexport.tgz
+cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-random.pvrexport.tgz pvtx.d/
+```
+
+### Execute
+
+```bash
+docker rm -f pva-test 2>/dev/null; docker volume rm storage-test 2>/dev/null
+docker run --name pva-test -d --privileged \
+    -v $(pwd)/pvtx.d:/usr/lib/pantavisor/pvtx.d \
+    -v storage-test:/var/pantavisor/storage \
+    --entrypoint /bin/sh pantavisor-appengine:latest -c "sleep infinity"
+
+docker exec pva-test sh -c 'pv-appengine &'
+sleep 15
+```
+
+### Verify
+
+```bash
+# Wait for a few restart cycles (random 10-30s sleep + retry delays)
+sleep 90
+
+# Check container is still being managed
+docker exec pva-test lxc-ls -f
+# Expected: pv-example-random RUNNING or RECOVERING
+
+# Check console log shows multiple restarts
+docker exec pva-test cat /var/pantavisor/storage/logs/0/pv-example-random/lxc/console.log
+# Expected: Multiple "Random restart container starting..." lines
+
+# Verify max_retries=10 is respected
+docker exec pva-test pvcontrol ls
+# Expected: auto_recovery.current_retries incrementing, max_retries=10
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Container status | RUNNING or RECOVERING (continuously) |
+| auto_recovery.type | `always` |
+| Console log | Multiple restart cycles with varying sleep times |
+| Retry behavior | Keeps restarting up to max_retries=10 |
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Container not restarting | auto_recovery not parsed | Check pantavisor.log for parsing errors |
+| No backoff visible | Timer not working | Check for `RECOVERING` status in pvcontrol ls |
+| Stabilize never stabilizes | Overlay not persisted | Verify lxc-overlay persistence is `boot` in run.json |
+| Too many retries | max_retries exceeded | Container stays STOPPED after max failures |

--- a/recipes-containers/pv-examples/files/pv-example-app-crash.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-app-crash.args.json
@@ -1,0 +1,3 @@
+{
+    "PV_RESTART_POLICY": "container"
+}

--- a/recipes-containers/pv-examples/files/pv-example-random.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-random.args.json
@@ -1,0 +1,10 @@
+{
+    "PV_AUTO_RECOVERY": {
+        "policy": "always",
+        "max_retries": 10,
+        "retry_delay": 2,
+        "backoff_factor": 1.5,
+        "reset_window": 300
+    },
+    "PV_RESTART_POLICY": "container"
+}

--- a/recipes-containers/pv-examples/files/pv-example-random.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-random.args.json
@@ -4,7 +4,9 @@
         "max_retries": 10,
         "retry_delay": 2,
         "backoff_factor": 1.5,
-        "reset_window": 300
+        "reset_window": 300,
+        "stable_timeout": 60,
+        "backoff_policy": "never"
     },
     "PV_RESTART_POLICY": "container"
 }

--- a/recipes-containers/pv-examples/files/pv-example-recovery.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-recovery.args.json
@@ -1,0 +1,10 @@
+{
+    "PV_AUTO_RECOVERY": {
+        "policy": "on-failure",
+        "max_retries": 5,
+        "retry_delay": 5,
+        "backoff_factor": 2.0,
+        "reset_window": 60
+    },
+    "PV_RESTART_POLICY": "container"
+}

--- a/recipes-containers/pv-examples/files/pv-example-recovery.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-recovery.args.json
@@ -4,7 +4,9 @@
         "max_retries": 5,
         "retry_delay": 5,
         "backoff_factor": 2.0,
-        "reset_window": 60
+        "reset_window": 60,
+        "stable_timeout": 30,
+        "backoff_policy": "10min"
     },
     "PV_RESTART_POLICY": "container"
 }

--- a/recipes-containers/pv-examples/files/pv-example-stabilize.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-stabilize.args.json
@@ -1,0 +1,11 @@
+{
+    "PV_AUTO_RECOVERY": {
+        "policy": "on-failure",
+        "max_retries": 5,
+        "retry_delay": 2,
+        "backoff_factor": 1.5,
+        "reset_window": 300
+    },
+    "PV_RESTART_POLICY": "container",
+    "PV_VOLUME_MOUNTS": "dir:/var/lib:permanent"
+}

--- a/recipes-containers/pv-examples/files/pv-example-stabilize.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-stabilize.args.json
@@ -4,7 +4,9 @@
         "max_retries": 5,
         "retry_delay": 2,
         "backoff_factor": 1.5,
-        "reset_window": 300
+        "reset_window": 300,
+        "stable_timeout": 15,
+        "backoff_policy": "reboot"
     },
     "PV_RESTART_POLICY": "container"
 }

--- a/recipes-containers/pv-examples/files/pv-example-stabilize.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-stabilize.args.json
@@ -6,6 +6,5 @@
         "backoff_factor": 1.5,
         "reset_window": 300
     },
-    "PV_RESTART_POLICY": "container",
-    "PV_VOLUME_MOUNTS": "dir:/var/lib:permanent"
+    "PV_RESTART_POLICY": "container"
 }

--- a/recipes-containers/pv-examples/files/pv-random.sh
+++ b/recipes-containers/pv-examples/files/pv-random.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+echo "Random restart container starting..."
+echo "Uptime: $(cat /proc/uptime)"
+
+# Generate a random sleep time between 10 and 30 seconds
+SLEEP_TIME=$(( (RANDOM % 21) + 10 ))
+
+echo "I will sleep for $SLEEP_TIME seconds and then exit with failure (1)."
+sleep $SLEEP_TIME
+echo "Exiting now!"
+exit 1

--- a/recipes-containers/pv-examples/files/pv-random.sh
+++ b/recipes-containers/pv-examples/files/pv-random.sh
@@ -3,7 +3,7 @@ echo "Random restart container starting..."
 echo "Uptime: $(cat /proc/uptime)"
 
 # Generate a random sleep time between 10 and 30 seconds
-SLEEP_TIME=$(( ($RANDOM % 21) + 10 ))
+SLEEP_TIME=$(( $(od -An -tu2 -N2 /dev/urandom | tr -d ' ') % 21 + 10 ))
 
 echo "I will sleep for $SLEEP_TIME seconds and then exit with failure (1)."
 sleep $SLEEP_TIME

--- a/recipes-containers/pv-examples/files/pv-random.sh
+++ b/recipes-containers/pv-examples/files/pv-random.sh
@@ -3,7 +3,7 @@ echo "Random restart container starting..."
 echo "Uptime: $(cat /proc/uptime)"
 
 # Generate a random sleep time between 10 and 30 seconds
-SLEEP_TIME=$(( (RANDOM % 21) + 10 ))
+SLEEP_TIME=$(( ($RANDOM % 21) + 10 ))
 
 echo "I will sleep for $SLEEP_TIME seconds and then exit with failure (1)."
 sleep $SLEEP_TIME

--- a/recipes-containers/pv-examples/files/pv-recovery.sh
+++ b/recipes-containers/pv-examples/files/pv-recovery.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "Recovery test container starting..."
+echo "Uptime: $(cat /proc/uptime)"
+echo "I will sleep for 10 seconds and then exit with failure (1)."
+sleep 10
+echo "Exiting now!"
+exit 1

--- a/recipes-containers/pv-examples/files/pv-stabilize.sh
+++ b/recipes-containers/pv-examples/files/pv-stabilize.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+STATE_FILE="/var/lib/boot_count"
+mkdir -p /var/lib
+
+if [ ! -f "$STATE_FILE" ]; then
+    echo "0" > "$STATE_FILE"
+fi
+
+COUNT=$(cat "$STATE_FILE")
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$STATE_FILE"
+
+echo "Stabilize test container starting... (Run #$COUNT)"
+echo "Uptime: $(cat /proc/uptime)"
+
+if [ "$COUNT" -le 3 ]; then
+    echo "I am in the failing phase. Sleeping 5s and exiting with error."
+    sleep 5
+    exit 1
+else
+    echo "I have reached the stable phase! Sleeping infinity..."
+    sleep infinity
+fi

--- a/recipes-containers/pv-examples/pv-example-app-crash.bb
+++ b/recipes-containers/pv-examples/pv-example-app-crash.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Pantavisor Example App Crash Container (inherits group auto-recovery)"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-app-crash"
+
+IMAGE_INSTALL += "busybox"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+SRC_URI += "file://pv-recovery.sh file://pv-example-app-crash.args.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-recovery.sh ${IMAGE_ROOTFS}${bindir}/pv-recovery
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+PVR_APP_ADD_GROUP = "app"
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-recovery"

--- a/recipes-containers/pv-examples/pv-example-random.bb
+++ b/recipes-containers/pv-examples/pv-example-random.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Pantavisor Example Random Restart Container"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-random"
+
+IMAGE_INSTALL += "busybox"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+SRC_URI += "file://pv-random.sh file://pv-example-random.args.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-random.sh ${IMAGE_ROOTFS}${bindir}/pv-random
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+FILES:${PN} += "${bindir}/pv-random"
+
+IMAGE_INSTALL:append = " busybox"
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-random"

--- a/recipes-containers/pv-examples/pv-example-recovery.bb
+++ b/recipes-containers/pv-examples/pv-example-recovery.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Pantavisor Example Recovery Container"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-recovery"
+
+IMAGE_INSTALL += "busybox"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+SRC_URI += "file://pv-recovery.sh file://pv-example-recovery.args.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-recovery.sh ${IMAGE_ROOTFS}${bindir}/pv-recovery
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-recovery"

--- a/recipes-containers/pv-examples/pv-example-stabilize.bb
+++ b/recipes-containers/pv-examples/pv-example-stabilize.bb
@@ -1,0 +1,27 @@
+SUMMARY = "Pantavisor Example Stabilize Container"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-stabilize"
+
+IMAGE_INSTALL += "busybox"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+SRC_URI += "file://pv-stabilize.sh file://pv-example-stabilize.args.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-stabilize.sh ${IMAGE_ROOTFS}${bindir}/pv-stabilize
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+FILES:${PN} += "${bindir}/pv-stabilize"
+
+# Ensure busybox is present for the script
+IMAGE_INSTALL:append = " busybox"
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-stabilize"

--- a/recipes-containers/pv-examples/pv-example-stabilize.bb
+++ b/recipes-containers/pv-examples/pv-example-stabilize.bb
@@ -25,3 +25,4 @@ FILES:${PN} += "${bindir}/pv-stabilize"
 IMAGE_INSTALL:append = " busybox"
 
 PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-stabilize"
+PVR_APP_ADD_EXTRA_ARGS += "--volume=lxc-overlay:revision"

--- a/recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json
@@ -33,7 +33,15 @@
 	    "name": "app",
 	    "restart_policy": "container",
 	    "status_goal": "STARTED",
-	    "timeout": 30
+	    "timeout": 30,
+	    "auto_recovery": {
+		"policy": "on-failure",
+		"max_retries": 5,
+		"retry_delay": 5,
+		"backoff_factor": 2.0,
+		"stable_timeout": 30,
+		"backoff_policy": "reboot"
+	    }
 	}
     ],
     "volumes": {

--- a/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json
@@ -33,7 +33,15 @@
 	    "name": "app",
 	    "restart_policy": "container",
 	    "status_goal": "STARTED",
-	    "timeout": 30
+	    "timeout": 30,
+	    "auto_recovery": {
+		"policy": "on-failure",
+		"max_retries": 5,
+		"retry_delay": 5,
+		"backoff_factor": 2.0,
+		"stable_timeout": 30,
+		"backoff_policy": "reboot"
+	    }
 	}
     ],
     "volumes": {

--- a/recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json
@@ -33,7 +33,15 @@
 	    "name": "app",
 	    "restart_policy": "container",
 	    "status_goal": "STARTED",
-	    "timeout": 30
+	    "timeout": 30,
+	    "auto_recovery": {
+		"policy": "on-failure",
+		"max_retries": 5,
+		"retry_delay": 5,
+		"backoff_factor": 2.0,
+		"stable_timeout": 30,
+		"backoff_policy": "reboot"
+	    }
 	}
     ],
     "volumes": {

--- a/recipes-pv/pantavisor/files/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/pantavisor-default-skel/device.json
@@ -33,7 +33,15 @@
 	    "name": "app",
 	    "restart_policy": "container",
 	    "status_goal": "STARTED",
-	    "timeout": 30
+	    "timeout": 30,
+	    "auto_recovery": {
+		"policy": "on-failure",
+		"max_retries": 5,
+		"retry_delay": 5,
+		"backoff_factor": 2.0,
+		"stable_timeout": 30,
+		"backoff_policy": "reboot"
+	    }
 	}
     ],
     "volumes": {

--- a/recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json
@@ -33,7 +33,15 @@
 	    "name": "app",
 	    "restart_policy": "container",
 	    "status_goal": "STARTED",
-	    "timeout": 30
+	    "timeout": 30,
+	    "auto_recovery": {
+		"policy": "on-failure",
+		"max_retries": 5,
+		"retry_delay": 5,
+		"backoff_factor": 2.0,
+		"stable_timeout": 30,
+		"backoff_policy": "reboot"
+	    }
 	}
     ],
     "volumes": {

--- a/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
@@ -33,7 +33,15 @@
 	    "name": "app",
 	    "restart_policy": "container",
 	    "status_goal": "STARTED",
-	    "timeout": 30
+	    "timeout": 30,
+	    "auto_recovery": {
+		"policy": "on-failure",
+		"max_retries": 5,
+		"retry_delay": 5,
+		"backoff_factor": 2.0,
+		"stable_timeout": 30,
+		"backoff_policy": "reboot"
+	    }
 	}
     ],
     "volumes": {

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -33,7 +33,7 @@ SRC_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https;branch=${PA
            file://rev0json \
            "
 
-SRCREV = "1c2c94fdad81d8df82db67681c65c9a654535179"
+SRCREV = "86cdc8ca80332e50d0f1cc10dce0219fd2693326"
 PE = "1"
 PKGV = "026+git0+${GITPKGV}"
 


### PR DESCRIPTION
## Summary

Add auto-recovery group defaults, example containers, and test infrastructure for pantavisor's auto-recovery feature with stability tracking and backoff policies.

### Dependencies

- **Requires**: pantavisor/pantavisor#610 (`feature/auto-recovery`)

### Changes

- **device.json**: `app` group now ships with default `auto_recovery` policy (on-failure, max_retries=5, stable_timeout=30, backoff_policy=reboot)
- **pv-example-recovery**: On-failure recovery with exponential backoff, `stable_timeout=30`, `backoff_policy="10min"` -- tests per-container auto_recovery
- **pv-example-stabilize**: Fails 3 times then stabilizes, `stable_timeout=15`, `backoff_policy="reboot"`
- **pv-example-random**: Always-restart with random timing, `stable_timeout=60`, `backoff_policy="never"`
- **pv-example-app-crash**: Crashing container in `app` group with NO auto_recovery -- tests group-level inheritance
- **pv-random.sh**: Fix `$RANDOM` to `/dev/urandom` (POSIX-compatible for busybox sh)
- **SRCREV**: Updated to `feature/auto-recovery` HEAD
- **TESTPLAN-auto-recovery.md**: 8 test scenarios covering recovery, stability, backoff policies, and group inheritance

### Commits

- `feat(auto-recovery): add recovery, stabilize, and random test containers`
- `feat(auto-recovery): add test plan and update SRCREV for auto-recovery branch`
- `fix(auto-recovery): use /dev/urandom instead of $RANDOM in pv-random.sh`
- `feat(auto-recovery): add stable_timeout and backoff_policy to example containers`

## Test plan

- [x] Test 1: on-failure recovery with exponential backoff (5s, 10s, 20s, 40s, 80s)
- [x] Test 2: stabilize pattern (fail 3x, stable on run #4)
- [x] Test 3: always-restart with random timing and `backoff_policy="never"`
- [x] Test 4: group inheritance -- app-crash container inherits app group's auto_recovery
- [x] Test 5: container override -- recovery container uses its own, ignores group
- [x] Test 7: backoff_policy "never" leaves container stopped, no reboot
- [x] Test 8: backoff_policy "10min" resets retry cycle after 600s
- [ ] Test 6: stable_timeout holds commit during TESTING
