### PR TITLE
fix(appengine): remove cgroup tmpfs mount breaking cgroup v2 detection

### DIFF
--- a/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
@@ -301,7 +301,6 @@ exec_test() {
 		--mount type=tmpfs,target="/volumes" \
 		--mount type=tmpfs,target="/configs" \
 		-p 8222:8222 \
-		--mount type=tmpfs,target="/sys/fs/cgroup" \
 		-v "$abs_test_path":"/work/$test_path" \
 		-v "$abs_common_path":"/work/$test_path/../../common" \
 		-v "$abs_storage_path":/var/pantavisor/storage \


### PR DESCRIPTION
## Summary
- Remove the `--mount type=tmpfs,target="/sys/fs/cgroup"` line from test.docker.sh
- This tmpfs mount was overwriting Docker's cgroup2 filesystem, causing pantavisor to incorrectly detect cgroup v1
- With this fix, nested containers work correctly with `lxc.cgroup.relative=1` without requiring `--cgroupns host`

## Test plan
- [x] Build with `./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml`
- [x] Load containers with `./test.docker.sh install-docker`
- [x] Run test with `./test.docker.sh run pvtests-local:0 -i`
- [x] Verify pantavisor detects `CGROUP_UNIFIED` in logs
- [x] Verify pvr-sdk container starts successfully