### PR TITLE
feat(pantavisor): split mdev LXC mount hook into pantavisor-hooks-mdev

### DIFF
--- a/classes/pvbase.bbclass
+++ b/classes/pvbase.bbclass
@@ -9,6 +9,7 @@ PANTAVISOR_FEATURES ??= " \
 	rngdaemon \
 	pvcontrol \
 	xconnect \
+	container-mdev \
 "
 # PANTAVISOR_FEATURES += "lxc-next"
 # PANTAVISOR_FEATURES += "console-logging"

--- a/recipes-pv/images/pantavisor-initramfs.bb
+++ b/recipes-pv/images/pantavisor-initramfs.bb
@@ -20,6 +20,7 @@ PACKAGE_INSTALL = "pantavisor \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'automod', 'kmod', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'pvcontrol', 'pantavisor-pvcontrol', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'rpi-tryboot', 'mtools', '', d)} \
+	${@bb.utils.contains('PANTAVISOR_FEATURES', 'container-mdev', 'pantavisor-hooks-mdev', '', d)} \
 	${ROOTFS_BOOTSTRAP_INSTALL}"
 
 PACKAGE_INSTALL:append = " ${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', 'keyctl-caam keyutils', '', d)}"

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -37,7 +37,7 @@ SRCREV = "357b04163bd73b3ff53e2c882c0c273257834c16"
 PE = "1"
 PKGV = "026+git0+${GITPKGV}"
 
-PACKAGES =+ "${PN}-pvtx ${PN}-pvtx-static ${PN}-config ${PN}-pvtest ${PN}-pvcontrol ${PN}-pvcurl"
+PACKAGES =+ "${PN}-hooks-mdev ${PN}-pvtx ${PN}-pvtx-static ${PN}-config ${PN}-pvtest ${PN}-pvcontrol ${PN}-pvcurl"
 
 FILES:${PN} += " /usr/bin/pv-appengine"
 FILES:${PN} += " /usr/lib"
@@ -66,6 +66,11 @@ RDEPENDS:${PN}-pvcontrol += "${PN}-pvcurl json-sh"
 RPROVIDES:${PN}-pvcontrol += "pvcontrol"
 RREPLACES:${PN}-pvcontrol += "pvcontrol"
 RCONFLICTS:${PN}-pvcontrol += "pvcontrol"
+
+# mdev LXC mount hook — split out so BSPs that don't use per-container
+# mdev rules can drop it (PANTAVISOR_FEATURES:remove = "container-mdev") to
+# avoid the fork-exec cost of running the hook on every container start.
+FILES:${PN}-hooks-mdev = "${libdir}/pantavisor/pv/hooks_lxc-mount.d/mdev.sh"
 
 FILES:${PN}-pvcurl += "${bindir}/pvcurl"
 RDEPENDS:${PN}-pvcurl += "netcat-openbsd"


### PR DESCRIPTION
## Summary

Split the `mdev.sh` LXC mount hook into its own `pantavisor-hooks-mdev` subpackage so BSPs that don't use per-container mdev rules can opt out.

## Why

pantavisor scans `${PV_INSTALL_FULL_PVLIBDIR}/hooks_lxc-mount.d/` at container-start time and registers every file it finds as an `lxc.hook.mount` (`plugins/pv_lxc.c:389-413`). `mdev.sh` self-checks and early-exits if `/storage/trails/<rev>/<container>/mdev.json` is missing, but the LXC fork-exec of the script still runs every time.

On low-spec single-core ARMv7 / 128 MB targets, the fork-exec + script preamble + existence check costs ~50–150 ms per container start, compounding to roughly a second of extra boot latency on devices with 7+ containers. For BSPs that never ship an `mdev.json`, the hook is pure cost.

## Change

- New subpackage `${PN}-hooks-mdev` owns `${libdir}/pantavisor/pv/hooks_lxc-mount.d/mdev.sh`. The main `${PN}` package no longer contains this file.
- New `container-mdev` entry in `PANTAVISOR_FEATURES` (default-on) gates pulling `pantavisor-hooks-mdev` into `pantavisor-initramfs`.
- BSPs that want to drop the hook:

  ```
  PANTAVISOR_FEATURES:remove = "container-mdev"
  ```

- Default remains unchanged — **no on-device functional change for existing BSPs**.

## Test plan

- [x] `bitbake -c package -f pantavisor` splits `mdev.sh` into `packages-split/pantavisor-hooks-mdev/...`; main `pantavisor` hooks dir now contains only `export.sh` + `remount`.
- [x] Default build includes `pantavisor-hooks-mdev` in the initramfs.
- [ ] On-device: default feature set — behavior unchanged.
- [ ] On-device: `PANTAVISOR_FEATURES:remove = "container-mdev"` — `mdev.sh` absent from `/usr/lib/pantavisor/pv/hooks_lxc-mount.d/`, container starts no longer incur the fork-exec.

## Context

Complements the pantavisor-side per-container startup timing work — isolates sources of fork-exec overhead on low-spec ARMv7 / 128 MB targets.
