### PR TITLE
feat(rpi): enable CONFIG_COMPAT_VDSO=y on arm64 kernels

### DIFF
--- a/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,0 +1,80 @@
+
+# meta-pantavisor/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+#
+# Enable CONFIG_COMPAT_VDSO=y for arm64 kernels by exposing a 32-bit
+# ARM cross-toolchain (gcc + binutils) to Kbuild via PATH +
+# CROSS_COMPILE_COMPAT.
+#
+# Background: arch/arm64/Kconfig defines COMPAT_VDSO as default-y, but
+# only if either (CC_IS_CLANG && LD_IS_LLD) or CROSS_COMPILE_COMPAT is
+# set. With gcc + bfd (Yocto's default), CROSS_COMPILE_COMPAT must be
+# provided explicitly, otherwise the compat vDSO is silently dropped
+# from the build.
+#
+# Without the compat vDSO, 32-bit userspace processes (e.g. Go binaries
+# built for linux/arm/v6) running on a 64-bit kernel fall back to the
+# raw clock_gettime syscall path, which has historically had
+# regressions on arm64 compat (Go runtime startup wedges, futex_time64
+# issues, etc.). Providing the compat vDSO matches what stock distro
+# arm64 kernels (Debian, Ubuntu, Arch) ship.
+
+# The cross-toolchain triplet's libc suffix depends on the distro's
+# C library (musl vs glibc). Pantavisor builds against musl, so the
+# arm32 cross-toolchain is `arm-poky-linux-musleabi-`. On a glibc
+# distro it would be `arm-poky-linux-gnueabi-`.
+COMPAT_LIBC_SUFFIX = "${@'musleabi' if d.getVar('TCLIBC') == 'musl' else 'gnueabi'}"
+COMPAT_TRIPLET = "arm${TARGET_VENDOR}-linux-${COMPAT_LIBC_SUFFIX}"
+
+# The 32-bit ARM cross-gcc and cross-binutils are produced by the
+# rpi-kernel multiconfig (MACHINE=raspberrypi). Each multiconfig has
+# an isolated `recipe-sysroot-native`, so the arm64 kernel build
+# can't see the v6 multiconfig's binaries on PATH by default. Add
+# both component bin dirs to PATH at compile time so Kbuild's
+# vdso32 step can find arm-poky-linux-musleabi-{gcc,as,ld,...}.
+COMPAT_GCC_BIN_DIR  = "${TOPDIR}/tmp-${DISTRO_CODENAME}-rpi-kernel-raspberrypi/sysroots-components/${BUILD_ARCH}/gcc-cross-arm/usr/bin/${COMPAT_TRIPLET}"
+COMPAT_BUTILS_BIN_DIR = "${TOPDIR}/tmp-${DISTRO_CODENAME}-rpi-kernel-raspberrypi/sysroots-components/${BUILD_ARCH}/binutils-cross-arm/usr/bin/${COMPAT_TRIPLET}"
+
+EXTRA_OEMAKE:append:aarch64 = " CROSS_COMPILE_COMPAT=${COMPAT_TRIPLET}-"
+
+# Build a shim directory under the kernel's WORKDIR with un-prefixed
+# symlinks (`as`, `ld`, `objcopy`, `objdump`, `gcc`, `cpp`, `nm`, `ar`,
+# `ranlib`, `strip`) pointing at the v6 multiconfig's prefixed cross-
+# binaries. Without this, gcc's internal assembler invocation finds
+# the host /usr/bin/as ("as: unrecognized option '-EL'") because the
+# Yocto cross-gcc package doesn't ship `as` in its libexec — it
+# expects PATH to provide either the prefixed or un-prefixed name,
+# and Kbuild's vdso32 rules end up calling plain `as` directly.
+COMPAT_SHIM_DIR = "${WORKDIR}/compat-toolchain-shim"
+
+setup_compat_toolchain_shim () {
+    install -d ${COMPAT_SHIM_DIR}
+    for tool in as ld objcopy objdump nm ar ranlib strip cpp; do
+        ln -sf "${COMPAT_BUTILS_BIN_DIR}/${COMPAT_TRIPLET}-$tool" \
+            "${COMPAT_SHIM_DIR}/$tool"
+    done
+    for tool in gcc g++ cpp; do
+        ln -sf "${COMPAT_GCC_BIN_DIR}/${COMPAT_TRIPLET}-$tool" \
+            "${COMPAT_SHIM_DIR}/$tool" 2>/dev/null || true
+    done
+    export PATH="${COMPAT_SHIM_DIR}:${COMPAT_GCC_BIN_DIR}:${COMPAT_BUTILS_BIN_DIR}:${PATH}"
+}
+
+# Both `do_compile` (vmlinux) AND `do_compile_kernelmodules` (in-tree
+# modules) run vdso_prepare, so both need the shim + PATH applied.
+# Without the second one, `do_compile_kernelmodules` re-fails on
+# `arm-poky-linux-musleabi-gcc: not found` even after a successful
+# `do_compile`.
+do_compile:prepend:aarch64 () {
+    setup_compat_toolchain_shim
+}
+do_compile_kernelmodules:prepend:aarch64 () {
+    setup_compat_toolchain_shim
+}
+
+# Make do_compile wait until the rpi-kernel multiconfig has populated
+# both gcc-cross-arm and binutils-cross-arm sysroots — without these
+# mcdepends, the arm64 kernel may run vdso32 compile before the path
+# above is populated. mcdepends crosses the per-multiconfig boundary
+# that ordinary DEPENDS cannot.
+do_compile[mcdepends] += "mc::rpi-kernel:gcc-cross-arm:do_populate_sysroot \
+                          mc::rpi-kernel:binutils-cross-arm:do_populate_sysroot"

--- a/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -17,6 +17,21 @@
 # regressions on arm64 compat (Go runtime startup wedges, futex_time64
 # issues, etc.). Providing the compat vDSO matches what stock distro
 # arm64 kernels (Debian, Ubuntu, Arch) ship.
+#
+# The 32-bit ARM cross-toolchain only exists inside the rpi-kernel
+# multiconfig's sysroots-components tree, which is only built when
+# the unified rpi-tryboot configuration enables BBMULTICONFIG (e.g.
+# kas/build-configs/release/rpi-scarthgap.yaml). Pure single-arch
+# builds like raspberrypi-armv8-scarthgap.yaml do NOT enable that
+# multiconfig, so referencing mc::rpi-kernel:... unconditionally
+# would break parsing with:
+#   "Multiconfig 'rpi-kernel' is referenced in multiconfig dependency
+#    ... but not enabled in BBMULTICONFIG?"
+#
+# Therefore the entire compat-vDSO setup (mcdepends, EXTRA_OEMAKE,
+# the PATH shim) is gated on rpi-kernel actually being part of
+# BBMULTICONFIG. On a non-multiconfig arm64 build this bbappend is
+# a no-op.
 
 # The cross-toolchain triplet's libc suffix depends on the distro's
 # C library (musl vs glibc). Pantavisor builds against musl, so the
@@ -34,7 +49,31 @@ COMPAT_TRIPLET = "arm${TARGET_VENDOR}-linux-${COMPAT_LIBC_SUFFIX}"
 COMPAT_GCC_BIN_DIR  = "${TOPDIR}/tmp-${DISTRO_CODENAME}-rpi-kernel-raspberrypi/sysroots-components/${BUILD_ARCH}/gcc-cross-arm/usr/bin/${COMPAT_TRIPLET}"
 COMPAT_BUTILS_BIN_DIR = "${TOPDIR}/tmp-${DISTRO_CODENAME}-rpi-kernel-raspberrypi/sysroots-components/${BUILD_ARCH}/binutils-cross-arm/usr/bin/${COMPAT_TRIPLET}"
 
-EXTRA_OEMAKE:append:aarch64 = " CROSS_COMPILE_COMPAT=${COMPAT_TRIPLET}-"
+COMPAT_SHIM_DIR = "${WORKDIR}/compat-toolchain-shim"
+
+# Sentinel: only "1" when the rpi-kernel multiconfig is enabled and
+# this kernel is being built for aarch64. The shell prepends below
+# read this and become no-ops otherwise.
+PV_COMPAT_VDSO_ENABLED ?= "0"
+
+python __anonymous () {
+    bbmc = (d.getVar('BBMULTICONFIG') or '').split()
+    if 'rpi-kernel' not in bbmc:
+        return
+    if d.getVar('TARGET_ARCH') != 'aarch64':
+        return
+    d.setVar('PV_COMPAT_VDSO_ENABLED', '1')
+    triplet = d.getVar('COMPAT_TRIPLET')
+    d.appendVar('EXTRA_OEMAKE', ' CROSS_COMPILE_COMPAT=%s-' % triplet)
+    # mcdepends across multiconfig boundary; safe to add only when
+    # rpi-kernel is actually enabled in BBMULTICONFIG.
+    d.appendVarFlag('do_compile', 'mcdepends',
+        ' mc::rpi-kernel:gcc-cross-arm:do_populate_sysroot'
+        ' mc::rpi-kernel:binutils-cross-arm:do_populate_sysroot')
+    d.appendVarFlag('do_compile_kernelmodules', 'mcdepends',
+        ' mc::rpi-kernel:gcc-cross-arm:do_populate_sysroot'
+        ' mc::rpi-kernel:binutils-cross-arm:do_populate_sysroot')
+}
 
 # Build a shim directory under the kernel's WORKDIR with un-prefixed
 # symlinks (`as`, `ld`, `objcopy`, `objdump`, `gcc`, `cpp`, `nm`, `ar`,
@@ -44,8 +83,6 @@ EXTRA_OEMAKE:append:aarch64 = " CROSS_COMPILE_COMPAT=${COMPAT_TRIPLET}-"
 # Yocto cross-gcc package doesn't ship `as` in its libexec — it
 # expects PATH to provide either the prefixed or un-prefixed name,
 # and Kbuild's vdso32 rules end up calling plain `as` directly.
-COMPAT_SHIM_DIR = "${WORKDIR}/compat-toolchain-shim"
-
 setup_compat_toolchain_shim () {
     install -d ${COMPAT_SHIM_DIR}
     for tool in as ld objcopy objdump nm ar ranlib strip cpp; do
@@ -65,16 +102,12 @@ setup_compat_toolchain_shim () {
 # `arm-poky-linux-musleabi-gcc: not found` even after a successful
 # `do_compile`.
 do_compile:prepend:aarch64 () {
-    setup_compat_toolchain_shim
+    if [ "${PV_COMPAT_VDSO_ENABLED}" = "1" ]; then
+        setup_compat_toolchain_shim
+    fi
 }
 do_compile_kernelmodules:prepend:aarch64 () {
-    setup_compat_toolchain_shim
+    if [ "${PV_COMPAT_VDSO_ENABLED}" = "1" ]; then
+        setup_compat_toolchain_shim
+    fi
 }
-
-# Make do_compile wait until the rpi-kernel multiconfig has populated
-# both gcc-cross-arm and binutils-cross-arm sysroots — without these
-# mcdepends, the arm64 kernel may run vdso32 compile before the path
-# above is populated. mcdepends crosses the per-multiconfig boundary
-# that ordinary DEPENDS cannot.
-do_compile[mcdepends] += "mc::rpi-kernel:gcc-cross-arm:do_populate_sysroot \
-                          mc::rpi-kernel:binutils-cross-arm:do_populate_sysroot"


### PR DESCRIPTION
## Summary

Adds a bbappend to \`linux-raspberrypi\` that enables \`CONFIG_COMPAT_VDSO=y\` on the arm64 kernel multiconfigs (rpi-kernel8 + rpi-kernel_2712), so 32-bit userspace running on a 64-bit kernel gets \`clock_gettime\` and friends through the compat vDSO instead of falling back to the raw syscall path.

This matters for the unified rpi-tryboot image which has to host the same agent stack on the full Pi family — Pi 0/1/2 (32-bit hardware, 32-bit kernel, no compat layer) and Pi 3/4/5 (32-bit OR 64-bit kernel). When 32-bit userspace meets the 64-bit kernel, the compat vDSO is what stock distro arm64 kernels (Debian, Ubuntu, Arch) all ship.

## Why it wasn't trivially \`COMPAT_VDSO=y\` in defconfig

\`arch/arm64/Kconfig\` makes \`COMPAT_VDSO\` default-y only when either \`(CC_IS_CLANG && LD_IS_LLD)\` *or* \`CROSS_COMPILE_COMPAT\` is set. We build with gcc + bfd, so we have to provide \`CROSS_COMPILE_COMPAT\` ourselves or the compat vDSO is silently dropped from the build. The challenge is that the arm32 cross-toolchain only exists in the rpi-kernel (32-bit) multiconfig's sysroots-components tree, and each multiconfig's \`recipe-sysroot-native\` is isolated.

## What this bbappend does

1. **Picks the right libc suffix from \`TCLIBC\`** — \`musleabi\` on musl, \`gnueabi\` on glibc. Hardcoding \`gnueabi\` is wrong for the musl build since the binary on disk is \`arm-poky-linux-musleabi-gcc\`.

2. **Sets \`CROSS_COMPILE_COMPAT=arm\${TARGET_VENDOR}-linux-\${COMPAT_LIBC_SUFFIX}-\`** so the kernel build constructs the right tool names.

3. **\`mcdepends\` on the rpi-kernel multiconfig's \`gcc-cross-arm\` + \`binutils-cross-arm\`** — ensures the v6 multiconfig populates them into its sysroots-components tree before our arm64 kernel's \`do_compile\` runs. The arm32 cross isn't a buildable target in the aarch64 multiconfig parsing context, so a plain \`DEPENDS\` won't resolve.

4. **Builds a per-build shim dir under \`\${WORKDIR}\`** with un-prefixed symlinks (\`as\`, \`ld\`, \`objcopy\`, \`nm\`, \`ar\`, \`ranlib\`, \`strip\`, \`cpp\`, \`gcc\`, \`g++\`) pointing at the v6 multiconfig's prefixed binaries, and PATH-prepends that dir at compile time. Without the shim, gcc's internal assembler invocation finds the host \`/usr/bin/as\` (which rejects \`-EL\`) because Yocto's cross-gcc package doesn't ship \`as\` in its libexec — it expects PATH to provide either the prefixed or un-prefixed name, and Kbuild's vdso32 Makefile ends up calling plain \`as\` directly.

5. **Applies the shim to both \`do_compile:prepend:aarch64\` AND \`do_compile_kernelmodules:prepend:aarch64\`** — both tasks re-run \`vdso_prepare\` and need the toolchain on PATH.

## Verification

Multi-machine BSP build clean:
\`\`\`
Tasks Summary: Attempted 12260 tasks of which 12140 didn't need to be rerun and all succeeded.
\`\`\`

On the device after deploy:
\`\`\`
\$ zcat /proc/config.gz | grep -i COMPAT_VDSO
CONFIG_COMPAT_VDSO=y
CONFIG_THUMB2_COMPAT_VDSO=y
CONFIG_GENERIC_COMPAT_VDSO=y
\`\`\`

## Caveat

This was originally chased to fix a 32-bit-arm pvwificonnect Go-runtime wedge on aarch64 hardware. **Compat-VDSO turned out to *not* be the cause of that wedge** — even with \`CONFIG_COMPAT_VDSO=y\` enabled, the same 32-bit pvwificonnect binary still spins identically (Threads=1, SigCgt=0, no syscalls). That bug lives somewhere else in Go runtime + arm32-on-aarch64 compat. **The bbappend itself is still correct and worth landing** — it brings the kernel in line with what the rest of the arm64 distro world ships, fixes a silent regression, and removes a footgun for any future 32-bit binary that does happen to depend on the compat vDSO.

## Test plan

- [x] BSP builds clean from scratch on rpi-scarthgap.yaml
- [x] \`CONFIG_COMPAT_VDSO=y\` present in the running kernel (\`/proc/config.gz\`)
- [x] No regressions on the 32-bit kernel multiconfigs (rpi-kernel/2/7/7l)
- [x] arm64 userspace still healthy (pvwificonnect arm64 idle, agent-app classifying)
- [ ] Validate on a glibc-based pantavisor distro (suffix would resolve to \`gnueabi\` automatically)