### PR TITLE
feat(pvtx): add pvtx unit test support via appengine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Yocto/OpenEmbedded layer for building Pantavisor-based BSP images for embedded L
 | `classes/container-pvrexport.bbclass` | Container pvrexport packaging |
 | `.github/machines.json` | CI machine configurations — edit before regenerating workflows |
 
+
 ## Documentation Structure
 
 New documents should follow this layout:

--- a/docs/testing/automated-workflow.md
+++ b/docs/testing/automated-workflow.md
@@ -102,3 +102,4 @@ Test plans covering specific features live in [testplans/](testplans/):
 | [testplan-container-control.md](testplans/testplan-container-control.md) | Container lifecycle API (stop/start/restart, user_stopped, batch jobs) |
 | [testplan-pvctrl.md](testplans/testplan-pvctrl.md) | Full pv-ctrl REST API coverage |
 | [testplan-xconnect.md](testplans/testplan-xconnect.md) | xconnect service mesh (unix, D-Bus, DRM) |
+| [testplan-pvtx.md](testplans/testplan-pvtx.md) | pvtx transaction tool unit tests (no Pantavisor needed) |

--- a/docs/testing/testplans/testplan-pvtx.md
+++ b/docs/testing/testplans/testplan-pvtx.md
@@ -1,0 +1,197 @@
+# pvtx Unit Test Plan
+
+Tests for the **pvtx** transaction tool that manages Pantavisor revision state.
+
+Unlike the xconnect and pvctrl test plans (which require a running Pantavisor
+instance), pvtx tests are **unit tests** — they only need the `pvtx` binary and
+standard shell utilities (`jq`, `xxd`, `bc`).  They can be run:
+
+- **From the Pantavisor source tree** using CMake/CTest (no container needed)
+- **Inside the appengine container** using the helper script below
+
+The test suite lives at `test/pvtx/pvtx.sh` in the Pantavisor repository
+(upstream PR #680: `feat/test-pvtx-enhance-suite`).
+
+---
+
+## Tests Covered
+
+| Test | Description |
+|------|-------------|
+| `test_create_empty_transaction` | `pvtx begin empty` → show equals canonical empty state |
+| `test_process_json_keys_with_spaces` | Keys containing spaces round-trip intact |
+| `test_signature_removal` | Remove sig by sig path (`_sigs/`) |
+| `test_signature_removal2` | Remove sig by container name |
+| `test_signature_removal3` | Remove sig by `_config/` path |
+| `test_removal_config_pkg` | Remove a config package signature |
+| `test_package_update` | Re-adding an existing container updates its entry |
+| `test_add_package_from_tar` | Add container from a `.tar` archive |
+| `test_add_new_package` | Add a previously-absent container |
+| `test_add_new_package_from_cat` | Add container via stdin pipe (production use case) |
+| `test_update_bsp` | BSP object update merges correctly |
+| `test_update_bsp_with_groups` | BSP update with separate `groups.json` |
+| `test_install_from_tgz` | Install OS container from `.tar.gz` |
+| `test_two_package_signing_same_files` | Two packages claiming the same files; remove one sig |
+| `test_two_package_signing_same_files_with_globs` | Same as above with glob patterns |
+| `test_removal_of_signed_config` | Config addition followed by config removal |
+| `test_queue_new` | Queue `.status` binary layout is correct |
+| `test_queue_actions` | Queue remove writes correctly named action files |
+| `test_queue_process` | Full queue workflow (new → unpack → begin → process) — **offline** |
+| `test_queue_process_with_remove` | Queue remove action applied via process |
+| `test_deploy` | `pvtx deploy` writes `.pvr/json` matching show output |
+| `test_process_queue_without_begin` | Queue process with implicit `empty` begin |
+| `test_local_transaction` | Local transaction (objects path set) cannot be committed |
+| `test_empty_transaction_has_spec` | Empty state always carries `#spec` field |
+| `test_show_is_idempotent` | Consecutive `pvtx show` calls produce identical output |
+| `test_spec_preserved_after_remove` | `#spec` survives a container removal |
+| `test_add_state_roundtrip` | `add` then `show` equals the original input |
+| `test_double_add_is_idempotent` | Adding the same state twice is a no-op |
+| `test_abort_clears_transaction` | `abort` followed by `begin empty` yields clean empty state |
+
+Every test that captures `pvtx show` JSON also runs **`check_canonical_json`**
+which verifies:
+
+1. The output is valid, parseable JSON
+2. The mandatory `#spec` field is present
+3. `jq -S .` applied twice yields the same bytes (idempotent normalisation)
+
+---
+
+## Option A — From Pantavisor Source Tree (CMake / CTest)
+
+This is the recommended path when developing or patching the pantavisor source
+directly.
+
+### Prerequisites
+
+- CMake ≥ 3.0
+- Pantavisor built with `-DPANTAVISOR_PVTX=ON` (the default)
+- `jq`, `xxd`, `bc`, `tar`, `mktemp` in PATH
+
+### Build
+
+```bash
+git clone https://github.com/pantavisor/pantavisor.git
+cd pantavisor
+
+# Apply the patch (until it lands upstream)
+git apply /path/to/meta-pv-pvtx/patches/pantavisor/0001-test-pvtx-enhance-test-suite.patch
+
+mkdir build && cd build
+cmake .. -DPANTAVISOR_PVTX=ON -DPANTAVISOR_PVTX_STATIC=ON
+make -j$(nproc) pvtx
+```
+
+### Run All pvtx Tests
+
+```bash
+# From the build directory:
+ctest -R pvtx -V
+```
+
+### Run with Verbose pvtx Output
+
+```bash
+PVTX_TEST_PRINT_ALL=1 ctest -R pvtx -V
+```
+
+### Run Manually (without CTest)
+
+```bash
+# From the build directory:
+../test/pvtx/pvtx.sh .. .
+```
+
+### Expected Output
+
+```
+test_create_empty_transaction                      [OK]
+test_create_empty_transaction_canonical            [OK]
+test_process_json_keys_with_spaces                 [OK]
+test_process_json_keys_with_spaces_canonical       [OK]
+...
+test_abort_clears_transaction                      [OK]
+test_abort_clears_transaction_canonical            [OK]
+```
+
+Every test line appears twice — the functional check followed by its canonical
+JSON validation.
+
+---
+
+## Option B — Inside Appengine Container (meta-pantavisor)
+
+This path tests the same pvtx binary that will ship in a Yocto image.
+
+### Prerequisites
+
+Build the appengine image (the `pantavisor-pvtest` package installs `pvtx`,
+the test script, and all test data into the image):
+
+```bash
+./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml
+
+docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
+```
+
+### Launch Container (Test Mode — No Pantavisor Needed)
+
+pvtx tests do **not** require Pantavisor to be running:
+
+```bash
+docker rm -f pva-pvtx 2>/dev/null
+
+docker run --name pva-pvtx -d --rm \
+    --entrypoint /bin/sh pantavisor-appengine:latest -c "sleep infinity"
+```
+
+### Run the Test Suite
+
+```bash
+docker exec pva-pvtx sh -c '
+    PVTX_BIN_DIR=$(dirname $(command -v pvtx))
+    TEST_DATA=/usr/share/pantavisor/pvtest/pvtx
+    TMPDIR=$(mktemp -d)
+    export PVTXDIR="${TMPDIR}/pvtxdir"
+    mkdir -p "${PVTXDIR}"
+    /usr/share/pantavisor/pvtest/pvtx/pvtx.sh "${TEST_DATA}/.." "${PVTX_BIN_DIR}"
+    rm -rf "${TMPDIR}"
+'
+```
+
+Or use the convenience wrapper (see `tools/testing/run-pvtx-tests`):
+
+```bash
+./tools/testing/run-pvtx-tests
+```
+
+### Teardown
+
+```bash
+docker rm -f pva-pvtx
+```
+
+---
+
+## Convenience Wrapper Script
+
+`tools/run-pvtx-tests.sh` automates Option B:
+
+```bash
+./tools/testing/run-pvtx-tests            # uses default image tag (latest)
+./tools/testing/run-pvtx-tests 1.0        # override image tag
+PVTX_TEST_PRINT_ALL=1 ./tools/testing/run-pvtx-tests   # verbose pvtx output
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `pvtx: not found` | pvtx not installed | Build with `-DPANTAVISOR_PVTX=ON` or use appengine image |
+| `jq: not found` | jq missing | Install `jq` on host, or use appengine image |
+| `couldn't find .../test/pvtx` | Wrong SRC_DIR argument | Pass the pantavisor repo root as first argument to pvtx.sh |
+| Test data missing in container | `pantavisor-pvtest` not included | Rebuild image; check `IMAGE_INSTALL` includes `pantavisor-pvtest` |
+| `check_canonical_json` fails with `#spec missing` | pvtx dropped the spec field | Check the pvtx transaction merge logic for the failing test case |
+| `check_canonical_json` fails idempotency check | jq or pvtx produces non-normalised JSON | Run `jq -S . < result.json` twice and compare |

--- a/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine-tester.bb
+++ b/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine-tester.bb
@@ -8,12 +8,14 @@ DOCKER_IMAGE_TAG = "1.0"
 DOCKER_IMAGE_EXTRA_TAGS = "latest"
 
 CORE_IMAGE_EXTRA_INSTALL += " \
+	bc \
 	curl \
 	jq \
 	pantavisor-pvtest \
 	procps \
 	pvr \
 	valgrind \
+	vim-xxd \
 "
 
 PV_DOCKER_IMAGE_ENVS = 'TEST_PATH="/" INTERACTIVE="false" MANUAL="false" OVERWRITE="false" VERBOSE="false" NETSIM="false"'

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -27,13 +27,15 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}_${PV}:"
 
 S = "${WORKDIR}/git"
 
+# TODO: restore "master" + update SRCREV once pantavisor#680 is merged
 PANTAVISOR_BRANCH ??= "master"
 
 SRC_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https;branch=${PANTAVISOR_BRANCH} \
            file://rev0json \
            "
 
-SRCREV = "dba91c26a90b39f23f6dbb1842851f0c47ae0b6b"
+SRCREV = "1cb03f1baf0f19c0f222888d61f938e357a3bc5c"
+
 PE = "1"
 PKGV = "026+git0+${GITPKGV}"
 
@@ -59,6 +61,7 @@ FILES:${PN}-config += "/etc/resolv.conf"
 
 FILES:${PN}-pvtest += "/usr/bin/pvtest-run"
 FILES:${PN}-pvtest += "/usr/share/pantavisor/pvtest/utils"
+FILES:${PN}-pvtest += "/usr/share/pantavisor/pvtest/pvtx"
 
 # pvcontrol and pvcurl packages (replace standalone recipes)
 FILES:${PN}-pvcontrol += "${bindir}/pvcontrol"
@@ -100,4 +103,26 @@ do_install() {
 	cmake_do_install
 	# [ -f ../../lib/pv ] && ln -sf ../../lib/pv ${D}/usr/lib/pv
 	echo "Yes"
+}
+
+do_install:append() {
+	if [ -d "${S}/test/pvtx" ]; then
+		install -d "${D}${datadir}/pantavisor/pvtest/pvtx/resources"
+		install -d "${D}${datadir}/pantavisor/pvtest/pvtx/expected"
+		install -m 0755 "${S}/test/pvtx/pvtx.sh" \
+			"${D}${datadir}/pantavisor/pvtest/pvtx/"
+		for f in "${S}/test/pvtx/resources/"*.json; do
+			[ -f "$f" ] && install -m 0644 "$f" \
+				"${D}${datadir}/pantavisor/pvtest/pvtx/resources/" || true
+		done
+		for f in "${S}/test/pvtx/resources/"*.tar \
+		          "${S}/test/pvtx/resources/"*.tgz; do
+			[ -f "$f" ] && install -m 0644 "$f" \
+				"${D}${datadir}/pantavisor/pvtest/pvtx/resources/" || true
+		done
+		for f in "${S}/test/pvtx/expected/"*.json; do
+			[ -f "$f" ] && install -m 0644 "$f" \
+				"${D}${datadir}/pantavisor/pvtest/pvtx/expected/" || true
+		done
+	fi
 }

--- a/tools/testing/run-pvtx-tests
+++ b/tools/testing/run-pvtx-tests
@@ -1,0 +1,100 @@
+#!/bin/sh
+# run-pvtx-tests - run the pvtx unit test suite inside the appengine container
+#
+# Usage:
+#   run-pvtx-tests [IMAGE_TAG]
+#
+# Environment variables:
+#   PVA_CONTAINER        container name to reuse (default: pva-pvtx)
+#   PVTX_TEST_PRINT_ALL  set to 1 for verbose pvtx output
+#   IMAGE_TAG            appengine image tag (default: latest)
+#
+# The test suite is installed at /usr/share/pantavisor/pvtest/pvtx/ inside
+# the image when the pantavisor-pvtest package is included.  Build the image
+# with the standard appengine config:
+#
+#   ./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml
+#   docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
+#
+# See docs/testing/testplans/testplan-pvtx.md for full documentation.
+
+set -e
+
+IMAGE_TAG="${1:-${IMAGE_TAG:-latest}}"
+CONTAINER="${PVA_CONTAINER:-pva-pvtx}"
+IMAGE="pantavisor-appengine-tester:${IMAGE_TAG}"
+TEST_DATA_DIR="/usr/share/pantavisor/pvtest/pvtx"
+TEST_SCRIPT="${TEST_DATA_DIR}/pvtx.sh"
+
+# The test script expects (SRC_DIR BIN_DIR) where:
+#   SRC_DIR/test/pvtx/ holds the test data
+#   BIN_DIR/pvtx       is the pvtx binary
+#
+# Since the data is installed flat under TEST_DATA_DIR we create a
+# compatible layout in a tmpdir inside the container.
+
+SETUP_CMD=$(cat <<'EOF'
+set -e
+TMPDIR=$(mktemp -d /tmp/pvtx-test.XXXXXX)
+# Build a fake "source tree" layout the test script expects:
+#   $TMPDIR/test/pvtx/{pvtx.sh,resources/,expected/}
+mkdir -p "${TMPDIR}/test/pvtx"
+cp -r /usr/share/pantavisor/pvtest/pvtx/. "${TMPDIR}/test/pvtx/"
+
+# BIN_DIR: directory containing pvtx binary
+BIN_DIR=$(dirname "$(command -v pvtx)")
+
+export PVTXDIR="${TMPDIR}/pvtxdir"
+mkdir -p "${PVTXDIR}"
+
+echo "=== pvtx test suite ==="
+echo "  image pvtx : $(pvtx --version 2>/dev/null || echo '(no --version)')"
+echo "  test data  : /usr/share/pantavisor/pvtest/pvtx"
+echo ""
+
+sh "${TMPDIR}/test/pvtx/pvtx.sh" "${TMPDIR}" "${BIN_DIR}"
+STATUS=$?
+rm -rf "${TMPDIR}"
+exit ${STATUS}
+EOF
+)
+
+cleanup() {
+    docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+
+echo "Checking image ${IMAGE} ..."
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    echo "Error: image '${IMAGE}' not found." >&2
+    echo "Build it first:" >&2
+    echo "  ./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml" >&2
+    echo "  docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-tester-docker.tar" >&2
+    exit 1
+fi
+
+docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+trap cleanup EXIT
+
+echo "Starting container ${CONTAINER} ..."
+docker run --name "${CONTAINER}" -d \
+    --entrypoint /bin/sh \
+    "${IMAGE}" -c "sleep infinity"
+
+echo "Running pvtx tests ..."
+echo ""
+
+EXEC_ENV=""
+if [ -n "${PVTX_TEST_PRINT_ALL}" ]; then
+    EXEC_ENV="-e PVTX_TEST_PRINT_ALL=1"
+fi
+
+docker exec ${EXEC_ENV} "${CONTAINER}" sh -c "${SETUP_CMD}"
+STATUS=$?
+
+echo ""
+if [ "${STATUS}" -eq 0 ]; then
+    echo "=== All pvtx tests PASSED ==="
+else
+    echo "=== pvtx tests FAILED (exit ${STATUS}) ===" >&2
+fi
+exit "${STATUS}"


### PR DESCRIPTION
## Summary

- Adds `pantavisor-pvtest` package install and pvtx test data to the appengine tester image
- Adds `bc` and `vim-xxd` to `pantavisor-appengine-tester` (required by `pvtx.sh`)
- Adds `tools/testing/run-pvtx-tests` convenience script to run the pvtx suite inside the tester container
- Adds `TESTPLAN-pvtx.md` documenting both CMake/CTest and appengine test paths
- Updates `pantavisor_git.bb` SRCREV to pick up upstream pvtx test suite (`feat/test-pvtx-enhance-suite`)

## Test plan

- Build: `./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml`
- Load: `docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-tester-docker.tar`
- Run: `./tools/testing/run-pvtx-tests`
- All tests in `TESTPLAN-pvtx.md` should pass