### PR TITLE
fix(ci): remove --depth from git fetch --tags

### DIFF
--- a/.github/workflows/buildkas-target.yaml
+++ b/.github/workflows/buildkas-target.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Fetch tags
         run: |
           git config --global --add safe.directory '*'
-          git fetch --tags --force --depth=${{ inputs.fetch-depth || 1 }}
+          git fetch --tags --force
       - name: setup workspace
         run: |
           chown -R builder:builder $RUNNER_WORKSPACE


### PR DESCRIPTION
## Summary

- Remove `--depth=${{ inputs.fetch-depth || 1 }}` from `git fetch --tags` in buildkas-target.yaml
- `inputs.fetch-depth` is not defined, so it defaults to `--depth=1` which fails in shallow clones
- Tags are lightweight refs and don't need depth limiting

## Test plan

- [x] Observed `Fetch tags` step failing on master push builds