### PR TITLE
docs: move TESTPLAN-cgroup into docs/testing/testplans/

### DIFF
--- a/docs/testing/automated-workflow.md
+++ b/docs/testing/automated-workflow.md
@@ -103,3 +103,4 @@ Test plans covering specific features live in [testplans/](testplans/):
 | [testplan-pvctrl.md](testplans/testplan-pvctrl.md) | Full pv-ctrl REST API coverage |
 | [testplan-xconnect.md](testplans/testplan-xconnect.md) | xconnect service mesh (unix, D-Bus, DRM) |
 | [testplan-pvtx.md](testplans/testplan-pvtx.md) | pvtx transaction tool unit tests (no Pantavisor needed) |
+| [testplan-cgroup.md](testplans/testplan-cgroup.md) | cgroup HYBRID-mode destroy and no-suffix accumulation (lenient + force stop) |

--- a/docs/testing/testplans/testplan-cgroup.md
+++ b/docs/testing/testplans/testplan-cgroup.md
@@ -1,4 +1,4 @@
-# TESTPLAN-cgroup
+# testplan-cgroup
 
 Validation for pantavisor's cgroup handling on HYBRID-mode devices (embedded/standalone init), covering both lenient-stop and force-stop (SIGKILL) container lifecycle paths.
 


### PR DESCRIPTION
## Summary

- Moves `TESTPLAN-cgroup.md` from the repo root into `docs/testing/testplans/testplan-cgroup.md`, consistent with all other test plans.
- Updates the heading to match the lowercase convention used by sibling files.
- Adds the new entry to the test plans table in `docs/testing/automated-workflow.md`.