### PR TITLE
feat(skel): add dm-versatile alias to dm-internal-secrets in default device.json

### DIFF
--- a/recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json
@@ -3,7 +3,8 @@
         {
 	    "name": "dm-internal-secrets",
 	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
-	    "type": "dm-crypt-versatile"
+	    "type": "dm-crypt-versatile",
+	    "aliases": ["dm-versatile"]
 	}
     ],
     "groups": [

--- a/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json
@@ -3,7 +3,8 @@
         {
 	    "name": "dm-internal-secrets",
 	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
-	    "type": "dm-crypt-versatile"
+	    "type": "dm-crypt-versatile",
+	    "aliases": ["dm-versatile"]
 	}
     ],
     "groups": [

--- a/recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json
@@ -3,7 +3,8 @@
         {
 	    "name": "dm-internal-secrets",
 	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
-	    "type": "dm-crypt-versatile"
+	    "type": "dm-crypt-versatile",
+	    "aliases": ["dm-versatile"]
 	}
     ],
     "groups": [

--- a/recipes-pv/pantavisor/files/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/pantavisor-default-skel/device.json
@@ -3,7 +3,8 @@
         {
 	    "name": "dm-internal-secrets",
 	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
-	    "type": "dm-crypt-versatile"
+	    "type": "dm-crypt-versatile",
+	    "aliases": ["dm-versatile"]
 	}
     ],
     "groups": [

--- a/recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json
@@ -3,7 +3,8 @@
         {
 	    "name": "dm-internal-secrets",
 	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
-	    "type": "dm-crypt-versatile"
+	    "type": "dm-crypt-versatile",
+	    "aliases": ["dm-versatile"]
 	}
     ],
     "groups": [

--- a/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
@@ -3,7 +3,8 @@
         {
 	    "name": "dm-internal-secrets",
 	    "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
-	    "type": "dm-crypt-versatile"
+	    "type": "dm-crypt-versatile",
+	    "aliases": ["dm-versatile"]
 	}
     ],
     "groups": [


### PR DESCRIPTION
## Summary

Adds `"aliases": ["dm-versatile"]` to the `dm-internal-secrets` disk in
every default-skel `device.json`:

- `recipes-pv/pantavisor/files/pantavisor-default-skel/device.json` (generic)
- `recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json`
- `recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json`
- `recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json`
- `recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json`
- `recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json`

## Motivation

Prebuilt platform containers — notably `pvr-sdk` v1.3.1 and v1.3.2 —
declare storage with `permanent@dm-versatile` even though no skel
shipped a disk with that name. Before pantavisor's strict missing-disk
check landed, this silently fell through (volume mounted with no
backing disk); with the strict check it correctly tears down the
revision on every reboot, which manifested as hard-to-deploy lab
devices on this layer.

Pantavisor's disk aliases feature (recently merged) lets a disk answer
to extra synonyms at lookup time. Adding `dm-versatile` as an alias
for the canonical `dm-internal-secrets` disk lets these upstream
containers boot on any device provisioned from this layer without
re-publishing the container or hand-editing the device's `run.json`.

Resolution is lookup-only — all downstream paths, mountpoints, and
log lines keep using the canonical `dm-internal-secrets` name, so this
is a no-op for any device whose containers don't reference
`dm-versatile`.

## Compatibility

- **New pantavisor (with aliases support):** containers referring to
  `disk: "dm-versatile"` resolve correctly to `dm-internal-secrets`.
- **Older pantavisor:** the `aliases` JSON key is ignored. Behavior
  for those devices is unchanged from today.

## Test plan

- [x] Build BSP for raspberrypi (rpi machine override) with this
      change + matching pantavisor revision; deploy to a device
      previously running pvr-sdk v1.3.1 and confirm boot reaches
      DONE (validated on `labslave_rpi5`, rev 8 DONE).
- [ ] Confirm INFO log line on the device:
      `volume 'docker--var-dmcrypt-volume' disk ref 'dm-versatile' resolved to 'dm-internal-secrets' via alias`
- [ ] Negative regression: a container referencing some other unknown
      disk still tears the revision down (strict check unaffected).