### PR TITLE
feat(debug): add pv-perf container with linux perf + strace

### DIFF
--- a/kas/with-perf.yaml
+++ b/kas/with-perf.yaml
@@ -1,0 +1,21 @@
+header:
+  version: 14
+
+# Enable on-device profiling via the pv-perf debug container.
+#
+# This overlay only enables DISTRO_FEATURES=tools-profile, which is
+# what the kernel recipe needs to build the `perf` package. The
+# pv-perf container recipe (recipes-containers/debug/pv-perf_1.0.bb)
+# pulls perf in via IMAGE_INSTALL and keeps the host PID/net/IPC/UTS
+# namespaces + CAP_SYS_ADMIN/PTRACE/PERFMON so
+# `pventer -c pv-perf perf top -p $(pidof pv-main-loop)` profiles
+# pantavisor's hot worker.
+#
+# We deliberately do NOT add `perf` to PANTAVISOR_FEATURES here:
+# putting perf in the initramfs grows it past the 128 MB rpi boot
+# partition and breaks the rpiab tryboot installer on devices already
+# flashed at that size. The container approach keeps perf out of the
+# boot path — it ships as a regular pvr object on the rootfs side.
+local_conf_header:
+  perf-feature: |
+    DISTRO_FEATURES:append = " tools-profile"

--- a/recipes-containers/debug/files/pv-perf-run.sh
+++ b/recipes-containers/debug/files/pv-perf-run.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# pv-perf entrypoint — keep the container alive so an operator can
+# pventer into it and run perf against pantavisor.
+#
+# The container is configured (see pv-perf.args.json) to keep the host
+# PID / net / IPC / UTS namespaces, so PIDs inside this container
+# match the host's.
+#
+# Note: PID 1 on the host is the pantavisor supervisor and is mostly
+# sleeping. The hot worker is `pv-main-loop`, a child process. Profile
+# it by name or by looking up its pid:
+#
+#   pid=$(pidof pv-main-loop)
+#   perf top -p "$pid"
+#   perf record -F 99 -p "$pid" -g -- sleep 20 && perf report
+#
+# To profile *all* pantavisor-side workers (pv-main-loop +
+# pv-platform-* + pv-logger-* + pv-xconnect-out):
+#
+#   perf top --comm pantavisor,pv-main-loop,pv-xconnect-out
+#
+# We don't run perf at boot — that would be a continuous attach. The
+# operator drives it interactively.
+
+set -eu
+
+log() { printf '%s pv-perf: %s\n' "$(date -Iseconds)" "$*" >&2; }
+
+log "started; $(perf --version 2>/dev/null || echo 'perf missing')"
+main_pid=$(pidof pv-main-loop 2>/dev/null || true)
+if [ -n "$main_pid" ]; then
+    log "pv-main-loop is host pid $main_pid"
+    log "  perf top -p $main_pid"
+    log "  perf record -F 99 -p $main_pid -g -- sleep 20 && perf report"
+else
+    log "pv-main-loop not yet visible from this namespace"
+fi
+
+# Keep the container alive forever; LXC wants this pid (which is
+# *not* host pid 1 — we kept the host PID namespace, but exec'd a
+# fresh process under it) to stay around.
+exec sleep infinity

--- a/recipes-containers/debug/files/pv-perf.args.json
+++ b/recipes-containers/debug/files/pv-perf.args.json
@@ -1,0 +1,16 @@
+{
+    "PV_LXC_NAMESPACE_KEEP": "user pid net ipc",
+    "PV_LXC_CAP_KEEP": [
+        "sys_admin",
+        "sys_ptrace",
+        "sys_resource",
+        "syslog",
+        "dac_read_search",
+        "ipc_lock",
+        "net_admin"
+    ],
+    "PV_SECURITY_WITH_HOSTPROC": "1",
+    "PV_SECURITY_WITH_STORAGE": "1",
+    "PV_LXC_DISABLE_CONSOLE": "1",
+    "LXC_TTY_MAX": "0"
+}

--- a/recipes-containers/debug/pv-perf_1.0.bb
+++ b/recipes-containers/debug/pv-perf_1.0.bb
@@ -1,0 +1,55 @@
+SUMMARY = "pv-perf — debug container with linux perf + strace, sharing the host PID namespace"
+DESCRIPTION = "On-device profiling and tracing. The container keeps the host PID, \
+network and IPC namespaces (lxc.namespace.keep) and holds CAP_SYS_ADMIN \
++ CAP_SYS_PTRACE, so `pventer -c pv-perf perf top -p $(pidof pv-main-loop)` \
+profiles pantavisor's hot worker, and `pventer -c pv-perf strace -p $(pidof pv-main-loop)` \
+traces its syscalls. Not intended for production images — opt in only when \
+you need to profile or trace."
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "${PN}"
+PVRIMAGE_AUTO_MDEV = "0"
+
+# perf comes from the kernel recipe (linux-raspberrypi here) and pulls
+# its runtime libs (libdw, libelf, libunwind, libdebuginfod, libslang,
+# libpython3, libstdc++, libz, libcrypto). We add a small shell so the
+# operator can pventer in and run things interactively.
+IMAGE_INSTALL += "perf busybox strace"
+
+# perf's package only exists when DISTRO_FEATURES has tools-profile.
+# The kernel recipe gates the build on that flag too, so without it
+# the image-install line above resolves to nothing useful and the
+# container is effectively empty. Encode the requirement explicitly
+# so the image fails fast with a clear message instead of producing a
+# silently-broken container.
+python __anonymous() {
+    distro_features = (d.getVar("DISTRO_FEATURES") or "").split()
+    if "tools-profile" not in distro_features:
+        bb.warn("pv-perf: DISTRO_FEATURES is missing 'tools-profile'; "
+                "perf will not be in the resulting image. Add it via "
+                "kas/with-perf.yaml or local.conf.")
+}
+
+do_fetch[noexec] = "0"
+do_unpack[noexec] = "0"
+
+SRC_URI += "file://pv-perf-run.sh \
+            file://pv-perf.args.json"
+
+install_pv_perf() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-perf-run.sh ${IMAGE_ROOTFS}${bindir}/pv-perf-run
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_pv_perf; "
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-perf-run"
+
+# Skip auto-recovery — when this dies it's almost always because the
+# operator killed the perf session, which we don't want to treat as a
+# failure that triggers reboots.
+PVR_APP_ADD_GROUP = "platform"


### PR DESCRIPTION
## Summary

Adds a diagnostic container (\`pv-perf\`) that ships \`perf\`, \`strace\`,
and busybox for an interactive shell. Keeps the host PID/net/IPC/UTS
namespaces and holds CAP_SYS_ADMIN + CAP_SYS_PTRACE so it can attach
to and trace any process running on the host:

\`\`\`
pventer -c pv-perf perf top -p \$(pidof pv-main-loop)
pventer -c pv-perf strace -p \$(pidof pv-main-loop)
pventer -c pv-perf perf record -F 99 -p \$(pidof pv-main-loop) -g -- sleep 20
\`\`\`

## Files

| File | Purpose |
|---|---|
| \`recipes-containers/debug/pv-perf_1.0.bb\` | core-image + container-pvrexport recipe; pulls \`perf busybox strace\` via IMAGE_INSTALL; group=platform so a killed perf session doesn't auto-recover into a reboot loop |
| \`recipes-containers/debug/files/pv-perf.args.json\` | namespace.keep = user/pid/net/ipc; CAP_SYS_ADMIN, CAP_SYS_PTRACE, CAP_SYS_RESOURCE, CAP_SYSLOG, CAP_DAC_READ_SEARCH, CAP_IPC_LOCK, CAP_NET_ADMIN; PV_SECURITY_WITH_HOSTPROC=1; LXC console disabled to coexist with pvr-sdk |
| \`recipes-containers/debug/files/pv-perf-run.sh\` | entrypoint that prints suggested perf/strace invocations and sleeps forever — interactive workflow, not a boot-time profiler |
| \`kas/with-perf.yaml\` | overlay that adds \`tools-profile\` to DISTRO_FEATURES (required by the kernel recipe to build \`perf\`) |

## Why a container, not initramfs

Putting \`perf\` on the boot side would push the rpi boot partition past
its 128 MB limit and brick devices already flashed at that size. The
container stays on the rootfs side as a regular pvr object so it can
be added or removed per-device without touching the BSP.

## Validation

Used on rpi5 (asacasa/labslave_rpi5) to identify two real bugs in the
last working session:

1. A stale fd registration leak in \`pv-main-loop\`'s libevent base —
   \`strace\` showed 3 phantom \`EPOLLHUP\` events per \`epoll_pwait\`
   iteration, leading to pantavisor [PR #699][pv-pr].
2. A 32-bit-arm-compat-VDSO Go-runtime wedge in pvwificonnect —
   \`perf\` pinpointed 100% of cycles in the compat VDSO at an address
   outside the binary's text segment, with \`SigCgt=0\` proving the Go
   runtime never installed signal handlers.

[pv-pr]: https://github.com/pantavisor/pantavisor/pull/699

## Test plan

- [x] Build with \`kas/with-perf.yaml\` overlay — produces \`pv-perf.pvrexport.tgz\`
- [x] Build without the overlay — recipe emits a clear bb.warn at parse time, image is empty (fail-fast)
- [x] Deploy via pvr to rpi5, confirm \`pventer -c pv-perf perf top -p \$(pidof pv-main-loop)\` works
- [x] Confirm \`pventer -c pv-perf strace -p <pid>\` attaches to host processes
- [x] Confirm coexistence with pvr-sdk (no tty contention)
- [ ] Validate on a non-rpi target (sunxi / imx) once kernel-side \`perf\` recipe is wired