### PR TITLE
feat(pv-examples): minimal test containers + cgroup testplan

### DIFF
--- a/TESTPLAN-cgroup.md
+++ b/TESTPLAN-cgroup.md
@@ -1,0 +1,116 @@
+# TESTPLAN-cgroup
+
+Validation for pantavisor's cgroup handling on HYBRID-mode devices (embedded/standalone init), covering both lenient-stop and force-stop (SIGKILL) container lifecycle paths.
+
+## Scope
+
+- Verify cgroup version detection reports `CGROUP_HYBRID` on devices that mount v1 controllers plus a v2 unified tree at `/sys/fs/cgroup/unified/`.
+- Verify `pv_cgroup_destroy()` cleans every v1 controller hierarchy plus the unified tree, removing both `lxc/<name>/` and `lxc.monitor.<name>[-N]/` leaves.
+- Verify no `-N` suffix accumulation on monitor cgroups across repeated stop/start cycles.
+- Verify behaviour on both lenient-stop (container handles SIGPWR) and force-stop (container ignores signals).
+
+## Test containers
+
+Two minimal `inherit image` containers (~700 KB each) in `recipes-containers/pv-examples/`:
+
+| Container | Script | Behaviour |
+|-----------|--------|-----------|
+| `pv-example-app` | `pv-app.sh` — traps `TERM PWR INT`, `exit 0` | Exits on LXC's lenient signal → no force_stop → LXC cleans cgroups itself |
+| `pv-example-stubborn` | `pv-stubborn.sh` — `trap '' TERM PWR INT HUP QUIT USR1 USR2` | Ignores all catchable signals → pantavisor's `lenient-stop` timer expires → `pv_platform_force_stop()` SIGKILLs init → `pv_cgroup_destroy()` cleans cgroups |
+
+Both have `PV_RESTART_POLICY=container` so they can be driven by the `pv-ctrl` container lifecycle API.
+
+## Prerequisites
+
+- Device deployed with a pantavisor build carrying the three commits on `fix/cgroup-destroy-all-init-modes` (PR #688).
+- Both example containers installed.
+- SSH or tailscale access to the device.
+
+Confirm detection first:
+```sh
+grep "cgroup version" /storage/logs/<rev>/pantavisor/pantavisor.log | tail -1
+# expect: cgroup version detected 'CGROUP_HYBRID'
+```
+
+## Baseline check
+
+After boot, each container's cgroup leaves are present across all hierarchies:
+```sh
+find /sys/fs/cgroup/ -maxdepth 3 \
+    \( -name "pv-example-app" -path "*/lxc/*" \
+       -o -name "lxc.monitor.pv-example-app*" \) \
+    | sort
+```
+Expected: 26 entries on a typical HYBRID device (13 hierarchies × 2 patterns each) — all without `-N` suffix.
+
+## Test 1 — lenient stop path
+
+```sh
+pvcontrol containers stop pv-example-app
+# wait for STOPPED status
+# then:
+find /sys/fs/cgroup/ -maxdepth 3 \
+    \( -name "pv-example-app" -path "*/lxc/*" \
+       -o -name "lxc.monitor.pv-example-app*" \) \
+    | wc -l
+```
+**Expected:**
+- `STOPPED` reached in ~3 s (no 30 s force_stop timeout).
+- Log: `platform 'pv-example-app' exited during lenient stop`.
+- Zero leaves after STOPPED state.
+
+## Test 2 — force stop path (SIGKILL)
+
+```sh
+pvcontrol containers stop pv-example-stubborn
+# wait for STOPPED status
+# then the find command above for pv-example-stubborn
+```
+**Expected:**
+- `STOPPED` reached in ~6-10 s (after lenient-stop timer expires).
+- Log: `platform 'pv-example-stubborn' did not exit after lenient stop, force stopping`.
+- Log: `pv_platform_force_stop: force stopping platform 'pv-example-stubborn'`.
+- Log: one or more `pv_cgroup_remove_retry: ... still exists. Removing...` entries.
+- Zero leaves after STOPPED state (pantavisor's cleanup ran).
+
+## Test 3 — repeated cycles, no -N accumulation
+
+For each container run 3 stop/start cycles:
+```sh
+for K in 1 2 3; do
+    pvcontrol containers stop <name>
+    # wait STOPPED
+    pvcontrol containers start <name>
+    # wait STARTED
+    # check no suffix
+    find /sys/fs/cgroup/ -maxdepth 3 -name "lxc.monitor.<name>-*"
+done
+```
+**Expected:**
+- Every `find` for `lxc.monitor.<name>-*` returns empty.
+- Container always starts with the base name `lxc.monitor.<name>` (no suffix).
+
+## Manual inspection on failure
+
+If dirt is observed, dump state across all hierarchies:
+```sh
+for h in /sys/fs/cgroup/*/; do
+    ls -d ${h}lxc.monitor.<name>* ${h}lxc/<name> 2>/dev/null
+done
+```
+And check pantavisor log for the relevant cgroup cleanup entries:
+```sh
+grep -E "pv_cgroup|cgroup_remove" /storage/logs/<rev>/pantavisor/pantavisor.log
+```
+
+## Known gotchas
+
+- **Status must fully reach STOPPED**: issuing `start` while the container is still `STOPPING` replaces the callback with `restart`, masking the test. Always wait for `STOPPED`.
+- **Busybox shell minimal toolset**: no `seq`, `wc` — use `while`/`$((i+1))` loops instead.
+- **Container must have `PV_RESTART_POLICY=container`**: system-policy containers cannot be driven by the lifecycle API.
+
+## Reference
+
+- PR: https://github.com/pantavisor/pantavisor/pull/688
+- LXC cgroup layout detection: `src/lxc/cgroups/cgfsng.c:2940` `cg_hybrid_init`
+- LXC monitor idx retry logic: `src/lxc/cgroups/cgfsng.c:1235` `cgfsng_monitor_create`

--- a/recipes-containers/pv-examples/files/pv-app.sh
+++ b/recipes-containers/pv-examples/files/pv-app.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-trap 'echo "Received SIGTERM, exiting..."; exit 0' TERM
+trap 'echo "Received shutdown signal, exiting..."; exit 0' TERM PWR INT
 
 echo "pv-example-app starting (PID $$)..."
 

--- a/recipes-containers/pv-examples/files/pv-example-stubborn.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-stubborn.args.json
@@ -1,0 +1,3 @@
+{
+    "PV_RESTART_POLICY": "container"
+}

--- a/recipes-containers/pv-examples/files/pv-stubborn.sh
+++ b/recipes-containers/pv-examples/files/pv-stubborn.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# pv-stubborn: ignore all catchable signals so LXC has to force-stop (SIGKILL)
+# this container. Used to exercise the pv_cgroup_destroy() cleanup path.
+
+# ignore every catchable signal
+trap '' TERM PWR INT HUP QUIT USR1 USR2
+
+echo "pv-example-stubborn starting (PID $$) - ignoring all signals..."
+
+while true; do
+    sleep 1
+done

--- a/recipes-containers/pv-examples/pv-example-stubborn.bb
+++ b/recipes-containers/pv-examples/pv-example-stubborn.bb
@@ -1,10 +1,10 @@
-SUMMARY = "Pantavisor Example App Container"
+SUMMARY = "Pantavisor Stubborn Example - ignores all signals, forces SIGKILL path"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit image container-pvrexport
 
-IMAGE_BASENAME = "pv-example-app"
+IMAGE_BASENAME = "pv-example-stubborn"
 
 IMAGE_INSTALL = "busybox"
 IMAGE_FEATURES = ""
@@ -13,13 +13,13 @@ NO_RECOMMENDATIONS = "1"
 
 PVRIMAGE_AUTO_MDEV = "0"
 
-SRC_URI += "file://pv-app.sh file://pv-example-app.args.json"
+SRC_URI += "file://pv-stubborn.sh file://pv-example-stubborn.args.json"
 
 install_scripts() {
     install -d ${IMAGE_ROOTFS}${bindir}
-    install -m 0755 ${WORKDIR}/pv-app.sh ${IMAGE_ROOTFS}${bindir}/pv-app
+    install -m 0755 ${WORKDIR}/pv-stubborn.sh ${IMAGE_ROOTFS}${bindir}/pv-stubborn
 }
 
 ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
 
-PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-app"
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-stubborn"


### PR DESCRIPTION
## Summary

Companion to pantavisor PR [pantavisor#688](https://github.com/pantavisor/pantavisor/pull/688) (cgroup cleanup on HYBRID devices).

- Switch `pv-example-app` from `inherit core-image` to `inherit image`, dropping the container from **~25 MB to ~700 KB**. Extend its signal trap to `TERM PWR INT` so LXC's default `SIGPWR` halt signal actually exits the script, letting us exercise the lenient-stop path without waiting for the force-stop timer.
- Add `pv-example-stubborn`: a twin that installs ignore-trap handlers for every catchable termination signal. Its sole purpose is to force pantavisor into the SIGKILL path so we can regression-test the cgroup cleanup fallback in `pv_cgroup_destroy()`.
- Add `TESTPLAN-cgroup.md` documenting the full validation procedure for both paths (detection, cleanup across v1+v2 hierarchies, no `-N` monitor suffix accumulation over repeated stop/start cycles).

## Test plan
- [x] Both containers build under `kas/build-configs/release/sunxi-orange-pi-3lts-scarthgap.yaml:kas/with-workspace.yaml`.
- [x] Deployed to an orange-pi-3lts device (HYBRID).
- [x] `pv-example-app` stops leniently in ~3-6 s.
- [x] `pv-example-stubborn` hits the force-stop timer and is SIGKILLed (~11 s total).
- [x] 3× stop/start cycles on each: zero cgroup leaves after STOPPED state, zero `-N` suffix on monitor cgroups.

## Notes
- The two containers share ~700 KB rootfs each (busybox-only, no base-files).
- `PV_RESTART_POLICY=container` on both so they're drivable via `pvcontrol containers start/stop`.