### PR TITLE
feat(images): guard host-ttys args.json behind PANTAVISOR_FEATURES

### DIFF
--- a/dynamic-layers/core/recipes-core/images/core-image-%.bbappend
+++ b/dynamic-layers/core/recipes-core/images/core-image-%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://args.json"
+SRC_URI += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'core-image-host-ttys', 'file://args.json', '', d)}"
 

--- a/dynamic-layers/meta-freescale-distro/recipes-fsl/images/fsl-image-%.bbappend
+++ b/dynamic-layers/meta-freescale-distro/recipes-fsl/images/fsl-image-%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://args.json"
+SRC_URI += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'fsl-image-host-ttys', 'file://args.json', '', d)}"
 
 

--- a/kas/platforms/freescale.yaml
+++ b/kas/platforms/freescale.yaml
@@ -24,4 +24,5 @@ repos:
 local_conf_header:
   platform-freescale: |
      ACCEPT_FSL_EULA = "1"
+     PANTAVISOR_FEATURES:append = " fsl-image-host-ttys"
 

--- a/kas/platforms/sunxi.yaml
+++ b/kas/platforms/sunxi.yaml
@@ -27,3 +27,4 @@ repos:
 local_conf_header:
   platform-sunxi: |
     PV_UBOOT_AUTOFDT = "1"
+    PANTAVISOR_FEATURES:append = " core-image-host-ttys"


### PR DESCRIPTION
## Summary
- The `core-image-%.bbappend` and `fsl-image-%.bbappend` in `dynamic-layers/` unconditionally added `files/args.json` (LXC_TTY_MIN/MAX) to **every** `core-image-*` and `fsl-image-*` build.
- Gate this behind explicit `PANTAVISOR_FEATURES` flags so it's opt-in:
  - `core-image-host-ttys` — enables `args.json` on `core-image-*`
  - `fsl-image-host-ttys` — enables `args.json` on `fsl-image-*`
- Both features are enabled by default in their respective platform kas files (`sunxi.yaml`, `freescale.yaml`) to preserve current behaviour.
- Integrators can now opt out of having these host TTY settings applied.

## Test plan
- [ ] Build sunxi platform (`orange-pi-3lts`) — verify `args.json` still picked up (feature default on)
- [ ] Build freescale platform — verify `args.json` still picked up
- [ ] Build with `PANTAVISOR_FEATURES:remove = "core-image-host-ttys"` — verify `args.json` NOT in WORKDIR
- [ ] Confirm no-op for platforms not using core-image-* or fsl-image-* base images

## Notes
Follow-up: rename `files/args.json` → `files/host-ttys.json` for clarity once the containers consuming it are updated (currently the fallback path in `container-pvrexport.bbclass` expects `args.json`).