### PR TITLE
feat(manifest-audit): rootfs drift audit class + upstream references + CI artifact

### DIFF
--- a/.github/workflows/buildkas-target.yaml
+++ b/.github/workflows/buildkas-target.yaml
@@ -53,6 +53,7 @@ jobs:
            su - builder -c "cd $GITHUB_WORKSPACE && env && kas shell ${{ inputs.configs }} -c 'bitbake -c populate_sdk ${{ inputs.build_target }}'"
 
       - name: prepare files for distribution
+        if: always()
         run: |
           chmod -R 777 $GITHUB_WORKSPACE
           BUILD_BASE_DIR=$(echo build/${{ env.TMPDIR }}/deploy/images/*)
@@ -72,6 +73,7 @@ jobs:
 
 ## File distribution
       - name: Archive AppEngine artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: appengine-${{ inputs.machine_name }}
@@ -81,6 +83,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Archive wic artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.build_target}}-${{ inputs.machine_name }}
@@ -89,6 +92,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Archive all pvrexport artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pvrexports-${{ inputs.machine_name }}
@@ -97,6 +101,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Archive bsp pvrexport artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pantavisor-bsp-${{ inputs.machine_name }}
@@ -105,6 +110,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Archive tezi tar artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: tezi-${{ inputs.build_target}}-${{ inputs.machine_name }}
@@ -113,6 +119,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Archive sdk tar artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: sdk-artifact-${{ inputs.machine_name }}
@@ -120,6 +127,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Archive manifest audit artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: manifest-audit-${{ inputs.build_target }}-${{ inputs.machine_name }}

--- a/.github/workflows/buildkas-target.yaml
+++ b/.github/workflows/buildkas-target.yaml
@@ -64,6 +64,9 @@ jobs:
           find build/${{ env.TMPDIR }}/deploy/images/ -name "test.docker.sh" -exec cp {} . \; 2>/dev/null || true
           find build/${{ env.TMPDIR }}/deploy/images/ -name "pantavisor-appengine*-docker.tar" -exec cp {} . \; 2>/dev/null || true
 
+          find build/${{ env.TMPDIR }}/deploy/images/ -name "*.manifest.txt" -exec cp {} . \; 2>/dev/null || true
+          find build/${{ env.TMPDIR }}/deploy/images/ -name "*.manifest.patch" -exec cp {} . \; 2>/dev/null || true
+
           find build/${{ env.TMPDIR }}/deploy/sdk/ -name "panta*.sh" -exec cp {} . \; 2>/dev/null || true
           ls -l .
 
@@ -114,4 +117,13 @@ jobs:
         with:
           name: sdk-artifact-${{ inputs.machine_name }}
           path: panta*.sh
+          if-no-files-found: ignore
+
+      - name: Archive manifest audit artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: manifest-audit-${{ inputs.build_target }}-${{ inputs.machine_name }}
+          path: |
+            *.manifest.txt
+            *.manifest.patch
           if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ New documents should follow this layout:
 Key documents:
 - [docs/how-to-build/pantavisor-development.md](docs/how-to-build/pantavisor-development.md) — local source development with workspace overlay
 - [docs/how-to-build/get-started.md](docs/how-to-build/get-started.md) — first build guide
+- [docs/how-to-build/manifest-audit.md](docs/how-to-build/manifest-audit.md) — rootfs manifest audit (`pv-manifest-audit` / `pv-manifest-strict`)
 - [docs/testing/development-workflow.md](docs/testing/development-workflow.md) — manual appengine testing during development
 - [docs/testing/automated-workflow.md](docs/testing/automated-workflow.md) — structured testing with test.docker.sh (valgrind, CI, testplans)
 

--- a/classes/pv-manifest-audit.bbclass
+++ b/classes/pv-manifest-audit.bbclass
@@ -1,0 +1,222 @@
+# pv-manifest-audit.bbclass
+#
+# Generates a deterministic manifest of the rootfs (path, mode, uid, gid,
+# type, size, symlink target) and audits it against a reference file
+# fetched into ${WORKDIR}.
+#
+# Activation: this class is meant to be inherited conditionally on
+# PANTAVISOR_FEATURES, e.g. in the recipe:
+#
+#   inherit ${@bb.utils.contains_any('PANTAVISOR_FEATURES', \
+#       'pv-manifest-audit pv-manifest-strict', 'pv-manifest-audit', '', d)}
+#
+# Modes:
+#   - 'pv-manifest-audit'  → advisory: deviations emit the patch as a WARNING
+#                            (build proceeds). Use this in dev distros.
+#   - 'pv-manifest-strict' → enforcing: deviations are FATAL (build fails).
+#                            Use this in release/CI distros to gate drift.
+#                            'strict' implies 'audit'; if both are set,
+#                            'strict' wins.
+#
+# Reference filename (in WORKDIR):
+#     ${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt
+#
+# PV_MANIFEST_PREFIX defaults to ${PN}; recipes should pin it to a stable
+# image label (e.g. "pv-initramfs", "pv-appengine") so the reference name
+# is decoupled from package versioning.
+#
+# The class itself does NOT touch SRC_URI. To enable the audit, a layer
+# (this one for upstream-supported machines, or a downstream bbappend for
+# their own MACHINE) adds:
+#
+#     FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+#     SRC_URI += "file://${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt"
+#
+# and ships the file under their layer's files/. Override semantics are the
+# stock Yocto ones — FILESEXTRAPATHS:prepend in a bbappend wins over the
+# upstream layer's copy.
+#
+# Output:
+#   - Manifest is always written to
+#       ${IMGDEPLOYDIR}/${IMAGE_NAME}.manifest.txt
+#   - On any deviation (missing reference or mismatch) a unified-diff patch
+#     is written next to the manifest as
+#       ${IMGDEPLOYDIR}/${IMAGE_NAME}.manifest.patch
+#     and printed in full to the bitbake log via bb.plain (CI-visible).
+#     The patch headers use the reference's bare basename, so a maintainer
+#     can apply it with:
+#       cd <layer>/files && patch < .../${IMAGE_NAME}.manifest.patch
+
+PV_MANIFEST_PREFIX ??= "${PN}"
+PV_MANIFEST_REFERENCE_NAME ??= "${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt"
+
+# Path prefixes (rootfs-relative, leading slash) whose entire subtree is
+# omitted from the manifest. Defaults cover package-manager state files
+# whose contents flip on every rebuild without reflecting a real change to
+# the image — package add/remove is still detectable via the installed
+# files themselves (binaries, libs, configs).
+PV_MANIFEST_EXCLUDES ??= "/var/lib/rpm /var/lib/dnf /var/lib/opkg /usr/lib/opkg /var/cache/ldconfig /var/cache/dnf /var/cache/yum"
+
+python pv_manifest_audit_run() {
+    import os, stat, difflib
+
+    rootfs = d.getVar('IMAGE_ROOTFS')
+    machine = d.getVar('MACHINE')
+    image_name = d.getVar('IMAGE_NAME')
+    deploy_dir = d.getVar('IMGDEPLOYDIR') or d.getVar('DEPLOY_DIR_IMAGE')
+    workdir = d.getVar('WORKDIR') or ''
+    ref_name = d.getVar('PV_MANIFEST_REFERENCE_NAME')
+    features = (d.getVar('PANTAVISOR_FEATURES') or '').split()
+    strict = 'pv-manifest-strict' in features
+
+    bb.utils.mkdirhier(deploy_dir)
+    manifest_path = os.path.join(deploy_dir, image_name + '.manifest.txt')
+    patch_path = os.path.join(deploy_dir, image_name + '.manifest.patch')
+    ref_path = os.path.join(workdir, ref_name)
+
+    # Render paths relative to TOPDIR so the strings are usable both inside
+    # the kas/bitbake container and on the host (TOPDIR maps to build/).
+    topdir = d.getVar('TOPDIR') or ''
+    def _rel(p):
+        try:
+            return os.path.relpath(p, topdir)
+        except ValueError:
+            return p
+    manifest_rel = _rel(manifest_path)
+    patch_rel = _rel(patch_path)
+
+    rootfs = os.path.realpath(rootfs)
+
+    excludes = [p for p in (d.getVar('PV_MANIFEST_EXCLUDES') or '').split() if p]
+    def _excluded(rel):
+        for ex in excludes:
+            if rel == ex or rel.startswith(ex + '/'):
+                return True
+        return False
+
+    entries = []
+    for dirpath, dirnames, filenames in os.walk(rootfs, followlinks=False):
+        # Prune excluded subtrees so we don't descend into them at all.
+        pruned = []
+        for dn in list(dirnames):
+            sub_rel = '/' + os.path.relpath(os.path.join(dirpath, dn), rootfs)
+            if _excluded(sub_rel):
+                pruned.append(dn)
+        for dn in pruned:
+            dirnames.remove(dn)
+        dirnames.sort()
+        names = sorted(set(dirnames) | set(filenames))
+        for name in names:
+            full = os.path.join(dirpath, name)
+            try:
+                st = os.lstat(full)
+            except OSError:
+                continue
+            rel = '/' + os.path.relpath(full, rootfs)
+            if rel == '/.':
+                continue
+            if _excluded(rel):
+                continue
+            mode = stat.S_IMODE(st.st_mode)
+            if stat.S_ISLNK(st.st_mode):
+                ftype = 'l'
+                try:
+                    target = os.readlink(full)
+                except OSError:
+                    target = ''
+                tail = ' -> ' + target
+            elif stat.S_ISDIR(st.st_mode):
+                ftype, tail = 'd', ''
+            elif stat.S_ISREG(st.st_mode):
+                ftype, tail = 'f', ''
+            elif stat.S_ISCHR(st.st_mode):
+                ftype = 'c'
+                tail = ' %d,%d' % (os.major(st.st_rdev), os.minor(st.st_rdev))
+            elif stat.S_ISBLK(st.st_mode):
+                ftype = 'b'
+                tail = ' %d,%d' % (os.major(st.st_rdev), os.minor(st.st_rdev))
+            elif stat.S_ISFIFO(st.st_mode):
+                ftype, tail = 'p', ''
+            elif stat.S_ISSOCK(st.st_mode):
+                ftype, tail = 's', ''
+            else:
+                ftype, tail = '?', ''
+            entries.append((rel, '%s %04o %d %d %s%s' % (
+                ftype, mode, st.st_uid, st.st_gid, rel, tail)))
+
+    entries.sort(key=lambda e: e[0])
+    body = '\n'.join(line for _, line in entries) + '\n'
+
+    with open(manifest_path, 'w') as f:
+        f.write('# pv-manifest-audit v1\n')
+        f.write('# format: type mode uid gid path[ -> symlink-target | major,minor]\n')
+        f.write('# machine: %s\n' % machine)
+        f.write('# distro:  %s (%s)\n' % (d.getVar('DISTRO') or '', d.getVar('DISTRO_CODENAME') or ''))
+        f.write('# prefix:  %s\n' % (d.getVar('PV_MANIFEST_PREFIX') or ''))
+        if excludes:
+            f.write('# exclude: %s\n' % ' '.join(excludes))
+        f.write(body)
+
+    bb.note('pv-manifest-audit: wrote %s (%d entries)' % (manifest_rel, len(entries)))
+
+    have_ref = os.path.exists(ref_path)
+    ref_text = ''
+    if have_ref:
+        with open(ref_path, 'r') as f:
+            ref_text = f.read()
+    with open(manifest_path, 'r') as f:
+        cur_text = f.read()
+
+    if have_ref and ref_text == cur_text:
+        bb.note('pv-manifest-audit: rootfs matches reference (%s)' % ref_name)
+        if os.path.exists(patch_path):
+            try: os.unlink(patch_path)
+            except OSError: pass
+        return
+
+    # Build a patch whose headers carry the bare basename so it applies
+    # from inside the layer's files/ directory:
+    #     cd <layer>/files && patch < .../${IMAGE_NAME}.manifest.patch
+    patch = ''.join(difflib.unified_diff(
+        ref_text.splitlines(keepends=True),
+        cur_text.splitlines(keepends=True),
+        fromfile=ref_name,
+        tofile=ref_name))
+    with open(patch_path, 'w') as f:
+        f.write(patch)
+
+    if have_ref:
+        headline = ("pv-manifest-audit: rootfs manifest for MACHINE '%s' "
+                    "differs from reference '%s'." % (machine, ref_name))
+    else:
+        headline = ("pv-manifest-audit: no reference manifest '%s' shipped "
+                    "via SRC_URI for MACHINE '%s' — emitting full-add patch."
+                    % (ref_name, machine))
+
+    banner = ['',
+              '=== pv-manifest-audit PATCH (%s, %s) ===' % (
+                  machine, 'STRICT' if strict else 'audit'),
+              '# patch file: %s (relative to TOPDIR)' % patch_rel,
+              '# manifest:   %s (relative to TOPDIR)' % manifest_rel,
+              '# apply with: cd <layer>/files && patch < $TOPDIR/%s' % patch_rel,
+              '']
+    bb.plain('\n'.join(banner) + patch + '=== end pv-manifest-audit PATCH ===\n')
+
+    advice = (" Patch: " + patch_rel +
+              ". To adopt: ship the regenerated reference via "
+              "SRC_URI += \"file://%s\" (or apply the patch under the "
+              "layer's files/ directory)." % ref_name)
+
+    if strict:
+        bb.fatal(headline + advice +
+                 " (PANTAVISOR_FEATURES contains 'pv-manifest-strict')")
+    else:
+        bb.warn(headline + advice +
+                " (advisory — set 'pv-manifest-strict' in "
+                "PANTAVISOR_FEATURES to gate the build)")
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "pv_manifest_audit_run;"
+
+# Make the audit re-run when feature flags or naming inputs change.
+pv_manifest_audit_run[vardeps] += "PANTAVISOR_FEATURES PV_MANIFEST_PREFIX PV_MANIFEST_REFERENCE_NAME PV_MANIFEST_EXCLUDES"

--- a/classes/pv-manifest-audit.bbclass
+++ b/classes/pv-manifest-audit.bbclass
@@ -38,10 +38,10 @@
 #
 # Output:
 #   - Manifest is always written to
-#       ${IMGDEPLOYDIR}/${IMAGE_NAME}.manifest.txt
+#       ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.manifest.txt
 #   - On any deviation (missing reference or mismatch) a unified-diff patch
 #     is written next to the manifest as
-#       ${IMGDEPLOYDIR}/${IMAGE_NAME}.manifest.patch
+#       ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.manifest.patch
 #     and printed in full to the bitbake log via bb.plain (CI-visible).
 #     The patch headers use the reference's bare basename, so a maintainer
 #     can apply it with:
@@ -63,7 +63,13 @@ python pv_manifest_audit_run() {
     rootfs = d.getVar('IMAGE_ROOTFS')
     machine = d.getVar('MACHINE')
     image_name = d.getVar('IMAGE_NAME')
-    deploy_dir = d.getVar('IMGDEPLOYDIR') or d.getVar('DEPLOY_DIR_IMAGE')
+    # Write directly to DEPLOY_DIR_IMAGE rather than IMGDEPLOYDIR so the
+    # manifest.txt + manifest.patch survive a bb.fatal in strict mode.
+    # IMGDEPLOYDIR is per-recipe staging that bitbake only rsyncs to
+    # DEPLOY_DIR_IMAGE on successful task completion — a strict-mode
+    # abort during ROOTFS_POSTPROCESS_COMMAND would otherwise leave the
+    # diagnostic artifact stranded in WORKDIR where CI never finds it.
+    deploy_dir = d.getVar('DEPLOY_DIR_IMAGE')
     workdir = d.getVar('WORKDIR') or ''
     ref_name = d.getVar('PV_MANIFEST_REFERENCE_NAME')
     features = (d.getVar('PANTAVISOR_FEATURES') or '').split()

--- a/conf/distro/panta-appengine.inc
+++ b/conf/distro/panta-appengine.inc
@@ -2,6 +2,7 @@
 # you dont need to use this distro, but remember to set these
 DISTRO_FEATURES += "pantavisor-appengine"
 PANTAVISOR_FEATURES:append = " appengine"
+PANTAVISOR_FEATURES:append = " pv-manifest-audit"
 PANTAVISOR_FEATURES:remove = "autogrow"
 
 PREFERRED_VERSION_mbedtls = "2.28.%"

--- a/conf/distro/panta-distro.inc
+++ b/conf/distro/panta-distro.inc
@@ -4,3 +4,8 @@ IMAGE_CLASSES:append = " image-pvrexport"
 
 TCLIBC ?= "musl"
 
+# Enable advisory rootfs manifest audit by default for the panta distro.
+# Set 'pv-manifest-strict' (instead of, or in addition to, 'pv-manifest-audit')
+# to gate the build on manifest drift.
+PANTAVISOR_FEATURES:append = " pv-manifest-audit"
+

--- a/docs/how-to-build/manifest-audit.md
+++ b/docs/how-to-build/manifest-audit.md
@@ -1,0 +1,198 @@
+# Pantavisor Manifest Audit
+
+`pv-manifest-audit.bbclass` produces a deterministic listing of every entry in
+an image rootfs (path, type, mode, ownership, symlink targets, device nodes)
+and compares it against a reference checked into a layer. Drift is surfaced as
+a unified-diff patch — printed to the bitbake log, written to the deploy
+directory, and (in strict mode) used to fail the build.
+
+This catches a class of regressions that ordinary CI does not:
+
+- a package starts shipping a setuid binary it never had before,
+- a recipe accidentally drops a previously-installed file,
+- ownership flips from `root:root` to `messagebus:messagebus`,
+- a new symlink is introduced in `/etc`,
+- a postinst leaves stray files in `/var`.
+
+None of these break the build. All of them change device behaviour in the
+field.
+
+## Two modes
+
+The class is inherited only when one of the feature flags is set in
+`PANTAVISOR_FEATURES`:
+
+| Flag                  | Behaviour on drift              | Use in                           |
+|-----------------------|---------------------------------|----------------------------------|
+| `pv-manifest-audit`   | Patch + WARNING (build proceeds)| Dev distros, default in `panta`  |
+| `pv-manifest-strict`  | Patch + ERROR  (build fails)    | Release / CI distros             |
+
+`pv-manifest-strict` implies `pv-manifest-audit`. Setting both is fine — strict
+wins.
+
+The default `panta` and `panta-appengine` distros enable advisory mode out of
+the box; flip to strict in a release config:
+
+```bitbake
+PANTAVISOR_FEATURES:append = " pv-manifest-strict"
+```
+
+## Reference filename
+
+References live in a layer's `files/` directory and are pulled into
+`${WORKDIR}` via `SRC_URI`:
+
+```
+${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt
+```
+
+`PV_MANIFEST_PREFIX` is set per recipe (`pv-initramfs` for the initramfs image,
+`pv-appengine` for the appengine image). Concrete examples:
+
+```
+pv-initramfs_panta-raspberrypi-scarthgap.manifest.reference.txt
+pv-initramfs_panta-raspberrypi5-scarthgap.manifest.reference.txt
+pv-appengine_panta-appengine-raspberrypi-scarthgap.manifest.reference.txt
+```
+
+The underscore separates the recipe prefix from the distro/machine/codename
+triple — both halves can themselves contain dashes, so the underscore makes
+the boundary unambiguous.
+
+## How to add a reference for a new MACHINE / DISTRO
+
+The reference is a normal `SRC_URI` `file://` entry. Add it from this layer
+(for upstream-supported machines) or from a downstream `.bbappend`:
+
+```bitbake
+# pantavisor-initramfs.bbappend in your layer
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://pv-initramfs_panta-<MACHINE>-<CODENAME>.manifest.reference.txt"
+```
+
+Drop the file under `<your-layer>/files/`. Normal Yocto override semantics
+apply: `FILESEXTRAPATHS:prepend` in a bbappend wins over the upstream layer's
+copy.
+
+Bootstrapping a brand-new MACHINE:
+
+1. Build with advisory mode (`pv-manifest-audit` set, no `pv-manifest-strict`).
+2. The build prints a full-add patch to the bitbake log and writes
+   `${IMGDEPLOYDIR}/${IMAGE_NAME}.manifest.patch` (also copied to the final
+   `deploy/images/<MACHINE>/` directory).
+3. Apply the patch under your layer's `files/` directory:
+
+   ```sh
+   cd <layer>/files
+   patch < <build>/tmp-scarthgap/.../pantavisor-initramfs-<MACHINE>-<TS>.manifest.patch
+   ```
+
+4. Add the matching `SRC_URI += "file://..."` line and rebuild. The next
+   `do_rootfs` should match cleanly.
+
+## Output artifacts
+
+Two files land in the image deploy dir for every build:
+
+| File                              | When written                          |
+|-----------------------------------|---------------------------------------|
+| `${IMAGE_NAME}.manifest.txt`      | Always                                |
+| `${IMAGE_NAME}.manifest.patch`    | Only when there is a drift to record  |
+
+The patch is also dumped in full into the bitbake log via `bb.plain` so it
+shows in CI output without any extra plumbing. Look for the banner:
+
+```
+=== pv-manifest-audit PATCH (<MACHINE>, audit|STRICT) ===
+# patch file: tmp-<codename>/.../...manifest.patch (relative to TOPDIR)
+# manifest:   tmp-<codename>/.../...manifest.txt (relative to TOPDIR)
+# apply with: cd <layer>/files && patch < $TOPDIR/<patch>
+--- <reference name>
++++ <reference name>
+...
+=== end pv-manifest-audit PATCH ===
+```
+
+## Manifest format
+
+```
+# pv-manifest-audit v1
+# format: type mode uid gid path[ -> symlink-target | major,minor]
+# machine: <MACHINE>
+# distro:  <DISTRO> (<DISTRO_CODENAME>)
+# prefix:  <PV_MANIFEST_PREFIX>
+# exclude: <space-separated paths excluded from the walk>
+<entries, sorted by path>
+```
+
+Each entry is `<type> <mode> <uid> <gid> <path>[<tail>]` where `tail` is
+` -> <target>` for a symlink, ` <major>,<minor>` for a device node, or empty.
+Types: `f` regular, `d` directory, `l` symlink, `c` char device, `b` block
+device, `p` fifo, `s` socket.
+
+File **size is intentionally omitted**: it would diff on every dependency
+version bump (busybox, mbedtls, kernel modules) without reflecting a
+meaningful behavioural change. Adding or removing a file is still detected via
+its presence or absence.
+
+## Excludes
+
+`PV_MANIFEST_EXCLUDES` is a space-separated list of rootfs-relative path
+prefixes to skip. Defaults cover package-manager state files whose contents
+flip on every rebuild without indicating real change:
+
+```
+/var/lib/rpm
+/var/lib/dnf
+/var/lib/opkg
+/usr/lib/opkg
+/var/cache/ldconfig
+/var/cache/dnf
+/var/cache/yum
+```
+
+Package add/remove is still detectable via the actual installed files
+(binaries, libs, configs in `/usr`, `/etc`, etc.); only the package-manager
+bookkeeping is filtered.
+
+A recipe or downstream layer can extend the list:
+
+```bitbake
+PV_MANIFEST_EXCLUDES:append = " /etc/ssh/ssh_host_keys /etc/machine-id"
+```
+
+The exclude list is part of the task's input hash (vardeps), so changes
+trigger a `do_rootfs` rerun.
+
+## Class variables
+
+| Variable                        | Default                                                                   | Purpose                                                                  |
+|---------------------------------|---------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `PV_MANIFEST_PREFIX`            | `${PN}`                                                                   | Recipe-stable label embedded in the reference filename                   |
+| `PV_MANIFEST_REFERENCE_NAME`    | `${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt` | Basename of the reference fetched into `${WORKDIR}`         |
+| `PV_MANIFEST_EXCLUDES`          | (see above)                                                               | Rootfs-relative path prefixes to omit from the manifest                  |
+
+## Inheriting the class
+
+Recipes inherit the class conditionally so it is a no-op when neither feature
+flag is set:
+
+```bitbake
+inherit ${@bb.utils.contains_any('PANTAVISOR_FEATURES', \
+    'pv-manifest-audit pv-manifest-strict', 'pv-manifest-audit', '', d)}
+PV_MANIFEST_PREFIX = "pv-initramfs"   # or pv-appengine, etc.
+```
+
+Currently inherited by:
+
+- `recipes-pv/images/pantavisor-initramfs.bb`
+- `dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine.inc`
+
+## Implementation
+
+`classes/pv-manifest-audit.bbclass` registers a `ROOTFS_POSTPROCESS_COMMAND`
+(`pv_manifest_audit_run`). It runs under pseudo, so the uid/gid recorded in
+the manifest are the same ones that end up in the cpio / tarball. The task is
+re-invalidated when `PANTAVISOR_FEATURES`, `PV_MANIFEST_PREFIX`,
+`PV_MANIFEST_REFERENCE_NAME`, or `PV_MANIFEST_EXCLUDES` change (declared via
+`vardeps`).

--- a/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine-tester.bb
+++ b/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine-tester.bb
@@ -3,6 +3,11 @@ LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecd
 
 include pantavisor-appengine.inc
 
+# Tester adds significantly more packages on top of base appengine, so
+# it gets its own audit reference under a distinct prefix.
+PV_MANIFEST_PREFIX = "pv-appengine-tester"
+SRC_URI += " file://pv-appengine-tester_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt"
+
 DOCKER_IMAGE_NAME = "${PN}"
 DOCKER_IMAGE_TAG = "1.0"
 DOCKER_IMAGE_EXTRA_TAGS = "latest"

--- a/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine.inc
+++ b/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine.inc
@@ -2,6 +2,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit pantavisor-docker
+inherit ${@bb.utils.contains_any('PANTAVISOR_FEATURES', 'pv-manifest-audit pv-manifest-strict', 'pv-manifest-audit', '', d)}
+
+PV_MANIFEST_PREFIX = "pv-appengine"
 
 DOCKER_IMAGE_NAME = "pantavisor-appengine"
 DOCKER_IMAGE_TAG = "1.0"

--- a/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine.inc
+++ b/dynamic-layers/virtualization-layer/recipes-pv/images/pantavisor-appengine.inc
@@ -6,6 +6,18 @@ inherit ${@bb.utils.contains_any('PANTAVISOR_FEATURES', 'pv-manifest-audit pv-ma
 
 PV_MANIFEST_PREFIX = "pv-appengine"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/pv-manifests:"
+
+# Reference manifests for the upstream-supported MACHINE. The audit
+# class only loads the one whose name matches the current
+# PREFIX/MACHINE/DISTRO/CODENAME; the others sit unused in WORKDIR.
+# Recipes that include this inc and produce a different rootfs (e.g.
+# the tester variant) override PV_MANIFEST_PREFIX and append their own
+# reference to SRC_URI.
+SRC_URI += " \
+    file://pv-appengine_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt \
+"
+
 DOCKER_IMAGE_NAME = "pantavisor-appengine"
 DOCKER_IMAGE_TAG = "1.0"
 

--- a/dynamic-layers/virtualization-layer/recipes-pv/images/pv-manifests/pv-appengine-tester_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt
+++ b/dynamic-layers/virtualization-layer/recipes-pv/images/pv-manifests/pv-appengine-tester_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt
@@ -1,0 +1,1927 @@
+# pv-manifest-audit v1
+# format: type mode uid gid path[ -> symlink-target | major,minor]
+# machine: docker-x86_64
+# distro:  panta-appengine (scarthgap)
+# prefix:  pv-appengine-tester
+# exclude: /var/lib/rpm /var/lib/dnf /var/lib/opkg /usr/lib/opkg /var/cache/ldconfig /var/cache/dnf /var/cache/yum
+d 0755 0 0 /bin
+l 0777 0 0 /bin/ash -> /bin/busybox
+l 0777 0 0 /bin/base64 -> /usr/bin/base64.coreutils
+l 0777 0 0 /bin/bash -> /bin/bash.bash
+f 0755 0 0 /bin/bash.bash
+f 4755 0 0 /bin/busybox
+l 0777 0 0 /bin/busybox.nosuid -> busybox
+l 0777 0 0 /bin/cat -> /bin/cat.coreutils
+f 0755 0 0 /bin/cat.coreutils
+l 0777 0 0 /bin/chattr -> /bin/busybox
+l 0777 0 0 /bin/chgrp -> /bin/chgrp.coreutils
+f 0755 0 0 /bin/chgrp.coreutils
+l 0777 0 0 /bin/chmod -> /bin/chmod.coreutils
+f 0755 0 0 /bin/chmod.coreutils
+l 0777 0 0 /bin/chown -> /bin/chown.coreutils
+f 0755 0 0 /bin/chown.coreutils
+l 0777 0 0 /bin/cp -> /bin/cp.coreutils
+f 0755 0 0 /bin/cp.coreutils
+l 0777 0 0 /bin/cpio -> /bin/busybox
+l 0777 0 0 /bin/date -> /bin/date.coreutils
+f 0755 0 0 /bin/date.coreutils
+l 0777 0 0 /bin/dd -> /bin/dd.coreutils
+f 0755 0 0 /bin/dd.coreutils
+l 0777 0 0 /bin/df -> /usr/bin/df.coreutils
+l 0777 0 0 /bin/dmesg -> /bin/dmesg.util-linux
+f 0755 0 0 /bin/dmesg.util-linux
+l 0777 0 0 /bin/dnsdomainname -> /bin/busybox
+l 0777 0 0 /bin/dumpkmap -> /bin/busybox
+l 0777 0 0 /bin/echo -> /bin/echo.coreutils
+f 0755 0 0 /bin/echo.coreutils
+l 0777 0 0 /bin/egrep -> /bin/busybox
+l 0777 0 0 /bin/false -> /bin/false.coreutils
+f 0755 0 0 /bin/false.coreutils
+l 0777 0 0 /bin/fgrep -> /bin/busybox
+l 0777 0 0 /bin/getopt -> /bin/getopt.util-linux
+f 0755 0 0 /bin/getopt.util-linux
+l 0777 0 0 /bin/grep -> /bin/busybox
+l 0777 0 0 /bin/gunzip -> /bin/busybox
+l 0777 0 0 /bin/gzip -> /bin/busybox
+l 0777 0 0 /bin/hostname -> /bin/hostname.coreutils
+f 0755 0 0 /bin/hostname.coreutils
+l 0777 0 0 /bin/kill -> /bin/kill.procps
+f 0755 0 0 /bin/kill.coreutils
+f 0755 0 0 /bin/kill.procps
+f 0755 0 0 /bin/kill.util-linux
+f 0755 0 0 /bin/kmod
+l 0777 0 0 /bin/ln -> /bin/ln.coreutils
+f 0755 0 0 /bin/ln.coreutils
+l 0777 0 0 /bin/login -> /bin/login.shadow
+f 0755 0 0 /bin/login.shadow
+l 0777 0 0 /bin/ls -> /bin/ls.coreutils
+f 0755 0 0 /bin/ls.coreutils
+l 0777 0 0 /bin/lsmod -> /bin/lsmod.kmod
+l 0777 0 0 /bin/lsmod.kmod -> kmod
+l 0777 0 0 /bin/mkdir -> /bin/mkdir.coreutils
+f 0755 0 0 /bin/mkdir.coreutils
+l 0777 0 0 /bin/mknod -> /bin/mknod.coreutils
+f 0755 0 0 /bin/mknod.coreutils
+l 0777 0 0 /bin/mktemp -> /usr/bin/mktemp.coreutils
+l 0777 0 0 /bin/more -> /bin/more.util-linux
+f 0755 0 0 /bin/more.util-linux
+l 0777 0 0 /bin/mount -> /bin/mount.util-linux
+f 4755 0 0 /bin/mount.util-linux
+l 0777 0 0 /bin/mountpoint -> /bin/mountpoint.util-linux
+f 0755 0 0 /bin/mountpoint.sysvinit
+f 0755 0 0 /bin/mountpoint.util-linux
+l 0777 0 0 /bin/mv -> /bin/mv.coreutils
+f 0755 0 0 /bin/mv.coreutils
+l 0777 0 0 /bin/netstat -> /bin/busybox
+l 0777 0 0 /bin/nice -> /usr/bin/nice.coreutils
+l 0777 0 0 /bin/pidof -> /bin/pidof.sysvinit
+f 0755 0 0 /bin/pidof.procps
+l 0777 0 0 /bin/pidof.sysvinit -> /sbin/killall5
+l 0777 0 0 /bin/ping -> /bin/busybox
+l 0777 0 0 /bin/ping6 -> /bin/busybox
+l 0777 0 0 /bin/printenv -> /usr/bin/printenv.coreutils
+l 0777 0 0 /bin/ps -> /bin/ps.procps
+f 0755 0 0 /bin/ps.procps
+l 0777 0 0 /bin/pwd -> /bin/pwd.coreutils
+f 0755 0 0 /bin/pwd.coreutils
+l 0777 0 0 /bin/rm -> /bin/rm.coreutils
+f 0755 0 0 /bin/rm.coreutils
+l 0777 0 0 /bin/rmdir -> /bin/rmdir.coreutils
+f 0755 0 0 /bin/rmdir.coreutils
+l 0777 0 0 /bin/run-parts -> /bin/busybox
+l 0777 0 0 /bin/sed -> /bin/busybox
+l 0777 0 0 /bin/sh -> /bin/bash.bash
+l 0777 0 0 /bin/sleep -> /bin/sleep.coreutils
+f 0755 0 0 /bin/sleep.coreutils
+f 0755 0 0 /bin/start_getty
+l 0777 0 0 /bin/stat -> /bin/stat.coreutils
+f 0755 0 0 /bin/stat.coreutils
+l 0777 0 0 /bin/stty -> /bin/stty.coreutils
+f 0755 0 0 /bin/stty.coreutils
+l 0777 0 0 /bin/su -> /bin/su.shadow
+f 4755 0 0 /bin/su.shadow
+l 0777 0 0 /bin/sync -> /bin/sync.coreutils
+f 0755 0 0 /bin/sync.coreutils
+l 0777 0 0 /bin/tar -> /bin/busybox
+l 0777 0 0 /bin/touch -> /bin/touch.coreutils
+f 0755 0 0 /bin/touch.coreutils
+l 0777 0 0 /bin/true -> /bin/true.coreutils
+f 0755 0 0 /bin/true.coreutils
+l 0777 0 0 /bin/umount -> /bin/umount.util-linux
+f 4755 0 0 /bin/umount.util-linux
+l 0777 0 0 /bin/uname -> /bin/uname.coreutils
+f 0755 0 0 /bin/uname.coreutils
+l 0777 0 0 /bin/usleep -> /bin/busybox
+l 0777 0 0 /bin/vi -> /bin/busybox
+l 0777 0 0 /bin/watch -> /bin/watch.procps
+f 0755 0 0 /bin/watch.procps
+l 0777 0 0 /bin/zcat -> /bin/busybox
+d 0755 0 0 /boot
+d 0755 0 0 /dev
+d 0755 0 0 /etc
+d 0755 0 0 /etc/avahi
+f 0644 0 0 /etc/avahi/avahi-daemon.conf
+f 0644 0 0 /etc/avahi/hosts
+d 0755 0 0 /etc/avahi/services
+f 0644 0 0 /etc/bindresvport.blacklist
+f 0644 0 0 /etc/busybox.links
+d 0755 0 0 /etc/ca-certificates
+f 0644 0 0 /etc/ca-certificates.conf
+d 0755 0 0 /etc/ca-certificates/update.d
+d 0755 0 0 /etc/dbus-1
+f 0644 0 0 /etc/dbus-1/session.conf
+f 0644 0 0 /etc/dbus-1/system.conf
+d 0755 0 0 /etc/dbus-1/system.d
+f 0644 0 0 /etc/dbus-1/system.d/avahi-dbus.conf
+d 0755 0 0 /etc/default
+f 0755 0 0 /etc/default/devpts
+f 0644 0 0 /etc/default/mountall
+f 0644 0 0 /etc/default/rcS
+f 0644 0 0 /etc/default/useradd
+d 0755 0 0 /etc/default/volatiles
+f 0644 0 0 /etc/default/volatiles/00_core
+f 0644 0 0 /etc/default/volatiles/01_bootlogd
+f 0644 0 0 /etc/default/volatiles/99_dbus
+d 0755 0 0 /etc/depmod.d
+d 0755 0 0 /etc/dnf
+f 0644 0 0 /etc/dnf/dnf.conf
+d 0755 0 0 /etc/dnf/modules.d
+d 0755 0 0 /etc/dnf/vars
+f 0644 0 0 /etc/dnf/vars/arch
+f 0644 0 0 /etc/dnf/vars/releasever
+f 0644 0 0 /etc/dnsmasq.conf
+d 0755 0 0 /etc/dnsmasq.d
+f 0644 0 0 /etc/ethertypes
+f 0644 0 0 /etc/fstab
+f 0644 0 0 /etc/group
+f 0644 0 0 /etc/group-
+f 0400 0 0 /etc/gshadow
+f 0400 0 0 /etc/gshadow-
+f 0644 0 0 /etc/host.conf
+f 0644 0 0 /etc/hostapd.conf
+f 0644 0 0 /etc/hostname
+f 0644 0 0 /etc/hosts
+d 0755 0 0 /etc/init.d
+f 0755 0 0 /etc/init.d/avahi-daemon
+f 0755 0 0 /etc/init.d/banner.sh
+f 0755 0 0 /etc/init.d/bootlogd
+f 0755 0 0 /etc/init.d/bootmisc.sh
+f 0755 0 0 /etc/init.d/checkroot.sh
+f 0755 0 0 /etc/init.d/dbus-1
+f 0755 0 0 /etc/init.d/devpts.sh
+f 0755 0 0 /etc/init.d/dmesg.sh
+f 0755 0 0 /etc/init.d/dnsmasq
+f 0644 0 0 /etc/init.d/functions
+f 0755 0 0 /etc/init.d/halt
+f 0755 0 0 /etc/init.d/hostapd
+f 0755 0 0 /etc/init.d/hostname.sh
+f 0755 0 0 /etc/init.d/hwclock.sh
+f 0755 0 0 /etc/init.d/modutils.sh
+f 0755 0 0 /etc/init.d/mountall.sh
+f 0755 0 0 /etc/init.d/mountnfs.sh
+f 0755 0 0 /etc/init.d/networking
+f 0755 0 0 /etc/init.d/populate-volatile.sh
+f 0755 0 0 /etc/init.d/rc
+f 0755 0 0 /etc/init.d/rcS
+f 0755 0 0 /etc/init.d/read-only-rootfs-hook.sh
+f 0755 0 0 /etc/init.d/reboot
+f 0755 0 0 /etc/init.d/rmnologin.sh
+f 0755 0 0 /etc/init.d/rpcbind
+f 0755 0 0 /etc/init.d/save-rtc.sh
+f 0755 0 0 /etc/init.d/sendsigs
+f 0755 0 0 /etc/init.d/single
+l 0777 0 0 /etc/init.d/stop-bootlogd -> bootlogd
+f 0755 0 0 /etc/init.d/sysfs.sh
+f 0755 0 0 /etc/init.d/syslog
+f 0755 0 0 /etc/init.d/udev
+f 0755 0 0 /etc/init.d/umountfs
+f 0755 0 0 /etc/init.d/umountnfs.sh
+f 0755 0 0 /etc/init.d/urandom
+f 0644 0 0 /etc/inittab
+d 0755 0 0 /etc/inittab.d
+f 0644 0 0 /etc/inputrc
+f 0644 0 0 /etc/issue
+f 0644 0 0 /etc/issue.net
+f 0644 0 0 /etc/ld.so.conf
+d 0755 0 0 /etc/libnl
+f 0644 0 0 /etc/libnl/classid
+f 0644 0 0 /etc/libnl/pktloc
+f 0644 0 0 /etc/limits
+f 0644 0 0 /etc/login.access
+f 0644 0 0 /etc/login.defs
+f 0644 0 0 /etc/logrotate-dmesg.conf
+d 0755 0 0 /etc/lxc
+f 0644 0 0 /etc/lxc/default.conf
+f 0644 0 0 /etc/mke2fs.conf
+d 0755 0 0 /etc/modprobe.d
+f 0644 0 0 /etc/motd
+l 0777 0 0 /etc/mtab -> /proc/mounts
+f 0644 0 0 /etc/netconfig
+d 0755 0 0 /etc/network
+d 0755 0 0 /etc/network/if-down.d
+d 0755 0 0 /etc/network/if-post-down.d
+d 0755 0 0 /etc/network/if-pre-up.d
+f 0755 0 0 /etc/network/if-pre-up.d/nfsroot
+d 0755 0 0 /etc/network/if-up.d
+f 0644 0 0 /etc/network/interfaces
+f 0644 0 0 /etc/nsswitch.conf
+d 0755 0 0 /etc/pantavisor
+f 0644 0 0 /etc/pantavisor-appengine.config
+d 0755 0 0 /etc/pantavisor/defaults
+f 0644 0 0 /etc/pantavisor/defaults/groups.json
+d 0755 0 0 /etc/pantavisor/policies
+f 0644 0 0 /etc/pantavisor/policies/prod.config
+f 0644 0 0 /etc/pantavisor/policies/test.config
+d 0755 0 0 /etc/pantavisor/pvs
+d 0755 0 0 /etc/pantavisor/pvs/trust
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-certificates.crt
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-oem-certificates.crt
+d 0755 0 0 /etc/pantavisor/ssh
+f 0644 0 0 /etc/pantavisor/ssh/README.ssh
+f 0644 0 0 /etc/passwd
+f 0644 0 0 /etc/passwd-
+f 0644 0 0 /etc/profile
+f 0644 0 0 /etc/protocols
+d 0755 0 0 /etc/rc0.d
+l 0777 0 0 /etc/rc0.d/K19avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc0.d/K20dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc0.d/K20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc0.d/K20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc0.d/K20hwclock.sh -> ../init.d/hwclock.sh
+l 0777 0 0 /etc/rc0.d/K20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc0.d/K31umountnfs.sh -> ../init.d/umountnfs.sh
+l 0777 0 0 /etc/rc0.d/K60rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc0.d/K80networking -> ../init.d/networking
+l 0777 0 0 /etc/rc0.d/S20sendsigs -> ../init.d/sendsigs
+l 0777 0 0 /etc/rc0.d/S25save-rtc.sh -> ../init.d/save-rtc.sh
+l 0777 0 0 /etc/rc0.d/S38urandom -> ../init.d/urandom
+l 0777 0 0 /etc/rc0.d/S40umountfs -> ../init.d/umountfs
+l 0777 0 0 /etc/rc0.d/S90halt -> ../init.d/halt
+d 0755 0 0 /etc/rc1.d
+l 0777 0 0 /etc/rc1.d/K19avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc1.d/K20dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc1.d/K20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc1.d/K20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc1.d/K20hwclock.sh -> ../init.d/hwclock.sh
+l 0777 0 0 /etc/rc1.d/K20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc1.d/K31umountnfs.sh -> ../init.d/umountnfs.sh
+l 0777 0 0 /etc/rc1.d/K60rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc1.d/K80networking -> ../init.d/networking
+d 0755 0 0 /etc/rc2.d
+l 0777 0 0 /etc/rc2.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc2.d/S02dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc2.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc2.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc2.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc2.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc2.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc2.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc2.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc2.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc3.d
+l 0777 0 0 /etc/rc3.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc3.d/S02dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc3.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc3.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc3.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc3.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc3.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc3.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc3.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc3.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc4.d
+l 0777 0 0 /etc/rc4.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc4.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc4.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc4.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc4.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc4.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc4.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc4.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc4.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc5.d
+l 0777 0 0 /etc/rc5.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc5.d/S02dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc5.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc5.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc5.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc5.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc5.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc5.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc5.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc5.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc6.d
+l 0777 0 0 /etc/rc6.d/K19avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc6.d/K20dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc6.d/K20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc6.d/K20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc6.d/K20hwclock.sh -> ../init.d/hwclock.sh
+l 0777 0 0 /etc/rc6.d/K20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc6.d/K31umountnfs.sh -> ../init.d/umountnfs.sh
+l 0777 0 0 /etc/rc6.d/K60rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc6.d/K80networking -> ../init.d/networking
+l 0777 0 0 /etc/rc6.d/S20sendsigs -> ../init.d/sendsigs
+l 0777 0 0 /etc/rc6.d/S25save-rtc.sh -> ../init.d/save-rtc.sh
+l 0777 0 0 /etc/rc6.d/S38urandom -> ../init.d/urandom
+l 0777 0 0 /etc/rc6.d/S40umountfs -> ../init.d/umountfs
+l 0777 0 0 /etc/rc6.d/S90reboot -> ../init.d/reboot
+d 0755 0 0 /etc/rcS.d
+l 0777 0 0 /etc/rcS.d/S02banner.sh -> ../init.d/banner.sh
+l 0777 0 0 /etc/rcS.d/S02sysfs.sh -> ../init.d/sysfs.sh
+l 0777 0 0 /etc/rcS.d/S03mountall.sh -> ../init.d/mountall.sh
+l 0777 0 0 /etc/rcS.d/S04udev -> ../init.d/udev
+l 0777 0 0 /etc/rcS.d/S05checkroot.sh -> ../init.d/checkroot.sh
+l 0777 0 0 /etc/rcS.d/S06devpts.sh -> ../init.d/devpts.sh
+l 0777 0 0 /etc/rcS.d/S06modutils.sh -> ../init.d/modutils.sh
+l 0777 0 0 /etc/rcS.d/S07bootlogd -> ../init.d/bootlogd
+l 0777 0 0 /etc/rcS.d/S29read-only-rootfs-hook.sh -> ../init.d/read-only-rootfs-hook.sh
+l 0777 0 0 /etc/rcS.d/S36bootmisc.sh -> ../init.d/bootmisc.sh
+l 0777 0 0 /etc/rcS.d/S37populate-volatile.sh -> ../init.d/populate-volatile.sh
+l 0777 0 0 /etc/rcS.d/S38dmesg.sh -> ../init.d/dmesg.sh
+l 0777 0 0 /etc/rcS.d/S38urandom -> ../init.d/urandom
+l 0777 0 0 /etc/rcS.d/S39hostname.sh -> ../init.d/hostname.sh
+l 0777 0 0 /etc/rcS.d/S40hwclock.sh -> ../init.d/hwclock.sh
+f 0644 0 0 /etc/resolv.conf
+f 0644 0 0 /etc/rpc
+f 0644 0 0 /etc/rpcbind.conf
+d 0755 0 0 /etc/rpm
+f 0644 0 0 /etc/rpm/macros
+f 0644 0 0 /etc/rpm/platform
+f 0644 0 0 /etc/rpmrc
+f 0400 0 0 /etc/securetty
+f 0644 0 0 /etc/services
+f 0400 0 0 /etc/shadow
+f 0400 0 0 /etc/shadow-
+f 0644 0 0 /etc/shells
+d 0755 0 0 /etc/skel
+f 0755 0 0 /etc/skel/.bashrc
+f 0755 0 0 /etc/skel/.profile
+d 0755 0 0 /etc/ssl
+d 0755 0 0 /etc/ssl/certs
+l 0777 0 0 /etc/ssl/certs/002c0b4f.0 -> GlobalSign_Root_R46.pem
+l 0777 0 0 /etc/ssl/certs/0179095f.0 -> BJCA_Global_Root_CA1.pem
+l 0777 0 0 /etc/ssl/certs/02265526.0 -> Entrust_Root_Certification_Authority_-_G2.pem
+l 0777 0 0 /etc/ssl/certs/062cdee6.0 -> GlobalSign_Root_CA_-_R3.pem
+l 0777 0 0 /etc/ssl/certs/064e0aa9.0 -> QuoVadis_Root_CA_2_G3.pem
+l 0777 0 0 /etc/ssl/certs/06dc52d5.0 -> SSL.com_EV_Root_Certification_Authority_RSA_R2.pem
+l 0777 0 0 /etc/ssl/certs/09789157.0 -> Starfield_Services_Root_Certificate_Authority_-_G2.pem
+l 0777 0 0 /etc/ssl/certs/0a775a30.0 -> GTS_Root_R3.pem
+l 0777 0 0 /etc/ssl/certs/0b1b94ef.0 -> CFCA_EV_ROOT.pem
+l 0777 0 0 /etc/ssl/certs/0b9bc432.0 -> ISRG_Root_X2.pem
+l 0777 0 0 /etc/ssl/certs/0bf05006.0 -> SSL.com_Root_Certification_Authority_ECC.pem
+l 0777 0 0 /etc/ssl/certs/0f5dc4f3.0 -> UCA_Extended_Validation_Root.pem
+l 0777 0 0 /etc/ssl/certs/0f6fa695.0 -> GDCA_TrustAUTH_R5_ROOT.pem
+l 0777 0 0 /etc/ssl/certs/1001acf7.0 -> GTS_Root_R1.pem
+l 0777 0 0 /etc/ssl/certs/106f3e4d.0 -> Entrust_Root_Certification_Authority_-_EC1.pem
+l 0777 0 0 /etc/ssl/certs/14bc7599.0 -> emSign_ECC_Root_CA_-_G3.pem
+l 0777 0 0 /etc/ssl/certs/1cef98f5.0 -> TrustAsia_Global_Root_CA_G4.pem
+l 0777 0 0 /etc/ssl/certs/1d3472b9.0 -> GlobalSign_ECC_Root_CA_-_R5.pem
+l 0777 0 0 /etc/ssl/certs/1e08bfd1.0 -> IdenTrust_Public_Sector_Root_CA_1.pem
+l 0777 0 0 /etc/ssl/certs/1e09d511.0 -> T-TeleSec_GlobalRoot_Class_2.pem
+l 0777 0 0 /etc/ssl/certs/228f89db.0 -> CommScope_Public_Trust_ECC_Root-01.pem
+l 0777 0 0 /etc/ssl/certs/244b5494.0 -> DigiCert_High_Assurance_EV_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/2923b3f9.0 -> emSign_Root_CA_-_G1.pem
+l 0777 0 0 /etc/ssl/certs/2ae6433e.0 -> CA_Disig_Root_R2.pem
+l 0777 0 0 /etc/ssl/certs/2b349938.0 -> AffirmTrust_Commercial.pem
+l 0777 0 0 /etc/ssl/certs/32888f65.0 -> Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem
+l 0777 0 0 /etc/ssl/certs/3513523f.0 -> DigiCert_Global_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/3bde41ac.0 -> Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem
+l 0777 0 0 /etc/ssl/certs/3e359ba6.0 -> BJCA_Global_Root_CA2.pem
+l 0777 0 0 /etc/ssl/certs/3fb36b73.0 -> NAVER_Global_Root_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/40193066.0 -> Certum_Trusted_Network_CA_2.pem
+l 0777 0 0 /etc/ssl/certs/4042bcee.0 -> ISRG_Root_X1.pem
+l 0777 0 0 /etc/ssl/certs/40547a79.0 -> COMODO_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/406c9bb1.0 -> emSign_Root_CA_-_C1.pem
+l 0777 0 0 /etc/ssl/certs/48bec511.0 -> Certum_Trusted_Network_CA.pem
+l 0777 0 0 /etc/ssl/certs/4b718d9b.0 -> emSign_ECC_Root_CA_-_C3.pem
+l 0777 0 0 /etc/ssl/certs/4bfab552.0 -> Starfield_Root_Certificate_Authority_-_G2.pem
+l 0777 0 0 /etc/ssl/certs/4f316efb.0 -> SwissSign_Gold_CA_-_G2.pem
+l 0777 0 0 /etc/ssl/certs/4fd49c6c.0 -> CommScope_Public_Trust_RSA_Root-02.pem
+l 0777 0 0 /etc/ssl/certs/5443e9e3.0 -> T-TeleSec_GlobalRoot_Class_3.pem
+l 0777 0 0 /etc/ssl/certs/54657681.0 -> Buypass_Class_2_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/5860aaa6.0 -> Security_Communication_ECC_RootCA1.pem
+l 0777 0 0 /etc/ssl/certs/5931b5bc.0 -> D-TRUST_EV_Root_CA_1_2020.pem
+l 0777 0 0 /etc/ssl/certs/5ad8a5d6.0 -> GlobalSign_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/5cd81ad7.0 -> TeliaSonera_Root_CA_v1.pem
+l 0777 0 0 /etc/ssl/certs/5f15c80c.0 -> TWCA_Global_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/5f618aec.0 -> certSIGN_Root_CA_G2.pem
+l 0777 0 0 /etc/ssl/certs/607986c7.0 -> DigiCert_Global_Root_G2.pem
+l 0777 0 0 /etc/ssl/certs/616816f6.0 -> SecureSign_Root_CA12.pem
+l 0777 0 0 /etc/ssl/certs/626dceaf.0 -> GTS_Root_R2.pem
+l 0777 0 0 /etc/ssl/certs/653b494a.0 -> Baltimore_CyberTrust_Root.pem
+l 0777 0 0 /etc/ssl/certs/68dd7389.0 -> Hongkong_Post_Root_CA_3.pem
+l 0777 0 0 /etc/ssl/certs/6a9bdba3.0 -> SecureSign_Root_CA15.pem
+l 0777 0 0 /etc/ssl/certs/6b99d060.0 -> Entrust_Root_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/6d41d539.0 -> Amazon_Root_CA_2.pem
+l 0777 0 0 /etc/ssl/certs/6fa5da56.0 -> SSL.com_Root_Certification_Authority_RSA.pem
+l 0777 0 0 /etc/ssl/certs/706f604c.0 -> XRamp_Global_CA_Root.pem
+l 0777 0 0 /etc/ssl/certs/749e9e03.0 -> QuoVadis_Root_CA_1_G3.pem
+l 0777 0 0 /etc/ssl/certs/75d1b2ed.0 -> DigiCert_Trusted_Root_G4.pem
+l 0777 0 0 /etc/ssl/certs/76faf6c0.0 -> QuoVadis_Root_CA_3.pem
+l 0777 0 0 /etc/ssl/certs/7719f463.0 -> Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.pem
+l 0777 0 0 /etc/ssl/certs/773e07ad.0 -> OISTE_WISeKey_Global_Root_GC_CA.pem
+l 0777 0 0 /etc/ssl/certs/7a3adc42.0 -> vTrus_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/7a780d93.0 -> Certainly_Root_R1.pem
+l 0777 0 0 /etc/ssl/certs/7f3d5d1d.0 -> DigiCert_Assured_ID_Root_G3.pem
+l 0777 0 0 /etc/ssl/certs/7fa05551.0 -> Telekom_Security_TLS_RSA_Root_2023.pem
+l 0777 0 0 /etc/ssl/certs/8160b96c.0 -> Microsec_e-Szigno_Root_CA_2009.pem
+l 0777 0 0 /etc/ssl/certs/81f2d2b1.0 -> CommScope_Public_Trust_ECC_Root-02.pem
+l 0777 0 0 /etc/ssl/certs/8312c4c1.0 -> CommScope_Public_Trust_RSA_Root-01.pem
+l 0777 0 0 /etc/ssl/certs/8508e720.0 -> Certainly_Root_E1.pem
+l 0777 0 0 /etc/ssl/certs/865fbdf9.0 -> SSL.com_TLS_ECC_Root_CA_2022.pem
+l 0777 0 0 /etc/ssl/certs/878d9bca.0 -> SecureSign_Root_CA14.pem
+l 0777 0 0 /etc/ssl/certs/8cb5ee0f.0 -> Amazon_Root_CA_3.pem
+l 0777 0 0 /etc/ssl/certs/8d86cdd1.0 -> certSIGN_ROOT_CA.pem
+l 0777 0 0 /etc/ssl/certs/8d89cda1.0 -> Microsoft_ECC_Root_Certificate_Authority_2017.pem
+l 0777 0 0 /etc/ssl/certs/8f103249.0 -> Telia_Root_CA_v2.pem
+l 0777 0 0 /etc/ssl/certs/9046744a.0 -> Sectigo_Public_Server_Authentication_Root_R46.pem
+l 0777 0 0 /etc/ssl/certs/90c5a3c8.0 -> HiPKI_Root_CA_-_G1.pem
+l 0777 0 0 /etc/ssl/certs/930ac5d2.0 -> Actalis_Authentication_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/93bc0acc.0 -> AffirmTrust_Networking.pem
+l 0777 0 0 /etc/ssl/certs/9482e63a.0 -> Certum_EC-384_CA.pem
+l 0777 0 0 /etc/ssl/certs/9846683b.0 -> DigiCert_TLS_ECC_P384_Root_G5.pem
+l 0777 0 0 /etc/ssl/certs/988a38cb.0 -> NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem
+l 0777 0 0 /etc/ssl/certs/9b46e03d.0 -> Atos_TrustedRoot_Root_CA_RSA_TLS_2021.pem
+l 0777 0 0 /etc/ssl/certs/9b5697b0.0 -> Trustwave_Global_ECC_P256_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/9bf03295.0 -> TrustAsia_Global_Root_CA_G3.pem
+l 0777 0 0 /etc/ssl/certs/9c8dfbd4.0 -> AffirmTrust_Premium_ECC.pem
+l 0777 0 0 /etc/ssl/certs/9d04f354.0 -> DigiCert_Assured_ID_Root_G2.pem
+l 0777 0 0 /etc/ssl/certs/9ef4a08a.0 -> D-TRUST_BR_Root_CA_1_2020.pem
+l 0777 0 0 /etc/ssl/certs/9f727ac7.0 -> HARICA_TLS_RSA_Root_CA_2021.pem
+l 0777 0 0 /etc/ssl/certs/ACCVRAIZ1.pem -> ../../..//usr/share/ca-certificates/mozilla/ACCVRAIZ1.crt
+l 0777 0 0 /etc/ssl/certs/AC_RAIZ_FNMT-RCM.pem -> ../../..//usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM.crt
+l 0777 0 0 /etc/ssl/certs/AC_RAIZ_FNMT-RCM_SERVIDORES_SEGUROS.pem -> ../../..//usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM_SERVIDORES_SEGUROS.crt
+l 0777 0 0 /etc/ssl/certs/ANF_Secure_Server_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/ANF_Secure_Server_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/Actalis_Authentication_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Actalis_Authentication_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/AffirmTrust_Commercial.pem -> ../../..//usr/share/ca-certificates/mozilla/AffirmTrust_Commercial.crt
+l 0777 0 0 /etc/ssl/certs/AffirmTrust_Networking.pem -> ../../..//usr/share/ca-certificates/mozilla/AffirmTrust_Networking.crt
+l 0777 0 0 /etc/ssl/certs/AffirmTrust_Premium.pem -> ../../..//usr/share/ca-certificates/mozilla/AffirmTrust_Premium.crt
+l 0777 0 0 /etc/ssl/certs/AffirmTrust_Premium_ECC.pem -> ../../..//usr/share/ca-certificates/mozilla/AffirmTrust_Premium_ECC.crt
+l 0777 0 0 /etc/ssl/certs/Amazon_Root_CA_1.pem -> ../../..//usr/share/ca-certificates/mozilla/Amazon_Root_CA_1.crt
+l 0777 0 0 /etc/ssl/certs/Amazon_Root_CA_2.pem -> ../../..//usr/share/ca-certificates/mozilla/Amazon_Root_CA_2.crt
+l 0777 0 0 /etc/ssl/certs/Amazon_Root_CA_3.pem -> ../../..//usr/share/ca-certificates/mozilla/Amazon_Root_CA_3.crt
+l 0777 0 0 /etc/ssl/certs/Amazon_Root_CA_4.pem -> ../../..//usr/share/ca-certificates/mozilla/Amazon_Root_CA_4.crt
+l 0777 0 0 /etc/ssl/certs/Atos_TrustedRoot_2011.pem -> ../../..//usr/share/ca-certificates/mozilla/Atos_TrustedRoot_2011.crt
+l 0777 0 0 /etc/ssl/certs/Atos_TrustedRoot_Root_CA_ECC_TLS_2021.pem -> ../../..//usr/share/ca-certificates/mozilla/Atos_TrustedRoot_Root_CA_ECC_TLS_2021.crt
+l 0777 0 0 /etc/ssl/certs/Atos_TrustedRoot_Root_CA_RSA_TLS_2021.pem -> ../../..//usr/share/ca-certificates/mozilla/Atos_TrustedRoot_Root_CA_RSA_TLS_2021.crt
+l 0777 0 0 /etc/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem -> ../../..//usr/share/ca-certificates/mozilla/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.crt
+l 0777 0 0 /etc/ssl/certs/BJCA_Global_Root_CA1.pem -> ../../..//usr/share/ca-certificates/mozilla/BJCA_Global_Root_CA1.crt
+l 0777 0 0 /etc/ssl/certs/BJCA_Global_Root_CA2.pem -> ../../..//usr/share/ca-certificates/mozilla/BJCA_Global_Root_CA2.crt
+l 0777 0 0 /etc/ssl/certs/Baltimore_CyberTrust_Root.pem -> ../../..//usr/share/ca-certificates/mozilla/Baltimore_CyberTrust_Root.crt
+l 0777 0 0 /etc/ssl/certs/Buypass_Class_2_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Buypass_Class_2_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/Buypass_Class_3_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Buypass_Class_3_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/CA_Disig_Root_R2.pem -> ../../..//usr/share/ca-certificates/mozilla/CA_Disig_Root_R2.crt
+l 0777 0 0 /etc/ssl/certs/CFCA_EV_ROOT.pem -> ../../..//usr/share/ca-certificates/mozilla/CFCA_EV_ROOT.crt
+l 0777 0 0 /etc/ssl/certs/COMODO_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/COMODO_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/COMODO_ECC_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/COMODO_ECC_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/COMODO_RSA_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/COMODO_RSA_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/Certainly_Root_E1.pem -> ../../..//usr/share/ca-certificates/mozilla/Certainly_Root_E1.crt
+l 0777 0 0 /etc/ssl/certs/Certainly_Root_R1.pem -> ../../..//usr/share/ca-certificates/mozilla/Certainly_Root_R1.crt
+l 0777 0 0 /etc/ssl/certs/Certigna.pem -> ../../..//usr/share/ca-certificates/mozilla/Certigna.crt
+l 0777 0 0 /etc/ssl/certs/Certigna_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Certigna_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/Certum_EC-384_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Certum_EC-384_CA.crt
+l 0777 0 0 /etc/ssl/certs/Certum_Trusted_Network_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA.crt
+l 0777 0 0 /etc/ssl/certs/Certum_Trusted_Network_CA_2.pem -> ../../..//usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA_2.crt
+l 0777 0 0 /etc/ssl/certs/Certum_Trusted_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Certum_Trusted_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/CommScope_Public_Trust_ECC_Root-01.pem -> ../../..//usr/share/ca-certificates/mozilla/CommScope_Public_Trust_ECC_Root-01.crt
+l 0777 0 0 /etc/ssl/certs/CommScope_Public_Trust_ECC_Root-02.pem -> ../../..//usr/share/ca-certificates/mozilla/CommScope_Public_Trust_ECC_Root-02.crt
+l 0777 0 0 /etc/ssl/certs/CommScope_Public_Trust_RSA_Root-01.pem -> ../../..//usr/share/ca-certificates/mozilla/CommScope_Public_Trust_RSA_Root-01.crt
+l 0777 0 0 /etc/ssl/certs/CommScope_Public_Trust_RSA_Root-02.pem -> ../../..//usr/share/ca-certificates/mozilla/CommScope_Public_Trust_RSA_Root-02.crt
+l 0777 0 0 /etc/ssl/certs/Comodo_AAA_Services_root.pem -> ../../..//usr/share/ca-certificates/mozilla/Comodo_AAA_Services_root.crt
+l 0777 0 0 /etc/ssl/certs/D-TRUST_BR_Root_CA_1_2020.pem -> ../../..//usr/share/ca-certificates/mozilla/D-TRUST_BR_Root_CA_1_2020.crt
+l 0777 0 0 /etc/ssl/certs/D-TRUST_BR_Root_CA_2_2023.pem -> ../../..//usr/share/ca-certificates/mozilla/D-TRUST_BR_Root_CA_2_2023.crt
+l 0777 0 0 /etc/ssl/certs/D-TRUST_EV_Root_CA_1_2020.pem -> ../../..//usr/share/ca-certificates/mozilla/D-TRUST_EV_Root_CA_1_2020.crt
+l 0777 0 0 /etc/ssl/certs/D-TRUST_EV_Root_CA_2_2023.pem -> ../../..//usr/share/ca-certificates/mozilla/D-TRUST_EV_Root_CA_2_2023.crt
+l 0777 0 0 /etc/ssl/certs/D-TRUST_Root_Class_3_CA_2_2009.pem -> ../../..//usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt
+l 0777 0 0 /etc/ssl/certs/D-TRUST_Root_Class_3_CA_2_EV_2009.pem -> ../../..//usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Assured_ID_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Assured_ID_Root_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G2.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Assured_ID_Root_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G3.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Global_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Global_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Global_Root_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Global_Root_G2.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Global_Root_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Global_Root_G3.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_High_Assurance_EV_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_High_Assurance_EV_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_TLS_ECC_P384_Root_G5.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_TLS_ECC_P384_Root_G5.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_TLS_RSA4096_Root_G5.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_TLS_RSA4096_Root_G5.crt
+l 0777 0 0 /etc/ssl/certs/DigiCert_Trusted_Root_G4.pem -> ../../..//usr/share/ca-certificates/mozilla/DigiCert_Trusted_Root_G4.crt
+l 0777 0 0 /etc/ssl/certs/Entrust.net_Premium_2048_Secure_Server_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Entrust.net_Premium_2048_Secure_Server_CA.crt
+l 0777 0 0 /etc/ssl/certs/Entrust_Root_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/Entrust_Root_Certification_Authority_-_EC1.pem -> ../../..//usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_EC1.crt
+l 0777 0 0 /etc/ssl/certs/Entrust_Root_Certification_Authority_-_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_G2.crt
+l 0777 0 0 /etc/ssl/certs/FIRMAPROFESIONAL_CA_ROOT-A_WEB.pem -> ../../..//usr/share/ca-certificates/mozilla/FIRMAPROFESIONAL_CA_ROOT-A_WEB.crt
+l 0777 0 0 /etc/ssl/certs/GDCA_TrustAUTH_R5_ROOT.pem -> ../../..//usr/share/ca-certificates/mozilla/GDCA_TrustAUTH_R5_ROOT.crt
+l 0777 0 0 /etc/ssl/certs/GLOBALTRUST_2020.pem -> ../../..//usr/share/ca-certificates/mozilla/GLOBALTRUST_2020.crt
+l 0777 0 0 /etc/ssl/certs/GTS_Root_R1.pem -> ../../..//usr/share/ca-certificates/mozilla/GTS_Root_R1.crt
+l 0777 0 0 /etc/ssl/certs/GTS_Root_R2.pem -> ../../..//usr/share/ca-certificates/mozilla/GTS_Root_R2.crt
+l 0777 0 0 /etc/ssl/certs/GTS_Root_R3.pem -> ../../..//usr/share/ca-certificates/mozilla/GTS_Root_R3.crt
+l 0777 0 0 /etc/ssl/certs/GTS_Root_R4.pem -> ../../..//usr/share/ca-certificates/mozilla/GTS_Root_R4.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_ECC_Root_CA_-_R4.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_ECC_Root_CA_-_R4.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_ECC_Root_CA_-_R5.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_ECC_Root_CA_-_R5.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_Root_CA_-_R3.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R3.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_Root_CA_-_R6.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R6.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_Root_E46.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_Root_E46.crt
+l 0777 0 0 /etc/ssl/certs/GlobalSign_Root_R46.pem -> ../../..//usr/share/ca-certificates/mozilla/GlobalSign_Root_R46.crt
+l 0777 0 0 /etc/ssl/certs/Go_Daddy_Class_2_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Go_Daddy_Class_2_CA.crt
+l 0777 0 0 /etc/ssl/certs/Go_Daddy_Root_Certificate_Authority_-_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/Go_Daddy_Root_Certificate_Authority_-_G2.crt
+l 0777 0 0 /etc/ssl/certs/HARICA_TLS_ECC_Root_CA_2021.pem -> ../../..//usr/share/ca-certificates/mozilla/HARICA_TLS_ECC_Root_CA_2021.crt
+l 0777 0 0 /etc/ssl/certs/HARICA_TLS_RSA_Root_CA_2021.pem -> ../../..//usr/share/ca-certificates/mozilla/HARICA_TLS_RSA_Root_CA_2021.crt
+l 0777 0 0 /etc/ssl/certs/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.pem -> ../../..//usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.crt
+l 0777 0 0 /etc/ssl/certs/Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem -> ../../..//usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt
+l 0777 0 0 /etc/ssl/certs/HiPKI_Root_CA_-_G1.pem -> ../../..//usr/share/ca-certificates/mozilla/HiPKI_Root_CA_-_G1.crt
+l 0777 0 0 /etc/ssl/certs/Hongkong_Post_Root_CA_3.pem -> ../../..//usr/share/ca-certificates/mozilla/Hongkong_Post_Root_CA_3.crt
+l 0777 0 0 /etc/ssl/certs/ISRG_Root_X1.pem -> ../../..//usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt
+l 0777 0 0 /etc/ssl/certs/ISRG_Root_X2.pem -> ../../..//usr/share/ca-certificates/mozilla/ISRG_Root_X2.crt
+l 0777 0 0 /etc/ssl/certs/IdenTrust_Commercial_Root_CA_1.pem -> ../../..//usr/share/ca-certificates/mozilla/IdenTrust_Commercial_Root_CA_1.crt
+l 0777 0 0 /etc/ssl/certs/IdenTrust_Public_Sector_Root_CA_1.pem -> ../../..//usr/share/ca-certificates/mozilla/IdenTrust_Public_Sector_Root_CA_1.crt
+l 0777 0 0 /etc/ssl/certs/Izenpe.com.pem -> ../../..//usr/share/ca-certificates/mozilla/Izenpe.com.crt
+l 0777 0 0 /etc/ssl/certs/Microsec_e-Szigno_Root_CA_2009.pem -> ../../..//usr/share/ca-certificates/mozilla/Microsec_e-Szigno_Root_CA_2009.crt
+l 0777 0 0 /etc/ssl/certs/Microsoft_ECC_Root_Certificate_Authority_2017.pem -> ../../..//usr/share/ca-certificates/mozilla/Microsoft_ECC_Root_Certificate_Authority_2017.crt
+l 0777 0 0 /etc/ssl/certs/Microsoft_RSA_Root_Certificate_Authority_2017.pem -> ../../..//usr/share/ca-certificates/mozilla/Microsoft_RSA_Root_Certificate_Authority_2017.crt
+l 0777 0 0 /etc/ssl/certs/NAVER_Global_Root_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/NAVER_Global_Root_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem -> ../../..//usr/share/ca-certificates/mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt
+l 0777 0 0 /etc/ssl/certs/OISTE_WISeKey_Global_Root_GB_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GB_CA.crt
+l 0777 0 0 /etc/ssl/certs/OISTE_WISeKey_Global_Root_GC_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GC_CA.crt
+l 0777 0 0 /etc/ssl/certs/QuoVadis_Root_CA_1_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_1_G3.crt
+l 0777 0 0 /etc/ssl/certs/QuoVadis_Root_CA_2.pem -> ../../..//usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2.crt
+l 0777 0 0 /etc/ssl/certs/QuoVadis_Root_CA_2_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2_G3.crt
+l 0777 0 0 /etc/ssl/certs/QuoVadis_Root_CA_3.pem -> ../../..//usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3.crt
+l 0777 0 0 /etc/ssl/certs/QuoVadis_Root_CA_3_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3_G3.crt
+l 0777 0 0 /etc/ssl/certs/SSL.com_EV_Root_Certification_Authority_ECC.pem -> ../../..//usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_ECC.crt
+l 0777 0 0 /etc/ssl/certs/SSL.com_EV_Root_Certification_Authority_RSA_R2.pem -> ../../..//usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_RSA_R2.crt
+l 0777 0 0 /etc/ssl/certs/SSL.com_Root_Certification_Authority_ECC.pem -> ../../..//usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_ECC.crt
+l 0777 0 0 /etc/ssl/certs/SSL.com_Root_Certification_Authority_RSA.pem -> ../../..//usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_RSA.crt
+l 0777 0 0 /etc/ssl/certs/SSL.com_TLS_ECC_Root_CA_2022.pem -> ../../..//usr/share/ca-certificates/mozilla/SSL.com_TLS_ECC_Root_CA_2022.crt
+l 0777 0 0 /etc/ssl/certs/SSL.com_TLS_RSA_Root_CA_2022.pem -> ../../..//usr/share/ca-certificates/mozilla/SSL.com_TLS_RSA_Root_CA_2022.crt
+l 0777 0 0 /etc/ssl/certs/SZAFIR_ROOT_CA2.pem -> ../../..//usr/share/ca-certificates/mozilla/SZAFIR_ROOT_CA2.crt
+l 0777 0 0 /etc/ssl/certs/Sectigo_Public_Server_Authentication_Root_E46.pem -> ../../..//usr/share/ca-certificates/mozilla/Sectigo_Public_Server_Authentication_Root_E46.crt
+l 0777 0 0 /etc/ssl/certs/Sectigo_Public_Server_Authentication_Root_R46.pem -> ../../..//usr/share/ca-certificates/mozilla/Sectigo_Public_Server_Authentication_Root_R46.crt
+l 0777 0 0 /etc/ssl/certs/SecureSign_Root_CA12.pem -> ../../..//usr/share/ca-certificates/mozilla/SecureSign_Root_CA12.crt
+l 0777 0 0 /etc/ssl/certs/SecureSign_Root_CA14.pem -> ../../..//usr/share/ca-certificates/mozilla/SecureSign_Root_CA14.crt
+l 0777 0 0 /etc/ssl/certs/SecureSign_Root_CA15.pem -> ../../..//usr/share/ca-certificates/mozilla/SecureSign_Root_CA15.crt
+l 0777 0 0 /etc/ssl/certs/SecureTrust_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/SecureTrust_CA.crt
+l 0777 0 0 /etc/ssl/certs/Secure_Global_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Secure_Global_CA.crt
+l 0777 0 0 /etc/ssl/certs/Security_Communication_ECC_RootCA1.pem -> ../../..//usr/share/ca-certificates/mozilla/Security_Communication_ECC_RootCA1.crt
+l 0777 0 0 /etc/ssl/certs/Security_Communication_RootCA2.pem -> ../../..//usr/share/ca-certificates/mozilla/Security_Communication_RootCA2.crt
+l 0777 0 0 /etc/ssl/certs/Starfield_Class_2_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/Starfield_Class_2_CA.crt
+l 0777 0 0 /etc/ssl/certs/Starfield_Root_Certificate_Authority_-_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/Starfield_Root_Certificate_Authority_-_G2.crt
+l 0777 0 0 /etc/ssl/certs/Starfield_Services_Root_Certificate_Authority_-_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/Starfield_Services_Root_Certificate_Authority_-_G2.crt
+l 0777 0 0 /etc/ssl/certs/SwissSign_Gold_CA_-_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/SwissSign_Gold_CA_-_G2.crt
+l 0777 0 0 /etc/ssl/certs/T-TeleSec_GlobalRoot_Class_2.pem -> ../../..//usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_2.crt
+l 0777 0 0 /etc/ssl/certs/T-TeleSec_GlobalRoot_Class_3.pem -> ../../..//usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_3.crt
+l 0777 0 0 /etc/ssl/certs/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.pem -> ../../..//usr/share/ca-certificates/mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt
+l 0777 0 0 /etc/ssl/certs/TWCA_CYBER_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/TWCA_CYBER_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/TWCA_Global_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/TWCA_Global_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/TWCA_Root_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/TWCA_Root_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/Telekom_Security_TLS_ECC_Root_2020.pem -> ../../..//usr/share/ca-certificates/mozilla/Telekom_Security_TLS_ECC_Root_2020.crt
+l 0777 0 0 /etc/ssl/certs/Telekom_Security_TLS_RSA_Root_2023.pem -> ../../..//usr/share/ca-certificates/mozilla/Telekom_Security_TLS_RSA_Root_2023.crt
+l 0777 0 0 /etc/ssl/certs/TeliaSonera_Root_CA_v1.pem -> ../../..//usr/share/ca-certificates/mozilla/TeliaSonera_Root_CA_v1.crt
+l 0777 0 0 /etc/ssl/certs/Telia_Root_CA_v2.pem -> ../../..//usr/share/ca-certificates/mozilla/Telia_Root_CA_v2.crt
+l 0777 0 0 /etc/ssl/certs/TrustAsia_Global_Root_CA_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/TrustAsia_Global_Root_CA_G3.crt
+l 0777 0 0 /etc/ssl/certs/TrustAsia_Global_Root_CA_G4.pem -> ../../..//usr/share/ca-certificates/mozilla/TrustAsia_Global_Root_CA_G4.crt
+l 0777 0 0 /etc/ssl/certs/Trustwave_Global_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/Trustwave_Global_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/Trustwave_Global_ECC_P256_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/Trustwave_Global_ECC_P256_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/Trustwave_Global_ECC_P384_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/Trustwave_Global_ECC_P384_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/TunTrust_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/TunTrust_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/UCA_Extended_Validation_Root.pem -> ../../..//usr/share/ca-certificates/mozilla/UCA_Extended_Validation_Root.crt
+l 0777 0 0 /etc/ssl/certs/UCA_Global_G2_Root.pem -> ../../..//usr/share/ca-certificates/mozilla/UCA_Global_G2_Root.crt
+l 0777 0 0 /etc/ssl/certs/USERTrust_ECC_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/USERTrust_ECC_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/USERTrust_RSA_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/USERTrust_RSA_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/XRamp_Global_CA_Root.pem -> ../../..//usr/share/ca-certificates/mozilla/XRamp_Global_CA_Root.crt
+l 0777 0 0 /etc/ssl/certs/a09a51ae.0 -> D-TRUST_EV_Root_CA_2_2023.pem
+l 0777 0 0 /etc/ssl/certs/a3418fda.0 -> GTS_Root_R4.pem
+l 0777 0 0 /etc/ssl/certs/a89d74c2.0 -> SSL.com_TLS_RSA_Root_CA_2022.pem
+l 0777 0 0 /etc/ssl/certs/a94d09e5.0 -> ACCVRAIZ1.pem
+l 0777 0 0 /etc/ssl/certs/aee5f10d.0 -> Entrust.net_Premium_2048_Secure_Server_CA.pem
+l 0777 0 0 /etc/ssl/certs/b0e59380.0 -> GlobalSign_ECC_Root_CA_-_R4.pem
+l 0777 0 0 /etc/ssl/certs/b1159c4c.0 -> DigiCert_Assured_ID_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/b433981b.0 -> ANF_Secure_Server_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/b66938e9.0 -> Secure_Global_CA.pem
+l 0777 0 0 /etc/ssl/certs/b727005e.0 -> AffirmTrust_Premium.pem
+l 0777 0 0 /etc/ssl/certs/b7a5b843.0 -> TWCA_Root_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/b81b93f0.0 -> AC_RAIZ_FNMT-RCM_SERVIDORES_SEGUROS.pem
+l 0777 0 0 /etc/ssl/certs/b8d25de6.0 -> TWCA_CYBER_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/ba8887ce.0 -> FIRMAPROFESIONAL_CA_ROOT-A_WEB.pem
+l 0777 0 0 /etc/ssl/certs/bf53fb88.0 -> Microsoft_RSA_Root_Certificate_Authority_2017.pem
+l 0777 0 0 /etc/ssl/certs/c01eb047.0 -> UCA_Global_G2_Root.pem
+l 0777 0 0 /etc/ssl/certs/c28a8a30.0 -> D-TRUST_Root_Class_3_CA_2_2009.pem
+f 0644 0 0 /etc/ssl/certs/ca-certificates.crt
+l 0777 0 0 /etc/ssl/certs/ca6e4ad9.0 -> ePKI_Root_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/cbf06781.0 -> Go_Daddy_Root_Certificate_Authority_-_G2.pem
+l 0777 0 0 /etc/ssl/certs/cc450945.0 -> Izenpe.com.pem
+l 0777 0 0 /etc/ssl/certs/cd58d51e.0 -> Security_Communication_RootCA2.pem
+l 0777 0 0 /etc/ssl/certs/cd8c0d63.0 -> AC_RAIZ_FNMT-RCM.pem
+l 0777 0 0 /etc/ssl/certs/ce5e74ef.0 -> Amazon_Root_CA_1.pem
+l 0777 0 0 /etc/ssl/certs/certSIGN_ROOT_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/certSIGN_ROOT_CA.crt
+l 0777 0 0 /etc/ssl/certs/certSIGN_Root_CA_G2.pem -> ../../..//usr/share/ca-certificates/mozilla/certSIGN_Root_CA_G2.crt
+l 0777 0 0 /etc/ssl/certs/d4dae3dd.0 -> D-TRUST_Root_Class_3_CA_2_EV_2009.pem
+l 0777 0 0 /etc/ssl/certs/d52c538d.0 -> DigiCert_TLS_RSA4096_Root_G5.pem
+l 0777 0 0 /etc/ssl/certs/d6325660.0 -> COMODO_RSA_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/d7e8dc79.0 -> QuoVadis_Root_CA_2.pem
+l 0777 0 0 /etc/ssl/certs/d887a5bb.0 -> Trustwave_Global_ECC_P384_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/da0cfd1d.0 -> Sectigo_Public_Server_Authentication_Root_E46.pem
+l 0777 0 0 /etc/ssl/certs/dc4d6a89.0 -> GlobalSign_Root_CA_-_R6.pem
+l 0777 0 0 /etc/ssl/certs/dd8e9d41.0 -> DigiCert_Global_Root_G3.pem
+l 0777 0 0 /etc/ssl/certs/ddcda989.0 -> Telekom_Security_TLS_ECC_Root_2020.pem
+l 0777 0 0 /etc/ssl/certs/de6d66f3.0 -> Amazon_Root_CA_4.pem
+l 0777 0 0 /etc/ssl/certs/e-Szigno_Root_CA_2017.pem -> ../../..//usr/share/ca-certificates/mozilla/e-Szigno_Root_CA_2017.crt
+l 0777 0 0 /etc/ssl/certs/e113c810.0 -> Certigna.pem
+l 0777 0 0 /etc/ssl/certs/e18bfb83.0 -> QuoVadis_Root_CA_3_G3.pem
+l 0777 0 0 /etc/ssl/certs/e35234b1.0 -> Certum_Trusted_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/e36a6752.0 -> Atos_TrustedRoot_2011.pem
+l 0777 0 0 /etc/ssl/certs/e73d606e.0 -> OISTE_WISeKey_Global_Root_GB_CA.pem
+l 0777 0 0 /etc/ssl/certs/e868b802.0 -> e-Szigno_Root_CA_2017.pem
+l 0777 0 0 /etc/ssl/certs/e8de2f56.0 -> Buypass_Class_3_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/ePKI_Root_Certification_Authority.pem -> ../../..//usr/share/ca-certificates/mozilla/ePKI_Root_Certification_Authority.crt
+l 0777 0 0 /etc/ssl/certs/ecccd8db.0 -> HARICA_TLS_ECC_Root_CA_2021.pem
+l 0777 0 0 /etc/ssl/certs/ed858448.0 -> vTrus_ECC_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/ee64a828.0 -> Comodo_AAA_Services_root.pem
+l 0777 0 0 /etc/ssl/certs/eed8c118.0 -> COMODO_ECC_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/ef954a4e.0 -> IdenTrust_Commercial_Root_CA_1.pem
+l 0777 0 0 /etc/ssl/certs/emSign_ECC_Root_CA_-_C3.pem -> ../../..//usr/share/ca-certificates/mozilla/emSign_ECC_Root_CA_-_C3.crt
+l 0777 0 0 /etc/ssl/certs/emSign_ECC_Root_CA_-_G3.pem -> ../../..//usr/share/ca-certificates/mozilla/emSign_ECC_Root_CA_-_G3.crt
+l 0777 0 0 /etc/ssl/certs/emSign_Root_CA_-_C1.pem -> ../../..//usr/share/ca-certificates/mozilla/emSign_Root_CA_-_C1.crt
+l 0777 0 0 /etc/ssl/certs/emSign_Root_CA_-_G1.pem -> ../../..//usr/share/ca-certificates/mozilla/emSign_Root_CA_-_G1.crt
+l 0777 0 0 /etc/ssl/certs/f081611a.0 -> Go_Daddy_Class_2_CA.pem
+l 0777 0 0 /etc/ssl/certs/f0c70a8d.0 -> SSL.com_EV_Root_Certification_Authority_ECC.pem
+l 0777 0 0 /etc/ssl/certs/f249de83.0 -> Trustwave_Global_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/f30dd6ad.0 -> USERTrust_ECC_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/f387163d.0 -> Starfield_Class_2_CA.pem
+l 0777 0 0 /etc/ssl/certs/f39fc864.0 -> SecureTrust_CA.pem
+l 0777 0 0 /etc/ssl/certs/f51bb24c.0 -> Certigna_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/fa5da96b.0 -> GLOBALTRUST_2020.pem
+l 0777 0 0 /etc/ssl/certs/fb717492.0 -> Atos_TrustedRoot_Root_CA_ECC_TLS_2021.pem
+l 0777 0 0 /etc/ssl/certs/fc5a8f99.0 -> USERTrust_RSA_Certification_Authority.pem
+l 0777 0 0 /etc/ssl/certs/fd64f3fc.0 -> TunTrust_Root_CA.pem
+l 0777 0 0 /etc/ssl/certs/fe8a2cd8.0 -> SZAFIR_ROOT_CA2.pem
+l 0777 0 0 /etc/ssl/certs/feffd413.0 -> GlobalSign_Root_E46.pem
+l 0777 0 0 /etc/ssl/certs/ff34af3f.0 -> TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.pem
+l 0777 0 0 /etc/ssl/certs/ffdd40f9.0 -> D-TRUST_BR_Root_CA_2_2023.pem
+l 0777 0 0 /etc/ssl/certs/vTrus_ECC_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/vTrus_ECC_Root_CA.crt
+l 0777 0 0 /etc/ssl/certs/vTrus_Root_CA.pem -> ../../..//usr/share/ca-certificates/mozilla/vTrus_Root_CA.crt
+f 0644 0 0 /etc/ssl/openssl.cnf
+d 0755 0 0 /etc/ssl/private
+f 0644 0 0 /etc/subgid
+f 0644 0 0 /etc/subuid
+f 0644 0 0 /etc/sysctl.conf
+f 0644 0 0 /etc/syslog-startup.conf
+f 0644 0 0 /etc/syslog.conf
+d 0755 0 0 /etc/terminfo
+d 0755 0 0 /etc/terminfo/a
+f 0644 0 0 /etc/terminfo/a/ansi
+d 0755 0 0 /etc/terminfo/d
+f 0644 0 0 /etc/terminfo/d/dumb
+d 0755 0 0 /etc/terminfo/l
+f 0644 0 0 /etc/terminfo/l/linux
+d 0755 0 0 /etc/terminfo/r
+f 0644 0 0 /etc/terminfo/r/rxvt
+d 0755 0 0 /etc/terminfo/s
+f 0644 0 0 /etc/terminfo/s/screen
+f 0644 0 0 /etc/terminfo/s/screen-256color
+f 0644 0 0 /etc/terminfo/s/sun
+d 0755 0 0 /etc/terminfo/v
+f 0644 0 0 /etc/terminfo/v/vt100
+f 0644 0 0 /etc/terminfo/v/vt102
+f 0644 0 0 /etc/terminfo/v/vt200
+f 0644 0 0 /etc/terminfo/v/vt220
+f 0644 0 0 /etc/terminfo/v/vt52
+d 0755 0 0 /etc/terminfo/x
+l 0777 0 0 /etc/terminfo/x/xterm -> xterm-color
+f 0644 0 0 /etc/terminfo/x/xterm-256color
+f 0644 0 0 /etc/terminfo/x/xterm-color
+f 0644 0 0 /etc/terminfo/x/xterm-xfree86
+d 0755 0 0 /etc/thttp
+d 0755 0 0 /etc/thttp/certs
+f 0644 0 0 /etc/thttp/certs/isrg-root-x1-cross-signed.pem
+f 0644 0 0 /etc/thttp/certs/isrgrootx1.pem
+d 0755 0 0 /etc/udev
+d 0755 0 0 /etc/udev/rules.d
+f 0644 0 0 /etc/udev/rules.d/80-net-name-slot.rules
+f 0644 0 0 /etc/udev/rules.d/local.rules
+f 0644 0 0 /etc/udev/udev.conf
+d 0755 0 0 /etc/udhcpc.d
+f 0755 0 0 /etc/udhcpc.d/50default
+f 0644 0 0 /etc/version
+f 0644 0 0 /etc/xattr.conf
+d 0755 0 0 /home
+d 0700 0 0 /home/root
+d 0755 0 0 /lib
+d 0755 0 0 /lib/.debug
+f 0755 0 0 /lib/.debug/ld-linux-x86-64.so.2
+f 0755 0 0 /lib/.debug/libBrokenLocale.so.1
+f 0755 0 0 /lib/.debug/libanl.so.1
+f 0755 0 0 /lib/.debug/libc.so.6
+f 0755 0 0 /lib/.debug/libc_malloc_debug.so.0
+f 0755 0 0 /lib/.debug/libdl.so.2
+f 0755 0 0 /lib/.debug/libm.so.6
+f 0755 0 0 /lib/.debug/libmemusage.so
+f 0755 0 0 /lib/.debug/libmvec.so.1
+f 0755 0 0 /lib/.debug/libnsl.so.1
+f 0755 0 0 /lib/.debug/libnss_compat.so.2
+f 0755 0 0 /lib/.debug/libnss_db.so.2
+f 0755 0 0 /lib/.debug/libnss_dns.so.2
+f 0755 0 0 /lib/.debug/libnss_files.so.2
+f 0755 0 0 /lib/.debug/libnss_hesiod.so.2
+f 0755 0 0 /lib/.debug/libpcprofile.so
+f 0755 0 0 /lib/.debug/libpthread.so.0
+f 0755 0 0 /lib/.debug/libresolv.so.2
+f 0755 0 0 /lib/.debug/librt.so.1
+f 0755 0 0 /lib/.debug/libthread_db.so.1
+f 0755 0 0 /lib/.debug/libutil.so.1
+d 0755 0 0 /lib/depmod.d
+f 0644 0 0 /lib/depmod.d/exclude.conf
+f 0644 0 0 /lib/depmod.d/search.conf
+f 0755 0 0 /lib/ld-linux-x86-64.so.2
+f 0755 0 0 /lib/libBrokenLocale.so.1
+f 0755 0 0 /lib/libanl.so.1
+l 0777 0 0 /lib/libblkid.so.1 -> libblkid.so.1.1.0
+f 0755 0 0 /lib/libblkid.so.1.1.0
+f 0755 0 0 /lib/libc.so.6
+l 0777 0 0 /lib/libcap-ng.so.0 -> libcap-ng.so.0.0.0
+f 0755 0 0 /lib/libcap-ng.so.0.0.0
+l 0777 0 0 /lib/libcap.so.2 -> libcap.so.2.69
+f 0755 0 0 /lib/libcap.so.2.69
+l 0777 0 0 /lib/libcom_err.so.2 -> libcom_err.so.2.1
+f 0755 0 0 /lib/libcom_err.so.2.1
+f 0755 0 0 /lib/libdl.so.2
+l 0777 0 0 /lib/libe2p.so.2 -> libe2p.so.2.3
+f 0755 0 0 /lib/libe2p.so.2.3
+l 0777 0 0 /lib/libext2fs.so.2 -> libext2fs.so.2.4
+f 0755 0 0 /lib/libext2fs.so.2.4
+l 0777 0 0 /lib/libfdisk.so.1 -> libfdisk.so.1.1.0
+f 0755 0 0 /lib/libfdisk.so.1.1.0
+f 0644 0 0 /lib/libgcc_s.so.1
+f 0755 0 0 /lib/libm.so.6
+l 0777 0 0 /lib/libmount.so.1 -> libmount.so.1.1.0
+f 0755 0 0 /lib/libmount.so.1.1.0
+f 0755 0 0 /lib/libmvec.so.1
+l 0777 0 0 /lib/libncursesw.so.5 -> libncursesw.so.5.9
+f 0755 0 0 /lib/libncursesw.so.5.9
+f 0755 0 0 /lib/libnsl.so.1
+f 0755 0 0 /lib/libnss_compat.so.2
+f 0755 0 0 /lib/libnss_dns.so.2
+f 0755 0 0 /lib/libnss_files.so.2
+f 0755 0 0 /lib/libnss_mdns.so.2
+f 0755 0 0 /lib/libnss_mdns4.so.2
+f 0755 0 0 /lib/libnss_mdns4_minimal.so.2
+f 0755 0 0 /lib/libnss_mdns6.so.2
+f 0755 0 0 /lib/libnss_mdns6_minimal.so.2
+f 0755 0 0 /lib/libnss_mdns_minimal.so.2
+f 0755 0 0 /lib/libpthread.so.0
+f 0755 0 0 /lib/libresolv.so.2
+f 0755 0 0 /lib/librt.so.1
+l 0777 0 0 /lib/libsmartcols.so.1 -> libsmartcols.so.1.1.0
+f 0755 0 0 /lib/libsmartcols.so.1.1.0
+l 0777 0 0 /lib/libtinfo.so.5 -> libtinfo.so.5.9
+f 0755 0 0 /lib/libtinfo.so.5.9
+f 0755 0 0 /lib/libutil.so.1
+d 0755 0 0 /lib/modprobe.d
+d 0755 0 0 /lib/udev
+f 0755 0 0 /lib/udev/ata_id
+f 0755 0 0 /lib/udev/cdrom_id
+f 0755 0 0 /lib/udev/collect
+f 0755 0 0 /lib/udev/dmi_memory_id
+f 0755 0 0 /lib/udev/fido_id
+f 0755 0 0 /lib/udev/mtd_probe
+d 0755 0 0 /lib/udev/rules.d
+f 0644 0 0 /lib/udev/rules.d/50-udev-default.rules
+f 0644 0 0 /lib/udev/rules.d/60-autosuspend.rules
+f 0644 0 0 /lib/udev/rules.d/60-block.rules
+f 0644 0 0 /lib/udev/rules.d/60-cdrom_id.rules
+f 0644 0 0 /lib/udev/rules.d/60-drm.rules
+f 0644 0 0 /lib/udev/rules.d/60-evdev.rules
+f 0644 0 0 /lib/udev/rules.d/60-fido-id.rules
+f 0644 0 0 /lib/udev/rules.d/60-input-id.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-alsa.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-input.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-storage-tape.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-storage.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-v4l.rules
+f 0644 0 0 /lib/udev/rules.d/60-sensor.rules
+f 0644 0 0 /lib/udev/rules.d/60-serial.rules
+f 0644 0 0 /lib/udev/rules.d/64-btrfs.rules
+f 0644 0 0 /lib/udev/rules.d/70-camera.rules
+f 0644 0 0 /lib/udev/rules.d/70-joystick.rules
+f 0644 0 0 /lib/udev/rules.d/70-memory.rules
+f 0644 0 0 /lib/udev/rules.d/70-mouse.rules
+f 0644 0 0 /lib/udev/rules.d/70-touchpad.rules
+f 0644 0 0 /lib/udev/rules.d/75-net-description.rules
+f 0644 0 0 /lib/udev/rules.d/75-probe_mtd.rules
+f 0644 0 0 /lib/udev/rules.d/78-sound-card.rules
+f 0644 0 0 /lib/udev/rules.d/80-drivers.rules
+f 0644 0 0 /lib/udev/rules.d/80-net-name-slot.rules
+f 0644 0 0 /lib/udev/rules.d/81-net-dhcp.rules
+f 0755 0 0 /lib/udev/scsi_id
+f 0755 0 0 /lib/udev/v4l_id
+d 0755 0 0 /media
+d 0755 0 0 /mnt
+d 0555 0 0 /proc
+d 0755 0 0 /run
+d 0755 0 0 /sbin
+d 0755 0 0 /sbin/.debug
+f 0755 0 0 /sbin/.debug/ldconfig
+f 0755 0 0 /sbin/.debug/sln
+f 0755 0 0 /sbin/agetty
+l 0777 0 0 /sbin/blkid -> /sbin/blkid.util-linux
+f 0755 0 0 /sbin/blkid.util-linux
+l 0777 0 0 /sbin/blockdev -> /sbin/blockdev.util-linux
+f 0755 0 0 /sbin/blockdev.util-linux
+f 0755 0 0 /sbin/bootlogd
+f 0755 0 0 /sbin/cfdisk
+f 0755 0 0 /sbin/ctrlaltdel
+l 0777 0 0 /sbin/depmod -> /sbin/depmod.kmod
+l 0777 0 0 /sbin/depmod.kmod -> ../bin/kmod
+f 0755 0 0 /sbin/e2fsck
+l 0777 0 0 /sbin/fdisk -> /sbin/fdisk.util-linux
+f 0755 0 0 /sbin/fdisk.util-linux
+l 0777 0 0 /sbin/fsck -> /sbin/fsck.util-linux
+f 0755 0 0 /sbin/fsck.ext2
+f 0755 0 0 /sbin/fsck.ext3
+f 0755 0 0 /sbin/fsck.ext4
+f 0755 0 0 /sbin/fsck.util-linux
+f 0755 0 0 /sbin/fstab-decode
+l 0777 0 0 /sbin/fstrim -> /sbin/fstrim.util-linux
+f 0755 0 0 /sbin/fstrim.util-linux
+l 0777 0 0 /sbin/getty -> /sbin/agetty
+f 0755 0 0 /sbin/getty-wrapper
+l 0777 0 0 /sbin/halt -> /sbin/halt.sysvinit
+f 4754 0 70 /sbin/halt.sysvinit
+l 0777 0 0 /sbin/hwclock -> /sbin/hwclock.util-linux
+f 0755 0 0 /sbin/hwclock.util-linux
+l 0777 0 0 /sbin/ifconfig -> /bin/busybox
+l 0777 0 0 /sbin/ifdown -> /bin/busybox
+l 0777 0 0 /sbin/ifup -> /bin/busybox
+l 0777 0 0 /sbin/init -> /sbin/init.sysvinit
+f 0755 0 0 /sbin/init.sysvinit
+l 0777 0 0 /sbin/insmod -> /sbin/insmod.kmod
+l 0777 0 0 /sbin/insmod.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/ip -> /bin/busybox
+f 0755 0 0 /sbin/killall5
+l 0777 0 0 /sbin/klogd -> /bin/busybox
+f 0755 0 0 /sbin/ldconfig
+l 0777 0 0 /sbin/loadkmap -> /bin/busybox
+l 0777 0 0 /sbin/logread -> /bin/busybox
+l 0777 0 0 /sbin/losetup -> /sbin/losetup.util-linux
+f 0755 0 0 /sbin/losetup.util-linux
+l 0777 0 0 /sbin/lsmod -> /bin/lsmod.kmod
+l 0777 0 0 /sbin/mdev -> /bin/busybox
+l 0777 0 0 /sbin/mke2fs -> /sbin/mke2fs.e2fsprogs
+f 0755 0 0 /sbin/mke2fs.e2fsprogs
+l 0777 0 0 /sbin/mkfs.ext2 -> /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext3
+f 0755 0 0 /sbin/mkfs.ext4
+l 0777 0 0 /sbin/mkswap -> /sbin/mkswap.util-linux
+f 0755 0 0 /sbin/mkswap.util-linux
+l 0777 0 0 /sbin/modinfo -> /sbin/modinfo.kmod
+l 0777 0 0 /sbin/modinfo.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/modprobe -> /sbin/modprobe.kmod
+l 0777 0 0 /sbin/modprobe.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/nologin -> /sbin/nologin.shadow
+f 0755 0 0 /sbin/nologin.shadow
+f 0755 0 0 /sbin/nologin.util-linux
+l 0777 0 0 /sbin/pivot_root -> /sbin/pivot_root.util-linux
+f 0755 0 0 /sbin/pivot_root.util-linux
+l 0777 0 0 /sbin/poweroff -> /sbin/poweroff.sysvinit
+l 0777 0 0 /sbin/poweroff.sysvinit -> halt.sysvinit
+l 0777 0 0 /sbin/reboot -> /sbin/reboot.sysvinit
+l 0777 0 0 /sbin/reboot.sysvinit -> halt.sysvinit
+l 0777 0 0 /sbin/rmmod -> /sbin/rmmod.kmod
+l 0777 0 0 /sbin/rmmod.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/route -> /bin/busybox
+l 0777 0 0 /sbin/runlevel -> /sbin/runlevel.sysvinit
+f 0755 0 0 /sbin/runlevel.sysvinit
+l 0777 0 0 /sbin/setconsole -> /bin/busybox
+l 0777 0 0 /sbin/shutdown -> /sbin/shutdown.sysvinit
+f 4754 0 70 /sbin/shutdown.sysvinit
+l 0777 0 0 /sbin/start-stop-daemon -> /bin/busybox
+l 0777 0 0 /sbin/sulogin -> /sbin/sulogin.util-linux
+f 0755 0 0 /sbin/sulogin.util-linux
+l 0777 0 0 /sbin/swapoff -> /sbin/swapoff.util-linux
+f 0755 0 0 /sbin/swapoff.util-linux
+l 0777 0 0 /sbin/swapon -> /sbin/swapon.util-linux
+f 0755 0 0 /sbin/swapon.util-linux
+l 0777 0 0 /sbin/switch_root -> /sbin/switch_root.util-linux
+f 0755 0 0 /sbin/switch_root.util-linux
+l 0777 0 0 /sbin/sysctl -> /sbin/sysctl.procps
+f 0755 0 0 /sbin/sysctl.procps
+l 0777 0 0 /sbin/syslogd -> /bin/busybox
+l 0777 0 0 /sbin/telinit -> init
+l 0777 0 0 /sbin/udevadm -> /usr/bin/udevadm
+f 0755 0 0 /sbin/udevd
+l 0777 0 0 /sbin/udhcpc -> /bin/busybox
+l 0777 0 0 /sbin/vigr -> /sbin/vigr.shadow
+l 0777 0 0 /sbin/vigr.shadow -> vipw.shadow
+l 0777 0 0 /sbin/vipw -> /sbin/vipw.shadow
+f 0755 0 0 /sbin/vipw.shadow
+d 0555 0 0 /sys
+d 1777 0 0 /tmp
+d 0755 0 0 /usr
+d 0755 0 0 /usr/bin
+d 0755 0 0 /usr/bin/.debug
+f 0755 0 0 /usr/bin/.debug/gencat
+f 0755 0 0 /usr/bin/.debug/getconf
+f 0755 0 0 /usr/bin/.debug/getent
+f 0755 0 0 /usr/bin/.debug/iconv
+f 0755 0 0 /usr/bin/.debug/locale
+f 0755 0 0 /usr/bin/.debug/makedb
+f 0755 0 0 /usr/bin/.debug/pcprofiledump
+f 0755 0 0 /usr/bin/.debug/pldd
+f 0755 0 0 /usr/bin/.debug/sprof
+f 0755 0 0 /usr/bin/.debug/zdump
+f 0755 0 0 /usr/bin/JSON.sh
+l 0777 0 0 /usr/bin/[ -> /usr/bin/lbracket.coreutils
+l 0777 0 0 /usr/bin/[[ -> /bin/busybox
+l 0777 0 0 /usr/bin/arch -> /usr/bin/arch.coreutils
+f 0755 0 0 /usr/bin/arch.coreutils
+l 0777 0 0 /usr/bin/ascii -> /bin/busybox
+l 0777 0 0 /usr/bin/awk -> /bin/busybox
+f 0755 0 0 /usr/bin/b2sum
+l 0777 0 0 /usr/bin/base32 -> /usr/bin/base32.coreutils
+f 0755 0 0 /usr/bin/base32.coreutils
+f 0755 0 0 /usr/bin/base64.coreutils
+l 0777 0 0 /usr/bin/basename -> /usr/bin/basename.coreutils
+f 0755 0 0 /usr/bin/basename.coreutils
+f 0755 0 0 /usr/bin/basenc
+l 0777 0 0 /usr/bin/bc -> /usr/bin/bc.bc
+f 0755 0 0 /usr/bin/bc.bc
+l 0777 0 0 /usr/bin/bunzip2 -> /bin/busybox
+l 0777 0 0 /usr/bin/bzcat -> /bin/busybox
+l 0777 0 0 /usr/bin/bzip2 -> /bin/busybox
+l 0777 0 0 /usr/bin/cal -> /usr/bin/cal.util-linux
+f 0755 0 0 /usr/bin/cal.util-linux
+f 4755 0 0 /usr/bin/chage
+l 0777 0 0 /usr/bin/chcon -> /usr/bin/chcon.coreutils
+f 0755 0 0 /usr/bin/chcon.coreutils
+l 0777 0 0 /usr/bin/chfn -> /usr/bin/chfn.shadow
+f 4755 0 0 /usr/bin/chfn.shadow
+f 0755 0 0 /usr/bin/chmem
+f 0755 0 0 /usr/bin/choom
+l 0777 0 0 /usr/bin/chrt -> /usr/bin/chrt.util-linux
+f 0755 0 0 /usr/bin/chrt.util-linux
+l 0777 0 0 /usr/bin/chsh -> /usr/bin/chsh.shadow
+f 4755 0 0 /usr/bin/chsh.shadow
+l 0777 0 0 /usr/bin/chvt -> /bin/busybox
+l 0777 0 0 /usr/bin/cksum -> /usr/bin/cksum.coreutils
+f 0755 0 0 /usr/bin/cksum.coreutils
+l 0777 0 0 /usr/bin/clear -> /bin/busybox
+f 0755 0 0 /usr/bin/cmdmkovl
+f 0755 0 0 /usr/bin/cmdtreediff
+l 0777 0 0 /usr/bin/cmp -> /bin/busybox
+f 0755 0 0 /usr/bin/col
+f 0755 0 0 /usr/bin/colcrt
+f 0755 0 0 /usr/bin/colrm
+f 0755 0 0 /usr/bin/column
+l 0777 0 0 /usr/bin/comm -> /usr/bin/comm.coreutils
+f 0755 0 0 /usr/bin/comm.coreutils
+l 0777 0 0 /usr/bin/crc32 -> /bin/busybox
+l 0777 0 0 /usr/bin/csplit -> /usr/bin/csplit.coreutils
+f 0755 0 0 /usr/bin/csplit.coreutils
+f 0755 0 0 /usr/bin/curl
+l 0777 0 0 /usr/bin/cut -> /usr/bin/cut.coreutils
+f 0755 0 0 /usr/bin/cut.coreutils
+f 0755 0 0 /usr/bin/dbus-cleanup-sockets
+f 0755 0 0 /usr/bin/dbus-daemon
+f 0755 0 0 /usr/bin/dbus-launch
+f 0755 0 0 /usr/bin/dbus-monitor
+f 0755 0 0 /usr/bin/dbus-run-session
+f 0755 0 0 /usr/bin/dbus-send
+f 0755 0 0 /usr/bin/dbus-update-activation-environment
+f 0755 0 0 /usr/bin/dbus-uuidgen
+l 0777 0 0 /usr/bin/dc -> /usr/bin/dc.bc
+f 0755 0 0 /usr/bin/dc.bc
+f 0755 0 0 /usr/bin/dcp-blob-create
+l 0777 0 0 /usr/bin/deallocvt -> /bin/busybox
+f 0755 0 0 /usr/bin/df.coreutils
+f 0755 0 0 /usr/bin/dhcp_lease_time
+f 0755 0 0 /usr/bin/dhcp_release
+f 0755 0 0 /usr/bin/dhcp_release6
+l 0777 0 0 /usr/bin/diff -> /bin/busybox
+l 0777 0 0 /usr/bin/dir -> /usr/bin/dir.coreutils
+f 0755 0 0 /usr/bin/dir.coreutils
+l 0777 0 0 /usr/bin/dircolors -> /usr/bin/dircolors.coreutils
+f 0755 0 0 /usr/bin/dircolors.coreutils
+l 0777 0 0 /usr/bin/dirname -> /usr/bin/dirname.coreutils
+f 0755 0 0 /usr/bin/dirname.coreutils
+f 0755 0 0 /usr/bin/dnsmasq
+l 0777 0 0 /usr/bin/docker-runc -> runc
+l 0777 0 0 /usr/bin/du -> /usr/bin/du.coreutils
+f 0755 0 0 /usr/bin/du.coreutils
+l 0777 0 0 /usr/bin/dumpleases -> /bin/busybox
+l 0777 0 0 /usr/bin/eject -> /usr/bin/eject.util-linux
+f 0755 0 0 /usr/bin/eject.util-linux
+l 0777 0 0 /usr/bin/env -> /usr/bin/env.coreutils
+f 0755 0 0 /usr/bin/env.coreutils
+l 0777 0 0 /usr/bin/expand -> /usr/bin/expand.coreutils
+f 0755 0 0 /usr/bin/expand.coreutils
+f 4755 0 0 /usr/bin/expiry
+l 0777 0 0 /usr/bin/expr -> /usr/bin/expr.coreutils
+f 0755 0 0 /usr/bin/expr.coreutils
+l 0777 0 0 /usr/bin/factor -> /usr/bin/factor.coreutils
+f 0755 0 0 /usr/bin/factor.coreutils
+f 0755 0 0 /usr/bin/fadvise
+f 0755 0 0 /usr/bin/faillog
+f 0755 0 0 /usr/bin/fallbear-cmd
+l 0777 0 0 /usr/bin/fallocate -> /usr/bin/fallocate.util-linux
+f 0755 0 0 /usr/bin/fallocate.util-linux
+f 0755 0 0 /usr/bin/fcntl-lock
+f 0755 0 0 /usr/bin/fincore
+l 0777 0 0 /usr/bin/find -> /bin/busybox
+f 0755 0 0 /usr/bin/findmnt
+l 0777 0 0 /usr/bin/flock -> /usr/bin/flock.util-linux
+f 0755 0 0 /usr/bin/flock.util-linux
+l 0777 0 0 /usr/bin/fmt -> /usr/bin/fmt.coreutils
+f 0755 0 0 /usr/bin/fmt.coreutils
+l 0777 0 0 /usr/bin/fold -> /usr/bin/fold.coreutils
+f 0755 0 0 /usr/bin/fold.coreutils
+l 0777 0 0 /usr/bin/free -> /usr/bin/free.procps
+f 0755 0 0 /usr/bin/free.procps
+l 0777 0 0 /usr/bin/fuser -> /bin/busybox
+f 0755 0 0 /usr/bin/getsubids
+f 4755 0 0 /usr/bin/gpasswd
+l 0777 0 0 /usr/bin/groups -> /usr/bin/groups.shadow
+f 0755 0 0 /usr/bin/groups.coreutils
+f 0755 0 0 /usr/bin/groups.shadow
+f 0755 0 0 /usr/bin/hardlink
+l 0777 0 0 /usr/bin/head -> /usr/bin/head.coreutils
+f 0755 0 0 /usr/bin/head.coreutils
+l 0777 0 0 /usr/bin/hexdump -> /usr/bin/hexdump.util-linux
+f 0755 0 0 /usr/bin/hexdump.util-linux
+l 0777 0 0 /usr/bin/hostid -> /usr/bin/hostid.coreutils
+f 0755 0 0 /usr/bin/hostid.coreutils
+l 0777 0 0 /usr/bin/i386 -> setarch
+l 0777 0 0 /usr/bin/id -> /usr/bin/id.coreutils
+f 0755 0 0 /usr/bin/id.coreutils
+l 0777 0 0 /usr/bin/install -> /usr/bin/install.coreutils
+f 0755 0 0 /usr/bin/install.coreutils
+l 0777 0 0 /usr/bin/ionice -> /usr/bin/ionice.util-linux
+f 0755 0 0 /usr/bin/ionice.util-linux
+f 0755 0 0 /usr/bin/ipcmk
+l 0777 0 0 /usr/bin/ipcrm -> /usr/bin/ipcrm.util-linux
+f 0755 0 0 /usr/bin/ipcrm.util-linux
+l 0777 0 0 /usr/bin/ipcs -> /usr/bin/ipcs.util-linux
+f 0755 0 0 /usr/bin/ipcs.util-linux
+f 0755 0 0 /usr/bin/irqtop
+f 0755 0 0 /usr/bin/isosize
+l 0777 0 0 /usr/bin/join -> /usr/bin/join.coreutils
+f 0755 0 0 /usr/bin/join.coreutils
+f 0755 0 0 /usr/bin/jq
+l 0777 0 0 /usr/bin/killall -> /bin/busybox
+l 0777 0 0 /usr/bin/last -> /usr/bin/last.sysvinit
+f 0755 0 0 /usr/bin/last.sysvinit
+f 0755 0 0 /usr/bin/last.util-linux
+l 0777 0 0 /usr/bin/lastb -> /usr/bin/lastb.sysvinit
+l 0777 0 0 /usr/bin/lastb.sysvinit -> last.sysvinit
+l 0777 0 0 /usr/bin/lastb.util-linux -> last.util-linux
+f 0755 0 0 /usr/bin/lbracket.coreutils
+l 0777 0 0 /usr/bin/less -> /bin/busybox
+l 0777 0 0 /usr/bin/link -> /usr/bin/link.coreutils
+f 0755 0 0 /usr/bin/link.coreutils
+l 0777 0 0 /usr/bin/linux32 -> setarch
+l 0777 0 0 /usr/bin/linux64 -> setarch
+l 0777 0 0 /usr/bin/logger -> /usr/bin/logger.util-linux
+f 0755 0 0 /usr/bin/logger.util-linux
+l 0777 0 0 /usr/bin/logname -> /usr/bin/logname.coreutils
+f 0755 0 0 /usr/bin/logname.coreutils
+f 0755 0 0 /usr/bin/look
+f 0755 0 0 /usr/bin/lsblk
+f 0755 0 0 /usr/bin/lscpu
+f 0755 0 0 /usr/bin/lsfd
+f 0755 0 0 /usr/bin/lsipc
+f 0755 0 0 /usr/bin/lsirq
+f 0755 0 0 /usr/bin/lslocks
+f 0755 0 0 /usr/bin/lslogins
+f 0755 0 0 /usr/bin/lsmem
+f 0755 0 0 /usr/bin/lsns
+l 0777 0 0 /usr/bin/lspci -> /bin/busybox
+l 0777 0 0 /usr/bin/lsusb -> /bin/busybox
+f 0755 0 0 /usr/bin/lxc-console
+f 0755 0 0 /usr/bin/lxc-info
+f 0755 0 0 /usr/bin/lxc-ls
+f 0755 0 0 /usr/bin/lxc-top
+l 0777 0 0 /usr/bin/lzcat -> /bin/busybox
+l 0777 0 0 /usr/bin/mcookie -> /usr/bin/mcookie.util-linux
+f 0755 0 0 /usr/bin/mcookie.util-linux
+l 0777 0 0 /usr/bin/md5sum -> /usr/bin/md5sum.coreutils
+f 0755 0 0 /usr/bin/md5sum.coreutils
+l 0777 0 0 /usr/bin/mesg -> /usr/bin/mesg.sysvinit
+f 0755 0 0 /usr/bin/mesg.sysvinit
+f 0755 0 0 /usr/bin/mesg.util-linux
+l 0777 0 0 /usr/bin/microcom -> /bin/busybox
+l 0777 0 0 /usr/bin/mkfifo -> /usr/bin/mkfifo.coreutils
+f 0755 0 0 /usr/bin/mkfifo.coreutils
+f 0755 0 0 /usr/bin/mktemp.coreutils
+f 0755 0 0 /usr/bin/namei
+l 0777 0 0 /usr/bin/nc -> /usr/bin/nc.netcat-openbsd
+f 0755 0 0 /usr/bin/nc.netcat-openbsd
+f 4755 0 0 /usr/bin/newgidmap
+l 0777 0 0 /usr/bin/newgrp -> /usr/bin/newgrp.shadow
+f 4755 0 0 /usr/bin/newgrp.shadow
+f 4755 0 0 /usr/bin/newuidmap
+f 0755 0 0 /usr/bin/nice.coreutils
+l 0777 0 0 /usr/bin/nl -> /usr/bin/nl.coreutils
+f 0755 0 0 /usr/bin/nl.coreutils
+l 0777 0 0 /usr/bin/nohup -> /usr/bin/nohup.coreutils
+f 0755 0 0 /usr/bin/nohup.coreutils
+l 0777 0 0 /usr/bin/nproc -> /usr/bin/nproc.coreutils
+f 0755 0 0 /usr/bin/nproc.coreutils
+l 0777 0 0 /usr/bin/nsenter -> /usr/bin/nsenter.util-linux
+f 0755 0 0 /usr/bin/nsenter.util-linux
+l 0777 0 0 /usr/bin/nslookup -> /bin/busybox
+f 0755 0 0 /usr/bin/numfmt
+l 0777 0 0 /usr/bin/od -> /usr/bin/od.coreutils
+f 0755 0 0 /usr/bin/od.coreutils
+f 0755 0 0 /usr/bin/openssl
+l 0777 0 0 /usr/bin/openvt -> /bin/busybox
+f 0755 0 0 /usr/bin/pantavisor
+l 0777 0 0 /usr/bin/passwd -> /usr/bin/passwd.shadow
+f 4755 0 0 /usr/bin/passwd.shadow
+l 0777 0 0 /usr/bin/paste -> /usr/bin/paste.coreutils
+f 0755 0 0 /usr/bin/paste.coreutils
+l 0777 0 0 /usr/bin/patch -> /bin/busybox
+l 0777 0 0 /usr/bin/pathchk -> /usr/bin/pathchk.coreutils
+f 0755 0 0 /usr/bin/pathchk.coreutils
+l 0777 0 0 /usr/bin/pgrep -> /usr/bin/pgrep.procps
+f 0755 0 0 /usr/bin/pgrep.procps
+f 0755 0 0 /usr/bin/pidwait
+l 0777 0 0 /usr/bin/pinky -> /usr/bin/pinky.coreutils
+f 0755 0 0 /usr/bin/pinky.coreutils
+f 0755 0 0 /usr/bin/pipesz
+l 0777 0 0 /usr/bin/pkill -> /usr/bin/pkill.procps
+f 0755 0 0 /usr/bin/pkill.procps
+l 0777 0 0 /usr/bin/pmap -> /usr/bin/pmap.procps
+f 0755 0 0 /usr/bin/pmap.procps
+l 0777 0 0 /usr/bin/pr -> /usr/bin/pr.coreutils
+f 0755 0 0 /usr/bin/pr.coreutils
+f 0755 0 0 /usr/bin/printenv.coreutils
+l 0777 0 0 /usr/bin/printf -> /usr/bin/printf.coreutils
+f 0755 0 0 /usr/bin/printf.coreutils
+l 0777 0 0 /usr/bin/prlimit -> /usr/bin/prlimit.util-linux
+f 0755 0 0 /usr/bin/prlimit.util-linux
+l 0777 0 0 /usr/bin/ptx -> /usr/bin/ptx.coreutils
+f 0755 0 0 /usr/bin/ptx.coreutils
+f 0755 0 0 /usr/bin/pv-appengine
+f 0755 0 0 /usr/bin/pv-xconnect
+f 0755 0 0 /usr/bin/pvcontrol
+f 0755 0 0 /usr/bin/pvcurl
+f 0755 0 0 /usr/bin/pventer
+f 0755 0 0 /usr/bin/pvr
+f 0755 0 0 /usr/bin/pvtest-run
+f 0755 0 0 /usr/bin/pvtx
+l 0777 0 0 /usr/bin/pwdx -> /usr/bin/pwdx.procps
+f 0755 0 0 /usr/bin/pwdx.procps
+f 0755 0 0 /usr/bin/readbootlog
+l 0777 0 0 /usr/bin/readlink -> /usr/bin/readlink.coreutils
+f 0755 0 0 /usr/bin/readlink.coreutils
+l 0777 0 0 /usr/bin/realpath -> /usr/bin/realpath.coreutils
+f 0755 0 0 /usr/bin/realpath.coreutils
+f 0755 0 0 /usr/bin/rename
+l 0777 0 0 /usr/bin/renice -> /usr/bin/renice.util-linux
+f 0755 0 0 /usr/bin/renice.util-linux
+l 0777 0 0 /usr/bin/reset -> /bin/busybox
+l 0777 0 0 /usr/bin/resize -> /bin/busybox
+l 0777 0 0 /usr/bin/rev -> /usr/bin/rev.util-linux
+f 0755 0 0 /usr/bin/rev.util-linux
+l 0777 0 0 /usr/bin/rpcinfo -> /usr/bin/rpcinfo.rpcbind
+f 0755 0 0 /usr/bin/rpcinfo.rpcbind
+f 0755 0 0 /usr/bin/runc
+l 0777 0 0 /usr/bin/runcon -> /usr/bin/runcon.coreutils
+f 0755 0 0 /usr/bin/runcon.coreutils
+f 0755 0 0 /usr/bin/script
+f 0755 0 0 /usr/bin/scriptlive
+l 0777 0 0 /usr/bin/scriptreplay -> /usr/bin/scriptreplay.util-linux
+f 0755 0 0 /usr/bin/scriptreplay.util-linux
+l 0777 0 0 /usr/bin/seq -> /usr/bin/seq.coreutils
+f 0755 0 0 /usr/bin/seq.coreutils
+f 0755 0 0 /usr/bin/setarch
+l 0777 0 0 /usr/bin/setpriv -> /usr/bin/setpriv.util-linux
+f 0755 0 0 /usr/bin/setpriv.util-linux
+l 0777 0 0 /usr/bin/setsid -> /usr/bin/setsid.util-linux
+f 0755 0 0 /usr/bin/setsid.util-linux
+f 0755 0 0 /usr/bin/setterm
+l 0777 0 0 /usr/bin/sg -> newgrp.shadow
+l 0777 0 0 /usr/bin/sha1sum -> /usr/bin/sha1sum.coreutils
+f 0755 0 0 /usr/bin/sha1sum.coreutils
+l 0777 0 0 /usr/bin/sha224sum -> /usr/bin/sha224sum.coreutils
+f 0755 0 0 /usr/bin/sha224sum.coreutils
+l 0777 0 0 /usr/bin/sha256sum -> /usr/bin/sha256sum.coreutils
+f 0755 0 0 /usr/bin/sha256sum.coreutils
+l 0777 0 0 /usr/bin/sha384sum -> /usr/bin/sha384sum.coreutils
+f 0755 0 0 /usr/bin/sha384sum.coreutils
+l 0777 0 0 /usr/bin/sha512sum -> /usr/bin/sha512sum.coreutils
+f 0755 0 0 /usr/bin/sha512sum.coreutils
+l 0777 0 0 /usr/bin/shred -> /usr/bin/shred.coreutils
+f 0755 0 0 /usr/bin/shred.coreutils
+l 0777 0 0 /usr/bin/shuf -> /usr/bin/shuf.coreutils
+f 0755 0 0 /usr/bin/shuf.coreutils
+l 0777 0 0 /usr/bin/skill -> /usr/bin/skill.procps
+f 0755 0 0 /usr/bin/skill.procps
+f 0755 0 0 /usr/bin/slabtop
+l 0777 0 0 /usr/bin/snice -> /usr/bin/snice.procps
+f 0755 0 0 /usr/bin/snice.procps
+l 0777 0 0 /usr/bin/sort -> /usr/bin/sort.coreutils
+f 0755 0 0 /usr/bin/sort.coreutils
+l 0777 0 0 /usr/bin/split -> /usr/bin/split.coreutils
+f 0755 0 0 /usr/bin/split.coreutils
+f 0755 0 0 /usr/bin/stdbuf
+l 0777 0 0 /usr/bin/strings -> /bin/busybox
+l 0777 0 0 /usr/bin/sum -> /usr/bin/sum.coreutils
+f 0755 0 0 /usr/bin/sum.coreutils
+l 0777 0 0 /usr/bin/tac -> /usr/bin/tac.coreutils
+f 0755 0 0 /usr/bin/tac.coreutils
+l 0777 0 0 /usr/bin/tail -> /usr/bin/tail.coreutils
+f 0755 0 0 /usr/bin/tail.coreutils
+l 0777 0 0 /usr/bin/taskset -> /usr/bin/taskset.util-linux
+f 0755 0 0 /usr/bin/taskset.util-linux
+l 0777 0 0 /usr/bin/tee -> /usr/bin/tee.coreutils
+f 0755 0 0 /usr/bin/tee.coreutils
+l 0777 0 0 /usr/bin/telnet -> /bin/busybox
+l 0777 0 0 /usr/bin/test -> /usr/bin/test.coreutils
+f 0755 0 0 /usr/bin/test.coreutils
+l 0777 0 0 /usr/bin/tftp -> /bin/busybox
+l 0777 0 0 /usr/bin/time -> /bin/busybox
+l 0777 0 0 /usr/bin/timeout -> /usr/bin/timeout.coreutils
+f 0755 0 0 /usr/bin/timeout.coreutils
+f 0755 0 0 /usr/bin/tload
+l 0777 0 0 /usr/bin/top -> /usr/bin/top.procps
+f 0755 0 0 /usr/bin/top.procps
+l 0777 0 0 /usr/bin/tr -> /usr/bin/tr.coreutils
+f 0755 0 0 /usr/bin/tr.coreutils
+l 0777 0 0 /usr/bin/traceroute -> /bin/busybox
+l 0777 0 0 /usr/bin/truncate -> /usr/bin/truncate.coreutils
+f 0755 0 0 /usr/bin/truncate.coreutils
+l 0777 0 0 /usr/bin/ts -> /bin/busybox
+l 0777 0 0 /usr/bin/tsort -> /usr/bin/tsort.coreutils
+f 0755 0 0 /usr/bin/tsort.coreutils
+l 0777 0 0 /usr/bin/tty -> /usr/bin/tty.coreutils
+f 0755 0 0 /usr/bin/tty.coreutils
+f 0755 0 0 /usr/bin/uclampset
+f 0755 0 0 /usr/bin/udevadm
+f 0755 0 0 /usr/bin/ul
+l 0777 0 0 /usr/bin/uname26 -> setarch
+l 0777 0 0 /usr/bin/unexpand -> /usr/bin/unexpand.coreutils
+f 0755 0 0 /usr/bin/unexpand.coreutils
+l 0777 0 0 /usr/bin/uniq -> /usr/bin/uniq.coreutils
+f 0755 0 0 /usr/bin/uniq.coreutils
+l 0777 0 0 /usr/bin/unlink -> /usr/bin/unlink.coreutils
+f 0755 0 0 /usr/bin/unlink.coreutils
+l 0777 0 0 /usr/bin/unshare -> /usr/bin/unshare.util-linux
+f 0755 0 0 /usr/bin/unshare.util-linux
+l 0777 0 0 /usr/bin/unzip -> /bin/busybox
+f 0755 0 0 /usr/bin/update-alternatives
+l 0777 0 0 /usr/bin/uptime -> /usr/bin/uptime.procps
+f 0755 0 0 /usr/bin/uptime.coreutils
+f 0755 0 0 /usr/bin/uptime.procps
+l 0777 0 0 /usr/bin/users -> /usr/bin/users.coreutils
+f 0755 0 0 /usr/bin/users.coreutils
+l 0777 0 0 /usr/bin/utmpdump -> /usr/bin/utmpdump.sysvinit
+f 0755 0 0 /usr/bin/utmpdump.sysvinit
+f 0755 0 0 /usr/bin/utmpdump.util-linux
+l 0777 0 0 /usr/bin/uuidgen -> /usr/bin/uuidgen.util-linux
+f 0755 0 0 /usr/bin/uuidgen.util-linux
+f 0755 0 0 /usr/bin/uuidparse
+f 0755 0 0 /usr/bin/valgrind
+f 0755 0 0 /usr/bin/valgrind-di-server
+f 0755 0 0 /usr/bin/valgrind-listener
+l 0777 0 0 /usr/bin/vdir -> /usr/bin/vdir.coreutils
+f 0755 0 0 /usr/bin/vdir.coreutils
+f 0755 0 0 /usr/bin/vgdb
+l 0777 0 0 /usr/bin/vlock -> /bin/busybox
+f 0755 0 0 /usr/bin/vmstat
+l 0777 0 0 /usr/bin/w -> /usr/bin/w.procps
+f 0755 0 0 /usr/bin/w.procps
+f 0755 0 0 /usr/bin/waitpid
+l 0777 0 0 /usr/bin/wall -> /usr/bin/wall.sysvinit
+f 0755 0 0 /usr/bin/wall.sysvinit
+f 0755 0 0 /usr/bin/wall.util-linux
+l 0777 0 0 /usr/bin/wc -> /usr/bin/wc.coreutils
+f 0755 0 0 /usr/bin/wc.coreutils
+f 0755 0 0 /usr/bin/wdctl
+l 0777 0 0 /usr/bin/wget -> /bin/busybox
+f 0755 0 0 /usr/bin/whereis
+l 0777 0 0 /usr/bin/which -> /bin/busybox
+l 0777 0 0 /usr/bin/who -> /usr/bin/who.coreutils
+f 0755 0 0 /usr/bin/who.coreutils
+l 0777 0 0 /usr/bin/whoami -> /usr/bin/whoami.coreutils
+f 0755 0 0 /usr/bin/whoami.coreutils
+f 0755 0 0 /usr/bin/write
+l 0777 0 0 /usr/bin/x86_64 -> setarch
+l 0777 0 0 /usr/bin/xargs -> /bin/busybox
+l 0777 0 0 /usr/bin/xxd -> /usr/bin/xxd.vim
+f 0755 0 0 /usr/bin/xxd.vim
+l 0777 0 0 /usr/bin/xzcat -> /bin/busybox
+l 0777 0 0 /usr/bin/yes -> /usr/bin/yes.coreutils
+f 0755 0 0 /usr/bin/yes.coreutils
+d 0755 0 0 /usr/games
+d 0755 0 0 /usr/include
+d 0755 0 0 /usr/lib
+d 0755 0 0 /usr/lib/audit
+d 0755 0 0 /usr/lib/audit/.debug
+f 0755 0 0 /usr/lib/audit/.debug/sotruss-lib.so
+d 0755 0 0 /usr/lib/coreutils
+f 0755 0 0 /usr/lib/coreutils/libstdbuf.so
+f 0755 0 0 /usr/lib/e2initrd_helper
+l 0777 0 0 /usr/lib/libX11.so.6 -> libX11.so.6.4.0
+f 0755 0 0 /usr/lib/libX11.so.6.4.0
+l 0777 0 0 /usr/lib/libXau.so.6 -> libXau.so.6.0.0
+f 0755 0 0 /usr/lib/libXau.so.6.0.0
+l 0777 0 0 /usr/lib/libXdmcp.so.6 -> libXdmcp.so.6.0.0
+f 0755 0 0 /usr/lib/libXdmcp.so.6.0.0
+l 0777 0 0 /usr/lib/libacl.so.1 -> libacl.so.1.1.2302
+f 0755 0 0 /usr/lib/libacl.so.1.1.2302
+l 0777 0 0 /usr/lib/libattr.so.1 -> libattr.so.1.1.2501
+f 0755 0 0 /usr/lib/libattr.so.1.1.2501
+l 0777 0 0 /usr/lib/libavahi-common.so.3 -> libavahi-common.so.3.5.4
+f 0755 0 0 /usr/lib/libavahi-common.so.3.5.4
+l 0777 0 0 /usr/lib/libavahi-core.so.7 -> libavahi-core.so.7.1.0
+f 0755 0 0 /usr/lib/libavahi-core.so.7.1.0
+l 0777 0 0 /usr/lib/libbsd.so.0 -> libbsd.so.0.12.1
+f 0755 0 0 /usr/lib/libbsd.so.0.12.1
+l 0777 0 0 /usr/lib/libcrypt.so.2 -> libcrypt.so.2.0.0
+f 0755 0 0 /usr/lib/libcrypt.so.2.0.0
+f 0755 0 0 /usr/lib/libcrypto.so.3
+l 0777 0 0 /usr/lib/libcryptsetup.so.12 -> libcryptsetup.so.12.10.0
+f 0755 0 0 /usr/lib/libcryptsetup.so.12.10.0
+l 0777 0 0 /usr/lib/libcurl.so.4 -> libcurl.so.4.8.0
+f 0755 0 0 /usr/lib/libcurl.so.4.8.0
+l 0777 0 0 /usr/lib/libdaemon.so.0 -> libdaemon.so.0.5.0
+f 0755 0 0 /usr/lib/libdaemon.so.0.5.0
+l 0777 0 0 /usr/lib/libdbus-1.so.3 -> libdbus-1.so.3.32.4
+f 0755 0 0 /usr/lib/libdbus-1.so.3.32.4
+f 0555 0 0 /usr/lib/libdevmapper.so.1.02
+l 0777 0 0 /usr/lib/libdrop_ambient.so.0 -> libdrop_ambient.so.0.0.0
+f 0755 0 0 /usr/lib/libdrop_ambient.so.0.0.0
+l 0777 0 0 /usr/lib/libexpat.so.1 -> libexpat.so.1.10.0
+f 0755 0 0 /usr/lib/libexpat.so.1.10.0
+l 0777 0 0 /usr/lib/libgmp.so.10 -> libgmp.so.10.5.0
+f 0755 0 0 /usr/lib/libgmp.so.10.5.0
+l 0777 0 0 /usr/lib/libhistory.so.8 -> libhistory.so.8.2
+f 0755 0 0 /usr/lib/libhistory.so.8.2
+l 0777 0 0 /usr/lib/libidn2.so.0 -> libidn2.so.0.4.0
+f 0755 0 0 /usr/lib/libidn2.so.0.4.0
+l 0777 0 0 /usr/lib/libjq.so.1 -> libjq.so.1.0.4
+f 0755 0 0 /usr/lib/libjq.so.1.0.4
+l 0777 0 0 /usr/lib/libjson-c.so.5 -> libjson-c.so.5.3.0
+f 0755 0 0 /usr/lib/libjson-c.so.5.3.0
+l 0777 0 0 /usr/lib/libkcapi.so.1 -> libkcapi.so.1.5.0
+f 0755 0 0 /usr/lib/libkcapi.so.1.5.0
+l 0777 0 0 /usr/lib/libkmod.so.2 -> libkmod.so.2.4.1
+f 0755 0 0 /usr/lib/libkmod.so.2.4.1
+l 0777 0 0 /usr/lib/liblxc.so.1 -> liblxc.so.1.8.0
+f 0755 0 0 /usr/lib/liblxc.so.1.8.0
+l 0777 0 0 /usr/lib/liblzma.so.5 -> liblzma.so.5.4.7
+f 0755 0 0 /usr/lib/liblzma.so.5.4.7
+f 0644 0 0 /usr/lib/libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedcrypto.so.7 -> libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedtls.so.14 -> libmbedtls.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedtls.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedx509.so.1 -> libmbedx509.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedx509.so.2.28.10
+l 0777 0 0 /usr/lib/libmd.so.0 -> libmd.so.0.1.0
+f 0755 0 0 /usr/lib/libmd.so.0.1.0
+l 0777 0 0 /usr/lib/libnl-3.so.200 -> libnl-3.so.200.26.0
+f 0755 0 0 /usr/lib/libnl-3.so.200.26.0
+l 0777 0 0 /usr/lib/libnl-genl-3.so.200 -> libnl-genl-3.so.200.26.0
+f 0755 0 0 /usr/lib/libnl-genl-3.so.200.26.0
+l 0777 0 0 /usr/lib/libonig.so.5 -> libonig.so.5.4.0
+f 0755 0 0 /usr/lib/libonig.so.5.4.0
+l 0777 0 0 /usr/lib/libpopt.so.0 -> libpopt.so.0.0.2
+f 0755 0 0 /usr/lib/libpopt.so.0.0.2
+l 0777 0 0 /usr/lib/libproc2.so.0 -> libproc2.so.0.0.2
+f 0755 0 0 /usr/lib/libproc2.so.0.0.2
+l 0777 0 0 /usr/lib/libpsx.so.2 -> libpsx.so.2.69
+f 0755 0 0 /usr/lib/libpsx.so.2.69
+l 0777 0 0 /usr/lib/libreadline.so.8 -> libreadline.so.8.2
+f 0755 0 0 /usr/lib/libreadline.so.8.2
+f 0755 0 0 /usr/lib/libssl.so.3
+l 0777 0 0 /usr/lib/libsubid.so.4 -> libsubid.so.4.0.0
+f 0755 0 0 /usr/lib/libsubid.so.4.0.0
+l 0777 0 0 /usr/lib/libtirpc.so.3 -> libtirpc.so.3.0.0
+f 0755 0 0 /usr/lib/libtirpc.so.3.0.0
+l 0777 0 0 /usr/lib/libunistring.so.5 -> libunistring.so.5.1.0
+f 0755 0 0 /usr/lib/libunistring.so.5.1.0
+l 0777 0 0 /usr/lib/libuuid.so.1 -> libuuid.so.1.3.0
+f 0755 0 0 /usr/lib/libuuid.so.1.3.0
+l 0777 0 0 /usr/lib/libxcb.so.1 -> libxcb.so.1.1.0
+f 0755 0 0 /usr/lib/libxcb.so.1.1.0
+l 0777 0 0 /usr/lib/libz.so.1 -> libz.so.1.3.1
+f 0755 0 0 /usr/lib/libz.so.1.3.1
+d 0755 0 0 /usr/lib/locale
+f 0644 0 0 /usr/lib/locale/locale-archive
+d 0755 0 0 /usr/lib/lxc
+d 0755 0 0 /usr/lib/lxc/rootfs
+f 0644 0 0 /usr/lib/lxc/rootfs/README
+d 0755 0 0 /usr/lib/ossl-modules
+f 0755 0 0 /usr/lib/ossl-modules/legacy.so
+d 0755 0 0 /usr/lib/pantavisor
+d 0755 0 0 /usr/lib/pantavisor/pv
+f 0755 0 0 /usr/lib/pantavisor/pv/JSON.sh
+d 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/export.sh
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/remount
+f 0755 0 0 /usr/lib/pantavisor/pv/pvcrash
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt/crypt
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity/dm
+f 0755 0 0 /usr/lib/pantavisor/pv_lxc.so
+d 0755 0 0 /usr/lib/pantavisor/skel
+d 0755 0 0 /usr/lib/pantavisor/skel/boot
+d 0755 0 0 /usr/lib/pantavisor/skel/config
+d 0755 0 0 /usr/lib/pantavisor/skel/disks
+d 0755 0 0 /usr/lib/pantavisor/skel/objects
+d 0755 0 0 /usr/lib/pantavisor/skel/trails
+d 0755 0 0 /usr/lib/pantavisor/skel/trails/0
+d 0755 0 0 /usr/lib/pantavisor/skel/trails/0/.pv
+d 0755 0 0 /usr/lib/pantavisor/skel/trails/0/.pvr
+f 0644 0 0 /usr/lib/pantavisor/skel/trails/0/.pvr/json
+d 0755 0 0 /usr/lib/ssl-3
+l 0777 0 0 /usr/lib/ssl-3/certs -> ../../../etc/ssl/certs
+f 0644 0 0 /usr/lib/ssl-3/ct_log_list.cnf
+f 0644 0 0 /usr/lib/ssl-3/ct_log_list.cnf.dist
+l 0777 0 0 /usr/lib/ssl-3/openssl.cnf -> ../../../etc/ssl/openssl.cnf
+f 0644 0 0 /usr/lib/ssl-3/openssl.cnf.dist
+l 0777 0 0 /usr/lib/ssl-3/private -> ../../../etc/ssl/private
+d 0755 0 0 /usr/lib/systemd
+d 0755 0 0 /usr/lib/systemd/user
+f 0644 0 0 /usr/lib/systemd/user/dbus.service
+f 0644 0 0 /usr/lib/systemd/user/dbus.socket
+d 0755 0 0 /usr/lib/systemd/user/sockets.target.wants
+l 0777 0 0 /usr/lib/systemd/user/sockets.target.wants/dbus.socket -> ../dbus.socket
+d 0755 0 0 /usr/libexec
+f 4755 0 999 /usr/libexec/dbus-daemon-launch-helper
+d 0755 0 0 /usr/libexec/lxc
+d 0755 0 0 /usr/libexec/lxc/hooks
+f 0755 0 0 /usr/libexec/lxc/hooks/unmount-namespace
+f 0755 0 0 /usr/libexec/lxc/lxc-monitord
+f 4755 0 0 /usr/libexec/lxc/lxc-user-nic
+d 0755 0 0 /usr/libexec/valgrind
+f 0644 0 0 /usr/libexec/valgrind/32bit-core-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-core-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-core.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-linux-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-linux-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-sse-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-sse-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/32bit-sse.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-avx-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-avx-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-avx.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-core-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-core-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-core.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-linux-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-linux-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-sse-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-sse-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/64bit-sse.xml
+f 0644 0 0 /usr/libexec/valgrind/amd64-avx-coresse-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/amd64-avx-coresse.xml
+f 0644 0 0 /usr/libexec/valgrind/amd64-avx-linux-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/amd64-avx-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/amd64-coresse-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/amd64-linux-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-core-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-core-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-core.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-vfpv3-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-vfpv3-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-vfpv3.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-with-vfpv3-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/arm-with-vfpv3.xml
+f 0755 0 0 /usr/libexec/valgrind/cachegrind-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/callgrind-amd64-linux
+f 0644 0 0 /usr/libexec/valgrind/default.supp
+f 0644 0 0 /usr/libexec/valgrind/dh_view.css
+f 0644 0 0 /usr/libexec/valgrind/dh_view.html
+f 0644 0 0 /usr/libexec/valgrind/dh_view.js
+f 0755 0 0 /usr/libexec/valgrind/dhat-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/drd-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/exp-bbv-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/getoff-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/helgrind-amd64-linux
+f 0644 0 0 /usr/libexec/valgrind/i386-coresse-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/i386-linux-valgrind.xml
+f 0755 0 0 /usr/libexec/valgrind/lackey-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/massif-amd64-linux
+f 0755 0 0 /usr/libexec/valgrind/memcheck-amd64-linux
+f 0644 0 0 /usr/libexec/valgrind/mips-cp0-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-cp0-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-cp0.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-cpu-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-cpu-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-cpu.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-fpu-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-fpu-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-fpu.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-linux-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/mips-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-cp0-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-cp0-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-cp0.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-cpu-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-cpu-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-cpu.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-fpu-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-fpu-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-fpu.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-linux-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/mips64-linux.xml
+f 0755 0 0 /usr/libexec/valgrind/none-amd64-linux
+f 0644 0 0 /usr/libexec/valgrind/power-altivec-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power-altivec-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power-altivec.xml
+f 0644 0 0 /usr/libexec/valgrind/power-core-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power-core-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power-core.xml
+f 0644 0 0 /usr/libexec/valgrind/power-fpu-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power-fpu-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power-fpu.xml
+f 0644 0 0 /usr/libexec/valgrind/power-linux-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power-linux-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/power-vsx-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power-vsx-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power-vsx.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-core-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-core-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-core.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-core2-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-core2-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-linux-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-linux-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/power64-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/powerpc-altivec32l-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/powerpc-altivec32l.xml
+f 0644 0 0 /usr/libexec/valgrind/powerpc-altivec64l-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/powerpc-altivec64l.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-acr-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-acr-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-acr.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-fpr-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-fpr-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-fpr.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-vx-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-vx-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/s390-vx.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-core64-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-core64-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-core64.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-generic-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-generic.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-linux64-valgrind-s1.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-linux64-valgrind-s2.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-linux64.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-vx-linux-valgrind.xml
+f 0644 0 0 /usr/libexec/valgrind/s390x-vx-linux.xml
+f 0644 0 0 /usr/libexec/valgrind/valgrind-monitor-def.py
+f 0644 0 0 /usr/libexec/valgrind/valgrind-monitor.py
+f 0755 0 0 /usr/libexec/valgrind/vgpreload_core-amd64-linux.so
+f 0755 0 0 /usr/libexec/valgrind/vgpreload_dhat-amd64-linux.so
+f 0755 0 0 /usr/libexec/valgrind/vgpreload_drd-amd64-linux.so
+f 0755 0 0 /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so
+f 0755 0 0 /usr/libexec/valgrind/vgpreload_massif-amd64-linux.so
+f 0755 0 0 /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so
+d 0755 0 0 /usr/sbin
+d 0755 0 0 /usr/sbin/.debug
+f 0755 0 0 /usr/sbin/.debug/iconvconfig
+f 0755 0 0 /usr/sbin/.debug/nscd
+f 0755 0 0 /usr/sbin/.debug/zic
+l 0777 0 0 /usr/sbin/addgroup -> /bin/busybox
+f 0755 0 0 /usr/sbin/addpart
+l 0777 0 0 /usr/sbin/adduser -> /bin/busybox
+f 0755 0 0 /usr/sbin/avahi-daemon
+f 0755 0 0 /usr/sbin/blkdiscard
+f 0755 0 0 /usr/sbin/blkpr
+f 0755 0 0 /usr/sbin/blkzone
+f 0755 0 0 /usr/sbin/chcpu
+f 0755 0 0 /usr/sbin/chgpasswd
+l 0777 0 0 /usr/sbin/chpasswd -> /usr/sbin/chpasswd.shadow
+f 0755 0 0 /usr/sbin/chpasswd.shadow
+l 0777 0 0 /usr/sbin/chroot -> /usr/sbin/chroot.coreutils
+f 0755 0 0 /usr/sbin/chroot.coreutils
+f 0755 0 0 /usr/sbin/cryptsetup
+l 0777 0 0 /usr/sbin/delgroup -> /bin/busybox
+f 0755 0 0 /usr/sbin/delpart
+l 0777 0 0 /usr/sbin/deluser -> /bin/busybox
+f 0555 0 0 /usr/sbin/dmsetup
+l 0777 0 0 /usr/sbin/dmstats -> dmsetup
+l 0777 0 0 /usr/sbin/fbset -> /bin/busybox
+l 0777 0 0 /usr/sbin/findfs -> /usr/sbin/findfs.util-linux
+f 0755 0 0 /usr/sbin/findfs.util-linux
+f 0755 0 0 /usr/sbin/fsck.cramfs
+l 0777 0 0 /usr/sbin/fsfreeze -> /usr/sbin/fsfreeze.util-linux
+f 0755 0 0 /usr/sbin/fsfreeze.util-linux
+f 0755 0 0 /usr/sbin/groupadd
+f 0755 0 0 /usr/sbin/groupdel
+f 0755 0 0 /usr/sbin/groupmems
+f 0755 0 0 /usr/sbin/groupmod
+f 0755 0 0 /usr/sbin/grpck
+f 0755 0 0 /usr/sbin/grpconv
+f 0755 0 0 /usr/sbin/grpunconv
+f 0755 0 0 /usr/sbin/hostapd
+f 0755 0 0 /usr/sbin/hostapd_cli
+f 0755 0 0 /usr/sbin/init.lxc
+f 0755 0 0 /usr/sbin/init.lxc.static
+f 0755 0 0 /usr/sbin/integritysetup
+f 0755 0 0 /usr/sbin/iw
+f 0755 0 0 /usr/sbin/ldattach
+l 0777 0 0 /usr/sbin/loadfont -> /bin/busybox
+f 0755 0 0 /usr/sbin/logoutd
+f 0755 0 0 /usr/sbin/mkfs
+f 0755 0 0 /usr/sbin/mkfs.cramfs
+f 0755 0 0 /usr/sbin/newusers
+f 0755 0 0 /usr/sbin/partx
+f 0755 0 0 /usr/sbin/pwck
+f 0755 0 0 /usr/sbin/pwconv
+f 0755 0 0 /usr/sbin/pwunconv
+l 0777 0 0 /usr/sbin/rdate -> /bin/busybox
+l 0777 0 0 /usr/sbin/readprofile -> /usr/sbin/readprofile.util-linux
+f 0755 0 0 /usr/sbin/readprofile.util-linux
+f 0755 0 0 /usr/sbin/resizepart
+l 0777 0 0 /usr/sbin/rfkill -> /usr/sbin/rfkill.util-linux
+f 0755 0 0 /usr/sbin/rfkill.util-linux
+f 0755 0 0 /usr/sbin/rpcbind
+l 0777 0 0 /usr/sbin/rtcwake -> /usr/sbin/rtcwake.util-linux
+f 0755 0 0 /usr/sbin/rtcwake.util-linux
+f 0755 0 0 /usr/sbin/service
+f 0755 0 0 /usr/sbin/sfdisk
+f 0755 0 0 /usr/sbin/swaplabel
+f 0755 0 0 /usr/sbin/ttyrun
+l 0777 0 0 /usr/sbin/udhcpd -> /bin/busybox
+f 0755 0 0 /usr/sbin/update-ca-certificates
+f 0755 0 0 /usr/sbin/update-rc.d
+f 0755 0 0 /usr/sbin/useradd
+f 0755 0 0 /usr/sbin/userdel
+f 0755 0 0 /usr/sbin/usermod
+f 0755 0 0 /usr/sbin/uuidd
+f 0755 0 0 /usr/sbin/veritysetup
+f 0755 0 0 /usr/sbin/wipefs
+f 0755 0 0 /usr/sbin/zramctl
+d 0755 0 0 /usr/share
+d 0755 0 0 /usr/share/X11
+f 0644 0 0 /usr/share/X11/XErrorDB
+f 0644 0 0 /usr/share/X11/Xcms.txt
+d 0755 0 0 /usr/share/avahi
+f 0644 0 0 /usr/share/avahi/avahi-service.dtd
+d 0755 0 0 /usr/share/ca-certificates
+d 0755 0 0 /usr/share/ca-certificates/mozilla
+f 0644 0 0 /usr/share/ca-certificates/mozilla/ACCVRAIZ1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM_SERVIDORES_SEGUROS.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/ANF_Secure_Server_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Actalis_Authentication_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/AffirmTrust_Commercial.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/AffirmTrust_Networking.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/AffirmTrust_Premium.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/AffirmTrust_Premium_ECC.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Amazon_Root_CA_1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Amazon_Root_CA_2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Amazon_Root_CA_3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Amazon_Root_CA_4.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Atos_TrustedRoot_2011.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Atos_TrustedRoot_Root_CA_ECC_TLS_2021.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Atos_TrustedRoot_Root_CA_RSA_TLS_2021.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/BJCA_Global_Root_CA1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/BJCA_Global_Root_CA2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Baltimore_CyberTrust_Root.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Buypass_Class_2_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Buypass_Class_3_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/CA_Disig_Root_R2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/CFCA_EV_ROOT.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/COMODO_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/COMODO_ECC_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/COMODO_RSA_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certainly_Root_E1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certainly_Root_R1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certigna.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certigna_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certum_EC-384_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA_2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Certum_Trusted_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/CommScope_Public_Trust_ECC_Root-01.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/CommScope_Public_Trust_ECC_Root-02.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/CommScope_Public_Trust_RSA_Root-01.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/CommScope_Public_Trust_RSA_Root-02.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Comodo_AAA_Services_root.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/D-TRUST_BR_Root_CA_1_2020.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/D-TRUST_BR_Root_CA_2_2023.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/D-TRUST_EV_Root_CA_1_2020.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/D-TRUST_EV_Root_CA_2_2023.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Global_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Global_Root_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Global_Root_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_High_Assurance_EV_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_TLS_ECC_P384_Root_G5.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_TLS_RSA4096_Root_G5.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/DigiCert_Trusted_Root_G4.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Entrust.net_Premium_2048_Secure_Server_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_EC1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/FIRMAPROFESIONAL_CA_ROOT-A_WEB.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GDCA_TrustAUTH_R5_ROOT.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GLOBALTRUST_2020.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GTS_Root_R1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GTS_Root_R2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GTS_Root_R3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GTS_Root_R4.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_ECC_Root_CA_-_R4.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_ECC_Root_CA_-_R5.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R6.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_Root_E46.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/GlobalSign_Root_R46.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Go_Daddy_Class_2_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Go_Daddy_Root_Certificate_Authority_-_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/HARICA_TLS_ECC_Root_CA_2021.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/HARICA_TLS_RSA_Root_CA_2021.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/HiPKI_Root_CA_-_G1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Hongkong_Post_Root_CA_3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/ISRG_Root_X2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/IdenTrust_Commercial_Root_CA_1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/IdenTrust_Public_Sector_Root_CA_1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Izenpe.com.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Microsec_e-Szigno_Root_CA_2009.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Microsoft_ECC_Root_Certificate_Authority_2017.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Microsoft_RSA_Root_Certificate_Authority_2017.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/NAVER_Global_Root_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GB_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GC_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_1_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_ECC.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_RSA_R2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_ECC.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_RSA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SSL.com_TLS_ECC_Root_CA_2022.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SSL.com_TLS_RSA_Root_CA_2022.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SZAFIR_ROOT_CA2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Sectigo_Public_Server_Authentication_Root_E46.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Sectigo_Public_Server_Authentication_Root_R46.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SecureSign_Root_CA12.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SecureSign_Root_CA14.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SecureSign_Root_CA15.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SecureTrust_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Secure_Global_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Security_Communication_ECC_RootCA1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Security_Communication_RootCA2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Starfield_Class_2_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Starfield_Root_Certificate_Authority_-_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Starfield_Services_Root_Certificate_Authority_-_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/SwissSign_Gold_CA_-_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TWCA_CYBER_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TWCA_Global_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TWCA_Root_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Telekom_Security_TLS_ECC_Root_2020.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Telekom_Security_TLS_RSA_Root_2023.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TeliaSonera_Root_CA_v1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Telia_Root_CA_v2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TrustAsia_Global_Root_CA_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TrustAsia_Global_Root_CA_G4.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Trustwave_Global_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Trustwave_Global_ECC_P256_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/Trustwave_Global_ECC_P384_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/TunTrust_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/UCA_Extended_Validation_Root.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/UCA_Global_G2_Root.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/USERTrust_ECC_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/USERTrust_RSA_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/XRamp_Global_CA_Root.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/certSIGN_ROOT_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/certSIGN_Root_CA_G2.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/e-Szigno_Root_CA_2017.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/ePKI_Root_Certification_Authority.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/emSign_ECC_Root_CA_-_C3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/emSign_ECC_Root_CA_-_G3.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/emSign_Root_CA_-_C1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/emSign_Root_CA_-_G1.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/vTrus_ECC_Root_CA.crt
+f 0644 0 0 /usr/share/ca-certificates/mozilla/vTrus_Root_CA.crt
+d 0755 0 0 /usr/share/dbus-1
+d 0755 0 0 /usr/share/dbus-1/interfaces
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.AddressResolver.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.DomainBrowser.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.EntryGroup.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.HostNameResolver.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.RecordBrowser.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.Server.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.ServiceBrowser.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.ServiceResolver.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.ServiceTypeBrowser.xml
+d 0755 0 0 /usr/share/dbus-1/services
+f 0644 0 0 /usr/share/dbus-1/session.conf
+d 0755 0 0 /usr/share/dbus-1/session.d
+d 0755 0 0 /usr/share/dbus-1/system-services
+f 0644 0 0 /usr/share/dbus-1/system.conf
+d 0755 0 0 /usr/share/dbus-1/system.d
+d 0755 0 0 /usr/share/dict
+d 0755 0 0 /usr/share/info
+d 0755 0 0 /usr/share/locale
+d 0755 0 0 /usr/share/locale/en_GB
+d 0755 0 0 /usr/share/locale/en_GB/LC_MESSAGES
+f 0644 0 0 /usr/share/locale/en_GB/LC_MESSAGES/avahi.mo
+d 0755 0 0 /usr/share/lxc
+d 0755 0 0 /usr/share/lxc/config
+f 0644 0 0 /usr/share/lxc/config/common.conf
+d 0755 0 0 /usr/share/lxc/config/common.conf.d
+f 0644 0 0 /usr/share/lxc/config/common.conf.d/README
+f 0644 0 0 /usr/share/lxc/config/common.seccomp
+f 0644 0 0 /usr/share/lxc/config/nesting.conf
+f 0644 0 0 /usr/share/lxc/config/oci.common.conf
+f 0644 0 0 /usr/share/lxc/config/userns.conf
+f 0644 0 0 /usr/share/lxc/lxc-patch.py
+f 0644 0 0 /usr/share/lxc/lxc.functions
+d 0755 0 0 /usr/share/man
+d 0755 0 0 /usr/share/misc
+d 0755 0 0 /usr/share/pantavisor
+d 0755 0 0 /usr/share/pantavisor/pvtest
+d 0755 0 0 /usr/share/pantavisor/pvtest/pvtx
+d 0755 0 0 /usr/share/pantavisor/pvtest/pvtx/expected
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state-empty.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_add_from_tar.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_adding_existing.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_install_config_b_remove_config_a.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_install_config_b_remove_config_a_with_glob.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_new_package.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_os_install.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_pvwificonnect.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_remove.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_after_remove_config_pkg.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_bsp_update.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_pvws_with_config.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_pvws_without_config.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/expected/state_queue_process.json
+f 0755 0 0 /usr/share/pantavisor/pvtest/pvtx/pvtx.sh
+d 0755 0 0 /usr/share/pantavisor/pvtest/pvtx/resources
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/awconnect.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/bsp_init.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/bsp_init_groups.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/bsp_update.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/config_a.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/config_a_glob.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/config_b.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/config_b_glob.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/initial_state.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/os.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/pvwificonnect.tgz
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/pvws_with_config.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/pvws_without_config.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/state-1.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/state_with_spaces.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/vaultwarden.json
+f 0644 0 0 /usr/share/pantavisor/pvtest/pvtx/resources/watchdog_pinger.tar
+f 0644 0 0 /usr/share/pantavisor/pvtest/utils
+f 0644 0 0 /usr/share/pantavisor/set-env
+d 0755 0 0 /usr/share/udhcpc
+f 0755 0 0 /usr/share/udhcpc/default.script
+d 0755 0 0 /usr/src
+d 0755 0 0 /var
+d 0755 0 0 /var/backups
+d 0755 0 0 /var/cache
+d 0755 0 0 /var/lib
+d 0755 999 999 /var/lib/dbus
+d 0755 0 0 /var/lib/misc
+d 0755 0 0 /var/lib/urandom
+d 0755 0 0 /var/local
+l 0777 0 0 /var/lock -> ../run/lock
+l 0777 0 0 /var/log -> volatile/log
+d 0755 0 0 /var/pantavisor
+d 0755 0 0 /var/pantavisor/storage
+d 0755 0 0 /var/pantavisor/storage/boot
+d 0755 0 0 /var/pantavisor/storage/config
+d 0755 0 0 /var/pantavisor/storage/disks
+d 0755 0 0 /var/pantavisor/storage/objects
+d 0755 0 0 /var/pantavisor/storage/trails
+d 0755 0 0 /var/pantavisor/storage/trails/0
+d 0755 0 0 /var/pantavisor/storage/trails/0/.pv
+d 0755 0 0 /var/pantavisor/storage/trails/0/.pvr
+f 0644 0 0 /var/pantavisor/storage/trails/0/.pvr/json
+l 0777 0 0 /var/run -> ../run
+d 0755 0 0 /var/spool
+d 0775 0 8 /var/spool/mail
+l 0777 0 0 /var/tmp -> volatile/tmp
+d 0755 0 0 /var/volatile
+d 0755 0 0 /var/volatile/log
+d 1777 0 0 /var/volatile/tmp

--- a/dynamic-layers/virtualization-layer/recipes-pv/images/pv-manifests/pv-appengine_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt
+++ b/dynamic-layers/virtualization-layer/recipes-pv/images/pv-manifests/pv-appengine_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt
@@ -1,0 +1,1196 @@
+# pv-manifest-audit v1
+# format: type mode uid gid path[ -> symlink-target | major,minor]
+# machine: docker-x86_64
+# distro:  panta-appengine (scarthgap)
+# prefix:  pv-appengine
+# exclude: /var/lib/rpm /var/lib/dnf /var/lib/opkg /usr/lib/opkg /var/cache/ldconfig /var/cache/dnf /var/cache/yum
+d 0755 0 0 /bin
+l 0777 0 0 /bin/ash -> /bin/busybox
+l 0777 0 0 /bin/base64 -> /usr/bin/base64.coreutils
+l 0777 0 0 /bin/bash -> /bin/bash.bash
+f 0755 0 0 /bin/bash.bash
+f 4755 0 0 /bin/busybox
+l 0777 0 0 /bin/busybox.nosuid -> busybox
+l 0777 0 0 /bin/cat -> /bin/cat.coreutils
+f 0755 0 0 /bin/cat.coreutils
+l 0777 0 0 /bin/chattr -> /bin/busybox
+l 0777 0 0 /bin/chgrp -> /bin/chgrp.coreutils
+f 0755 0 0 /bin/chgrp.coreutils
+l 0777 0 0 /bin/chmod -> /bin/chmod.coreutils
+f 0755 0 0 /bin/chmod.coreutils
+l 0777 0 0 /bin/chown -> /bin/chown.coreutils
+f 0755 0 0 /bin/chown.coreutils
+l 0777 0 0 /bin/cp -> /bin/cp.coreutils
+f 0755 0 0 /bin/cp.coreutils
+l 0777 0 0 /bin/cpio -> /bin/busybox
+l 0777 0 0 /bin/date -> /bin/date.coreutils
+f 0755 0 0 /bin/date.coreutils
+l 0777 0 0 /bin/dd -> /bin/dd.coreutils
+f 0755 0 0 /bin/dd.coreutils
+l 0777 0 0 /bin/df -> /usr/bin/df.coreutils
+l 0777 0 0 /bin/dmesg -> /bin/dmesg.util-linux
+f 0755 0 0 /bin/dmesg.util-linux
+l 0777 0 0 /bin/dnsdomainname -> /bin/busybox
+l 0777 0 0 /bin/dumpkmap -> /bin/busybox
+l 0777 0 0 /bin/echo -> /bin/echo.coreutils
+f 0755 0 0 /bin/echo.coreutils
+l 0777 0 0 /bin/egrep -> /bin/busybox
+l 0777 0 0 /bin/false -> /bin/false.coreutils
+f 0755 0 0 /bin/false.coreutils
+l 0777 0 0 /bin/fgrep -> /bin/busybox
+l 0777 0 0 /bin/getopt -> /bin/getopt.util-linux
+f 0755 0 0 /bin/getopt.util-linux
+l 0777 0 0 /bin/grep -> /bin/busybox
+l 0777 0 0 /bin/gunzip -> /bin/busybox
+l 0777 0 0 /bin/gzip -> /bin/busybox
+l 0777 0 0 /bin/hostname -> /bin/hostname.coreutils
+f 0755 0 0 /bin/hostname.coreutils
+l 0777 0 0 /bin/kill -> /bin/kill.coreutils
+f 0755 0 0 /bin/kill.coreutils
+f 0755 0 0 /bin/kill.util-linux
+f 0755 0 0 /bin/kmod
+l 0777 0 0 /bin/ln -> /bin/ln.coreutils
+f 0755 0 0 /bin/ln.coreutils
+l 0777 0 0 /bin/login -> /bin/login.shadow
+f 0755 0 0 /bin/login.shadow
+l 0777 0 0 /bin/ls -> /bin/ls.coreutils
+f 0755 0 0 /bin/ls.coreutils
+l 0777 0 0 /bin/lsmod -> /bin/lsmod.kmod
+l 0777 0 0 /bin/lsmod.kmod -> kmod
+l 0777 0 0 /bin/mkdir -> /bin/mkdir.coreutils
+f 0755 0 0 /bin/mkdir.coreutils
+l 0777 0 0 /bin/mknod -> /bin/mknod.coreutils
+f 0755 0 0 /bin/mknod.coreutils
+l 0777 0 0 /bin/mktemp -> /usr/bin/mktemp.coreutils
+l 0777 0 0 /bin/more -> /bin/more.util-linux
+f 0755 0 0 /bin/more.util-linux
+l 0777 0 0 /bin/mount -> /bin/mount.util-linux
+f 4755 0 0 /bin/mount.util-linux
+l 0777 0 0 /bin/mountpoint -> /bin/mountpoint.util-linux
+f 0755 0 0 /bin/mountpoint.sysvinit
+f 0755 0 0 /bin/mountpoint.util-linux
+l 0777 0 0 /bin/mv -> /bin/mv.coreutils
+f 0755 0 0 /bin/mv.coreutils
+l 0777 0 0 /bin/netstat -> /bin/busybox
+l 0777 0 0 /bin/nice -> /usr/bin/nice.coreutils
+l 0777 0 0 /bin/pidof -> /bin/pidof.sysvinit
+l 0777 0 0 /bin/pidof.sysvinit -> /sbin/killall5
+l 0777 0 0 /bin/ping -> /bin/busybox
+l 0777 0 0 /bin/ping6 -> /bin/busybox
+l 0777 0 0 /bin/printenv -> /usr/bin/printenv.coreutils
+l 0777 0 0 /bin/ps -> /bin/busybox
+l 0777 0 0 /bin/pwd -> /bin/pwd.coreutils
+f 0755 0 0 /bin/pwd.coreutils
+l 0777 0 0 /bin/rm -> /bin/rm.coreutils
+f 0755 0 0 /bin/rm.coreutils
+l 0777 0 0 /bin/rmdir -> /bin/rmdir.coreutils
+f 0755 0 0 /bin/rmdir.coreutils
+l 0777 0 0 /bin/run-parts -> /bin/busybox
+l 0777 0 0 /bin/sed -> /bin/busybox
+l 0777 0 0 /bin/sh -> /bin/bash.bash
+l 0777 0 0 /bin/sleep -> /bin/sleep.coreutils
+f 0755 0 0 /bin/sleep.coreutils
+f 0755 0 0 /bin/start_getty
+l 0777 0 0 /bin/stat -> /bin/stat.coreutils
+f 0755 0 0 /bin/stat.coreutils
+l 0777 0 0 /bin/stty -> /bin/stty.coreutils
+f 0755 0 0 /bin/stty.coreutils
+l 0777 0 0 /bin/su -> /bin/su.shadow
+f 4755 0 0 /bin/su.shadow
+l 0777 0 0 /bin/sync -> /bin/sync.coreutils
+f 0755 0 0 /bin/sync.coreutils
+l 0777 0 0 /bin/tar -> /bin/busybox
+l 0777 0 0 /bin/touch -> /bin/touch.coreutils
+f 0755 0 0 /bin/touch.coreutils
+l 0777 0 0 /bin/true -> /bin/true.coreutils
+f 0755 0 0 /bin/true.coreutils
+l 0777 0 0 /bin/umount -> /bin/umount.util-linux
+f 4755 0 0 /bin/umount.util-linux
+l 0777 0 0 /bin/uname -> /bin/uname.coreutils
+f 0755 0 0 /bin/uname.coreutils
+l 0777 0 0 /bin/usleep -> /bin/busybox
+l 0777 0 0 /bin/vi -> /bin/busybox
+l 0777 0 0 /bin/watch -> /bin/busybox
+l 0777 0 0 /bin/zcat -> /bin/busybox
+d 0755 0 0 /boot
+d 0755 0 0 /dev
+d 0755 0 0 /etc
+d 0755 0 0 /etc/avahi
+f 0644 0 0 /etc/avahi/avahi-daemon.conf
+f 0644 0 0 /etc/avahi/hosts
+d 0755 0 0 /etc/avahi/services
+f 0644 0 0 /etc/bindresvport.blacklist
+f 0644 0 0 /etc/busybox.links
+d 0755 0 0 /etc/dbus-1
+f 0644 0 0 /etc/dbus-1/session.conf
+f 0644 0 0 /etc/dbus-1/system.conf
+d 0755 0 0 /etc/dbus-1/system.d
+f 0644 0 0 /etc/dbus-1/system.d/avahi-dbus.conf
+d 0755 0 0 /etc/default
+f 0755 0 0 /etc/default/devpts
+f 0644 0 0 /etc/default/mountall
+f 0644 0 0 /etc/default/rcS
+f 0644 0 0 /etc/default/useradd
+d 0755 0 0 /etc/default/volatiles
+f 0644 0 0 /etc/default/volatiles/00_core
+f 0644 0 0 /etc/default/volatiles/01_bootlogd
+f 0644 0 0 /etc/default/volatiles/99_dbus
+d 0755 0 0 /etc/depmod.d
+d 0755 0 0 /etc/dnf
+f 0644 0 0 /etc/dnf/dnf.conf
+d 0755 0 0 /etc/dnf/modules.d
+d 0755 0 0 /etc/dnf/vars
+f 0644 0 0 /etc/dnf/vars/arch
+f 0644 0 0 /etc/dnf/vars/releasever
+f 0644 0 0 /etc/dnsmasq.conf
+d 0755 0 0 /etc/dnsmasq.d
+f 0644 0 0 /etc/ethertypes
+f 0644 0 0 /etc/fstab
+f 0644 0 0 /etc/group
+f 0644 0 0 /etc/group-
+f 0400 0 0 /etc/gshadow
+f 0400 0 0 /etc/gshadow-
+f 0644 0 0 /etc/host.conf
+f 0644 0 0 /etc/hostapd.conf
+f 0644 0 0 /etc/hostname
+f 0644 0 0 /etc/hosts
+d 0755 0 0 /etc/init.d
+f 0755 0 0 /etc/init.d/avahi-daemon
+f 0755 0 0 /etc/init.d/banner.sh
+f 0755 0 0 /etc/init.d/bootlogd
+f 0755 0 0 /etc/init.d/bootmisc.sh
+f 0755 0 0 /etc/init.d/checkroot.sh
+f 0755 0 0 /etc/init.d/dbus-1
+f 0755 0 0 /etc/init.d/devpts.sh
+f 0755 0 0 /etc/init.d/dmesg.sh
+f 0755 0 0 /etc/init.d/dnsmasq
+f 0644 0 0 /etc/init.d/functions
+f 0755 0 0 /etc/init.d/halt
+f 0755 0 0 /etc/init.d/hostapd
+f 0755 0 0 /etc/init.d/hostname.sh
+f 0755 0 0 /etc/init.d/hwclock.sh
+f 0755 0 0 /etc/init.d/modutils.sh
+f 0755 0 0 /etc/init.d/mountall.sh
+f 0755 0 0 /etc/init.d/mountnfs.sh
+f 0755 0 0 /etc/init.d/networking
+f 0755 0 0 /etc/init.d/populate-volatile.sh
+f 0755 0 0 /etc/init.d/rc
+f 0755 0 0 /etc/init.d/rcS
+f 0755 0 0 /etc/init.d/read-only-rootfs-hook.sh
+f 0755 0 0 /etc/init.d/reboot
+f 0755 0 0 /etc/init.d/rmnologin.sh
+f 0755 0 0 /etc/init.d/rpcbind
+f 0755 0 0 /etc/init.d/save-rtc.sh
+f 0755 0 0 /etc/init.d/sendsigs
+f 0755 0 0 /etc/init.d/single
+l 0777 0 0 /etc/init.d/stop-bootlogd -> bootlogd
+f 0755 0 0 /etc/init.d/sysfs.sh
+f 0755 0 0 /etc/init.d/syslog
+f 0755 0 0 /etc/init.d/udev
+f 0755 0 0 /etc/init.d/umountfs
+f 0755 0 0 /etc/init.d/umountnfs.sh
+f 0755 0 0 /etc/init.d/urandom
+f 0644 0 0 /etc/inittab
+d 0755 0 0 /etc/inittab.d
+f 0644 0 0 /etc/issue
+f 0644 0 0 /etc/issue.net
+f 0644 0 0 /etc/ld.so.conf
+d 0755 0 0 /etc/libnl
+f 0644 0 0 /etc/libnl/classid
+f 0644 0 0 /etc/libnl/pktloc
+f 0644 0 0 /etc/limits
+f 0644 0 0 /etc/login.access
+f 0644 0 0 /etc/login.defs
+f 0644 0 0 /etc/logrotate-dmesg.conf
+d 0755 0 0 /etc/lxc
+f 0644 0 0 /etc/lxc/default.conf
+f 0644 0 0 /etc/mke2fs.conf
+d 0755 0 0 /etc/modprobe.d
+f 0644 0 0 /etc/motd
+l 0777 0 0 /etc/mtab -> /proc/mounts
+f 0644 0 0 /etc/netconfig
+d 0755 0 0 /etc/network
+d 0755 0 0 /etc/network/if-down.d
+d 0755 0 0 /etc/network/if-post-down.d
+d 0755 0 0 /etc/network/if-pre-up.d
+f 0755 0 0 /etc/network/if-pre-up.d/nfsroot
+d 0755 0 0 /etc/network/if-up.d
+f 0644 0 0 /etc/network/interfaces
+f 0644 0 0 /etc/nsswitch.conf
+d 0755 0 0 /etc/pantavisor
+f 0644 0 0 /etc/pantavisor-appengine.config
+d 0755 0 0 /etc/pantavisor/defaults
+f 0644 0 0 /etc/pantavisor/defaults/groups.json
+d 0755 0 0 /etc/pantavisor/policies
+f 0644 0 0 /etc/pantavisor/policies/prod.config
+f 0644 0 0 /etc/pantavisor/policies/test.config
+d 0755 0 0 /etc/pantavisor/pvs
+d 0755 0 0 /etc/pantavisor/pvs/trust
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-certificates.crt
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-oem-certificates.crt
+d 0755 0 0 /etc/pantavisor/ssh
+f 0644 0 0 /etc/pantavisor/ssh/README.ssh
+f 0644 0 0 /etc/passwd
+f 0644 0 0 /etc/passwd-
+f 0644 0 0 /etc/profile
+f 0644 0 0 /etc/protocols
+d 0755 0 0 /etc/rc0.d
+l 0777 0 0 /etc/rc0.d/K19avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc0.d/K20dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc0.d/K20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc0.d/K20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc0.d/K20hwclock.sh -> ../init.d/hwclock.sh
+l 0777 0 0 /etc/rc0.d/K20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc0.d/K31umountnfs.sh -> ../init.d/umountnfs.sh
+l 0777 0 0 /etc/rc0.d/K60rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc0.d/K80networking -> ../init.d/networking
+l 0777 0 0 /etc/rc0.d/S20sendsigs -> ../init.d/sendsigs
+l 0777 0 0 /etc/rc0.d/S25save-rtc.sh -> ../init.d/save-rtc.sh
+l 0777 0 0 /etc/rc0.d/S38urandom -> ../init.d/urandom
+l 0777 0 0 /etc/rc0.d/S40umountfs -> ../init.d/umountfs
+l 0777 0 0 /etc/rc0.d/S90halt -> ../init.d/halt
+d 0755 0 0 /etc/rc1.d
+l 0777 0 0 /etc/rc1.d/K19avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc1.d/K20dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc1.d/K20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc1.d/K20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc1.d/K20hwclock.sh -> ../init.d/hwclock.sh
+l 0777 0 0 /etc/rc1.d/K20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc1.d/K31umountnfs.sh -> ../init.d/umountnfs.sh
+l 0777 0 0 /etc/rc1.d/K60rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc1.d/K80networking -> ../init.d/networking
+d 0755 0 0 /etc/rc2.d
+l 0777 0 0 /etc/rc2.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc2.d/S02dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc2.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc2.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc2.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc2.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc2.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc2.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc2.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc2.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc3.d
+l 0777 0 0 /etc/rc3.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc3.d/S02dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc3.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc3.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc3.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc3.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc3.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc3.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc3.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc3.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc4.d
+l 0777 0 0 /etc/rc4.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc4.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc4.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc4.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc4.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc4.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc4.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc4.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc4.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc5.d
+l 0777 0 0 /etc/rc5.d/S01networking -> ../init.d/networking
+l 0777 0 0 /etc/rc5.d/S02dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc5.d/S12rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc5.d/S15mountnfs.sh -> ../init.d/mountnfs.sh
+l 0777 0 0 /etc/rc5.d/S20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc5.d/S20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc5.d/S20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc5.d/S21avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc5.d/S99rmnologin.sh -> ../init.d/rmnologin.sh
+l 0777 0 0 /etc/rc5.d/S99stop-bootlogd -> ../init.d/stop-bootlogd
+d 0755 0 0 /etc/rc6.d
+l 0777 0 0 /etc/rc6.d/K19avahi-daemon -> ../init.d/avahi-daemon
+l 0777 0 0 /etc/rc6.d/K20dbus-1 -> ../init.d/dbus-1
+l 0777 0 0 /etc/rc6.d/K20dnsmasq -> ../init.d/dnsmasq
+l 0777 0 0 /etc/rc6.d/K20hostapd -> ../init.d/hostapd
+l 0777 0 0 /etc/rc6.d/K20hwclock.sh -> ../init.d/hwclock.sh
+l 0777 0 0 /etc/rc6.d/K20syslog -> ../init.d/syslog
+l 0777 0 0 /etc/rc6.d/K31umountnfs.sh -> ../init.d/umountnfs.sh
+l 0777 0 0 /etc/rc6.d/K60rpcbind -> ../init.d/rpcbind
+l 0777 0 0 /etc/rc6.d/K80networking -> ../init.d/networking
+l 0777 0 0 /etc/rc6.d/S20sendsigs -> ../init.d/sendsigs
+l 0777 0 0 /etc/rc6.d/S25save-rtc.sh -> ../init.d/save-rtc.sh
+l 0777 0 0 /etc/rc6.d/S38urandom -> ../init.d/urandom
+l 0777 0 0 /etc/rc6.d/S40umountfs -> ../init.d/umountfs
+l 0777 0 0 /etc/rc6.d/S90reboot -> ../init.d/reboot
+d 0755 0 0 /etc/rcS.d
+l 0777 0 0 /etc/rcS.d/S02banner.sh -> ../init.d/banner.sh
+l 0777 0 0 /etc/rcS.d/S02sysfs.sh -> ../init.d/sysfs.sh
+l 0777 0 0 /etc/rcS.d/S03mountall.sh -> ../init.d/mountall.sh
+l 0777 0 0 /etc/rcS.d/S04udev -> ../init.d/udev
+l 0777 0 0 /etc/rcS.d/S05checkroot.sh -> ../init.d/checkroot.sh
+l 0777 0 0 /etc/rcS.d/S06devpts.sh -> ../init.d/devpts.sh
+l 0777 0 0 /etc/rcS.d/S06modutils.sh -> ../init.d/modutils.sh
+l 0777 0 0 /etc/rcS.d/S07bootlogd -> ../init.d/bootlogd
+l 0777 0 0 /etc/rcS.d/S29read-only-rootfs-hook.sh -> ../init.d/read-only-rootfs-hook.sh
+l 0777 0 0 /etc/rcS.d/S36bootmisc.sh -> ../init.d/bootmisc.sh
+l 0777 0 0 /etc/rcS.d/S37populate-volatile.sh -> ../init.d/populate-volatile.sh
+l 0777 0 0 /etc/rcS.d/S38dmesg.sh -> ../init.d/dmesg.sh
+l 0777 0 0 /etc/rcS.d/S38urandom -> ../init.d/urandom
+l 0777 0 0 /etc/rcS.d/S39hostname.sh -> ../init.d/hostname.sh
+l 0777 0 0 /etc/rcS.d/S40hwclock.sh -> ../init.d/hwclock.sh
+f 0644 0 0 /etc/resolv.conf
+f 0644 0 0 /etc/rpc
+f 0644 0 0 /etc/rpcbind.conf
+d 0755 0 0 /etc/rpm
+f 0644 0 0 /etc/rpm/macros
+f 0644 0 0 /etc/rpm/platform
+f 0644 0 0 /etc/rpmrc
+f 0400 0 0 /etc/securetty
+f 0644 0 0 /etc/services
+f 0400 0 0 /etc/shadow
+f 0400 0 0 /etc/shadow-
+f 0644 0 0 /etc/shells
+d 0755 0 0 /etc/skel
+f 0755 0 0 /etc/skel/.bashrc
+f 0755 0 0 /etc/skel/.profile
+d 0755 0 0 /etc/ssl
+f 0644 0 0 /etc/ssl/openssl.cnf
+f 0644 0 0 /etc/subgid
+f 0644 0 0 /etc/subuid
+f 0644 0 0 /etc/syslog-startup.conf
+f 0644 0 0 /etc/syslog.conf
+d 0755 0 0 /etc/terminfo
+d 0755 0 0 /etc/terminfo/a
+f 0644 0 0 /etc/terminfo/a/ansi
+d 0755 0 0 /etc/terminfo/d
+f 0644 0 0 /etc/terminfo/d/dumb
+d 0755 0 0 /etc/terminfo/l
+f 0644 0 0 /etc/terminfo/l/linux
+d 0755 0 0 /etc/terminfo/r
+f 0644 0 0 /etc/terminfo/r/rxvt
+d 0755 0 0 /etc/terminfo/s
+f 0644 0 0 /etc/terminfo/s/screen
+f 0644 0 0 /etc/terminfo/s/screen-256color
+f 0644 0 0 /etc/terminfo/s/sun
+d 0755 0 0 /etc/terminfo/v
+f 0644 0 0 /etc/terminfo/v/vt100
+f 0644 0 0 /etc/terminfo/v/vt102
+f 0644 0 0 /etc/terminfo/v/vt200
+f 0644 0 0 /etc/terminfo/v/vt220
+f 0644 0 0 /etc/terminfo/v/vt52
+d 0755 0 0 /etc/terminfo/x
+l 0777 0 0 /etc/terminfo/x/xterm -> xterm-color
+f 0644 0 0 /etc/terminfo/x/xterm-256color
+f 0644 0 0 /etc/terminfo/x/xterm-color
+f 0644 0 0 /etc/terminfo/x/xterm-xfree86
+d 0755 0 0 /etc/thttp
+d 0755 0 0 /etc/thttp/certs
+f 0644 0 0 /etc/thttp/certs/isrg-root-x1-cross-signed.pem
+f 0644 0 0 /etc/thttp/certs/isrgrootx1.pem
+d 0755 0 0 /etc/udev
+d 0755 0 0 /etc/udev/rules.d
+f 0644 0 0 /etc/udev/rules.d/80-net-name-slot.rules
+f 0644 0 0 /etc/udev/rules.d/local.rules
+f 0644 0 0 /etc/udev/udev.conf
+d 0755 0 0 /etc/udhcpc.d
+f 0755 0 0 /etc/udhcpc.d/50default
+f 0644 0 0 /etc/version
+f 0644 0 0 /etc/xattr.conf
+d 0755 0 0 /home
+d 0700 0 0 /home/root
+d 0755 0 0 /lib
+d 0755 0 0 /lib/depmod.d
+f 0644 0 0 /lib/depmod.d/exclude.conf
+f 0644 0 0 /lib/depmod.d/search.conf
+f 0755 0 0 /lib/ld-linux-x86-64.so.2
+f 0755 0 0 /lib/libBrokenLocale.so.1
+f 0755 0 0 /lib/libanl.so.1
+l 0777 0 0 /lib/libblkid.so.1 -> libblkid.so.1.1.0
+f 0755 0 0 /lib/libblkid.so.1.1.0
+f 0755 0 0 /lib/libc.so.6
+l 0777 0 0 /lib/libcap-ng.so.0 -> libcap-ng.so.0.0.0
+f 0755 0 0 /lib/libcap-ng.so.0.0.0
+l 0777 0 0 /lib/libcap.so.2 -> libcap.so.2.69
+f 0755 0 0 /lib/libcap.so.2.69
+l 0777 0 0 /lib/libcom_err.so.2 -> libcom_err.so.2.1
+f 0755 0 0 /lib/libcom_err.so.2.1
+f 0755 0 0 /lib/libdl.so.2
+l 0777 0 0 /lib/libe2p.so.2 -> libe2p.so.2.3
+f 0755 0 0 /lib/libe2p.so.2.3
+l 0777 0 0 /lib/libext2fs.so.2 -> libext2fs.so.2.4
+f 0755 0 0 /lib/libext2fs.so.2.4
+l 0777 0 0 /lib/libfdisk.so.1 -> libfdisk.so.1.1.0
+f 0755 0 0 /lib/libfdisk.so.1.1.0
+f 0644 0 0 /lib/libgcc_s.so.1
+f 0755 0 0 /lib/libm.so.6
+l 0777 0 0 /lib/libmount.so.1 -> libmount.so.1.1.0
+f 0755 0 0 /lib/libmount.so.1.1.0
+f 0755 0 0 /lib/libmvec.so.1
+l 0777 0 0 /lib/libncursesw.so.5 -> libncursesw.so.5.9
+f 0755 0 0 /lib/libncursesw.so.5.9
+f 0755 0 0 /lib/libnsl.so.1
+f 0755 0 0 /lib/libnss_compat.so.2
+f 0755 0 0 /lib/libnss_dns.so.2
+f 0755 0 0 /lib/libnss_files.so.2
+f 0755 0 0 /lib/libnss_mdns.so.2
+f 0755 0 0 /lib/libnss_mdns4.so.2
+f 0755 0 0 /lib/libnss_mdns4_minimal.so.2
+f 0755 0 0 /lib/libnss_mdns6.so.2
+f 0755 0 0 /lib/libnss_mdns6_minimal.so.2
+f 0755 0 0 /lib/libnss_mdns_minimal.so.2
+f 0755 0 0 /lib/libpthread.so.0
+f 0755 0 0 /lib/libresolv.so.2
+f 0755 0 0 /lib/librt.so.1
+l 0777 0 0 /lib/libsmartcols.so.1 -> libsmartcols.so.1.1.0
+f 0755 0 0 /lib/libsmartcols.so.1.1.0
+l 0777 0 0 /lib/libtinfo.so.5 -> libtinfo.so.5.9
+f 0755 0 0 /lib/libtinfo.so.5.9
+f 0755 0 0 /lib/libutil.so.1
+d 0755 0 0 /lib/modprobe.d
+d 0755 0 0 /lib/udev
+f 0755 0 0 /lib/udev/ata_id
+f 0755 0 0 /lib/udev/cdrom_id
+f 0755 0 0 /lib/udev/collect
+f 0755 0 0 /lib/udev/dmi_memory_id
+f 0755 0 0 /lib/udev/fido_id
+f 0755 0 0 /lib/udev/mtd_probe
+d 0755 0 0 /lib/udev/rules.d
+f 0644 0 0 /lib/udev/rules.d/50-udev-default.rules
+f 0644 0 0 /lib/udev/rules.d/60-autosuspend.rules
+f 0644 0 0 /lib/udev/rules.d/60-block.rules
+f 0644 0 0 /lib/udev/rules.d/60-cdrom_id.rules
+f 0644 0 0 /lib/udev/rules.d/60-drm.rules
+f 0644 0 0 /lib/udev/rules.d/60-evdev.rules
+f 0644 0 0 /lib/udev/rules.d/60-fido-id.rules
+f 0644 0 0 /lib/udev/rules.d/60-input-id.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-alsa.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-input.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-storage-tape.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-storage.rules
+f 0644 0 0 /lib/udev/rules.d/60-persistent-v4l.rules
+f 0644 0 0 /lib/udev/rules.d/60-sensor.rules
+f 0644 0 0 /lib/udev/rules.d/60-serial.rules
+f 0644 0 0 /lib/udev/rules.d/64-btrfs.rules
+f 0644 0 0 /lib/udev/rules.d/70-camera.rules
+f 0644 0 0 /lib/udev/rules.d/70-joystick.rules
+f 0644 0 0 /lib/udev/rules.d/70-memory.rules
+f 0644 0 0 /lib/udev/rules.d/70-mouse.rules
+f 0644 0 0 /lib/udev/rules.d/70-touchpad.rules
+f 0644 0 0 /lib/udev/rules.d/75-net-description.rules
+f 0644 0 0 /lib/udev/rules.d/75-probe_mtd.rules
+f 0644 0 0 /lib/udev/rules.d/78-sound-card.rules
+f 0644 0 0 /lib/udev/rules.d/80-drivers.rules
+f 0644 0 0 /lib/udev/rules.d/80-net-name-slot.rules
+f 0644 0 0 /lib/udev/rules.d/81-net-dhcp.rules
+f 0755 0 0 /lib/udev/scsi_id
+f 0755 0 0 /lib/udev/v4l_id
+d 0755 0 0 /media
+d 0755 0 0 /mnt
+d 0555 0 0 /proc
+d 0755 0 0 /run
+d 0755 0 0 /sbin
+f 0755 0 0 /sbin/agetty
+l 0777 0 0 /sbin/blkid -> /sbin/blkid.util-linux
+f 0755 0 0 /sbin/blkid.util-linux
+l 0777 0 0 /sbin/blockdev -> /sbin/blockdev.util-linux
+f 0755 0 0 /sbin/blockdev.util-linux
+f 0755 0 0 /sbin/bootlogd
+f 0755 0 0 /sbin/cfdisk
+f 0755 0 0 /sbin/ctrlaltdel
+l 0777 0 0 /sbin/depmod -> /sbin/depmod.kmod
+l 0777 0 0 /sbin/depmod.kmod -> ../bin/kmod
+f 0755 0 0 /sbin/e2fsck
+l 0777 0 0 /sbin/fdisk -> /sbin/fdisk.util-linux
+f 0755 0 0 /sbin/fdisk.util-linux
+l 0777 0 0 /sbin/fsck -> /sbin/fsck.util-linux
+f 0755 0 0 /sbin/fsck.ext2
+f 0755 0 0 /sbin/fsck.ext3
+f 0755 0 0 /sbin/fsck.ext4
+f 0755 0 0 /sbin/fsck.util-linux
+f 0755 0 0 /sbin/fstab-decode
+l 0777 0 0 /sbin/fstrim -> /sbin/fstrim.util-linux
+f 0755 0 0 /sbin/fstrim.util-linux
+l 0777 0 0 /sbin/getty -> /sbin/agetty
+f 0755 0 0 /sbin/getty-wrapper
+l 0777 0 0 /sbin/halt -> /sbin/halt.sysvinit
+f 4754 0 70 /sbin/halt.sysvinit
+l 0777 0 0 /sbin/hwclock -> /sbin/hwclock.util-linux
+f 0755 0 0 /sbin/hwclock.util-linux
+l 0777 0 0 /sbin/ifconfig -> /bin/busybox
+l 0777 0 0 /sbin/ifdown -> /bin/busybox
+l 0777 0 0 /sbin/ifup -> /bin/busybox
+l 0777 0 0 /sbin/init -> /sbin/init.sysvinit
+f 0755 0 0 /sbin/init.sysvinit
+l 0777 0 0 /sbin/insmod -> /sbin/insmod.kmod
+l 0777 0 0 /sbin/insmod.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/ip -> /bin/busybox
+f 0755 0 0 /sbin/killall5
+l 0777 0 0 /sbin/klogd -> /bin/busybox
+f 0755 0 0 /sbin/ldconfig
+l 0777 0 0 /sbin/loadkmap -> /bin/busybox
+l 0777 0 0 /sbin/logread -> /bin/busybox
+l 0777 0 0 /sbin/losetup -> /sbin/losetup.util-linux
+f 0755 0 0 /sbin/losetup.util-linux
+l 0777 0 0 /sbin/lsmod -> /bin/lsmod.kmod
+l 0777 0 0 /sbin/mdev -> /bin/busybox
+l 0777 0 0 /sbin/mke2fs -> /sbin/mke2fs.e2fsprogs
+f 0755 0 0 /sbin/mke2fs.e2fsprogs
+l 0777 0 0 /sbin/mkfs.ext2 -> /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext3
+f 0755 0 0 /sbin/mkfs.ext4
+l 0777 0 0 /sbin/mkswap -> /sbin/mkswap.util-linux
+f 0755 0 0 /sbin/mkswap.util-linux
+l 0777 0 0 /sbin/modinfo -> /sbin/modinfo.kmod
+l 0777 0 0 /sbin/modinfo.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/modprobe -> /sbin/modprobe.kmod
+l 0777 0 0 /sbin/modprobe.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/nologin -> /sbin/nologin.shadow
+f 0755 0 0 /sbin/nologin.shadow
+f 0755 0 0 /sbin/nologin.util-linux
+l 0777 0 0 /sbin/pivot_root -> /sbin/pivot_root.util-linux
+f 0755 0 0 /sbin/pivot_root.util-linux
+l 0777 0 0 /sbin/poweroff -> /sbin/poweroff.sysvinit
+l 0777 0 0 /sbin/poweroff.sysvinit -> halt.sysvinit
+l 0777 0 0 /sbin/reboot -> /sbin/reboot.sysvinit
+l 0777 0 0 /sbin/reboot.sysvinit -> halt.sysvinit
+l 0777 0 0 /sbin/rmmod -> /sbin/rmmod.kmod
+l 0777 0 0 /sbin/rmmod.kmod -> ../bin/kmod
+l 0777 0 0 /sbin/route -> /bin/busybox
+l 0777 0 0 /sbin/runlevel -> /sbin/runlevel.sysvinit
+f 0755 0 0 /sbin/runlevel.sysvinit
+l 0777 0 0 /sbin/setconsole -> /bin/busybox
+l 0777 0 0 /sbin/shutdown -> /sbin/shutdown.sysvinit
+f 4754 0 70 /sbin/shutdown.sysvinit
+l 0777 0 0 /sbin/start-stop-daemon -> /bin/busybox
+l 0777 0 0 /sbin/sulogin -> /sbin/sulogin.util-linux
+f 0755 0 0 /sbin/sulogin.util-linux
+l 0777 0 0 /sbin/swapoff -> /sbin/swapoff.util-linux
+f 0755 0 0 /sbin/swapoff.util-linux
+l 0777 0 0 /sbin/swapon -> /sbin/swapon.util-linux
+f 0755 0 0 /sbin/swapon.util-linux
+l 0777 0 0 /sbin/switch_root -> /sbin/switch_root.util-linux
+f 0755 0 0 /sbin/switch_root.util-linux
+l 0777 0 0 /sbin/sysctl -> /bin/busybox
+l 0777 0 0 /sbin/syslogd -> /bin/busybox
+l 0777 0 0 /sbin/telinit -> init
+l 0777 0 0 /sbin/udevadm -> /usr/bin/udevadm
+f 0755 0 0 /sbin/udevd
+l 0777 0 0 /sbin/udhcpc -> /bin/busybox
+l 0777 0 0 /sbin/vigr -> /sbin/vigr.shadow
+l 0777 0 0 /sbin/vigr.shadow -> vipw.shadow
+l 0777 0 0 /sbin/vipw -> /sbin/vipw.shadow
+f 0755 0 0 /sbin/vipw.shadow
+d 0555 0 0 /sys
+d 1777 0 0 /tmp
+d 0755 0 0 /usr
+d 0755 0 0 /usr/bin
+f 0755 0 0 /usr/bin/JSON.sh
+l 0777 0 0 /usr/bin/[ -> /usr/bin/lbracket.coreutils
+l 0777 0 0 /usr/bin/[[ -> /bin/busybox
+l 0777 0 0 /usr/bin/arch -> /usr/bin/arch.coreutils
+f 0755 0 0 /usr/bin/arch.coreutils
+l 0777 0 0 /usr/bin/ascii -> /bin/busybox
+l 0777 0 0 /usr/bin/awk -> /bin/busybox
+f 0755 0 0 /usr/bin/b2sum
+l 0777 0 0 /usr/bin/base32 -> /usr/bin/base32.coreutils
+f 0755 0 0 /usr/bin/base32.coreutils
+f 0755 0 0 /usr/bin/base64.coreutils
+l 0777 0 0 /usr/bin/basename -> /usr/bin/basename.coreutils
+f 0755 0 0 /usr/bin/basename.coreutils
+f 0755 0 0 /usr/bin/basenc
+l 0777 0 0 /usr/bin/bunzip2 -> /bin/busybox
+l 0777 0 0 /usr/bin/bzcat -> /bin/busybox
+l 0777 0 0 /usr/bin/bzip2 -> /bin/busybox
+l 0777 0 0 /usr/bin/cal -> /usr/bin/cal.util-linux
+f 0755 0 0 /usr/bin/cal.util-linux
+f 4755 0 0 /usr/bin/chage
+l 0777 0 0 /usr/bin/chcon -> /usr/bin/chcon.coreutils
+f 0755 0 0 /usr/bin/chcon.coreutils
+l 0777 0 0 /usr/bin/chfn -> /usr/bin/chfn.shadow
+f 4755 0 0 /usr/bin/chfn.shadow
+f 0755 0 0 /usr/bin/chmem
+f 0755 0 0 /usr/bin/choom
+l 0777 0 0 /usr/bin/chrt -> /usr/bin/chrt.util-linux
+f 0755 0 0 /usr/bin/chrt.util-linux
+l 0777 0 0 /usr/bin/chsh -> /usr/bin/chsh.shadow
+f 4755 0 0 /usr/bin/chsh.shadow
+l 0777 0 0 /usr/bin/chvt -> /bin/busybox
+l 0777 0 0 /usr/bin/cksum -> /usr/bin/cksum.coreutils
+f 0755 0 0 /usr/bin/cksum.coreutils
+l 0777 0 0 /usr/bin/clear -> /bin/busybox
+l 0777 0 0 /usr/bin/cmp -> /bin/busybox
+f 0755 0 0 /usr/bin/col
+f 0755 0 0 /usr/bin/colcrt
+f 0755 0 0 /usr/bin/colrm
+f 0755 0 0 /usr/bin/column
+l 0777 0 0 /usr/bin/comm -> /usr/bin/comm.coreutils
+f 0755 0 0 /usr/bin/comm.coreutils
+l 0777 0 0 /usr/bin/crc32 -> /bin/busybox
+l 0777 0 0 /usr/bin/csplit -> /usr/bin/csplit.coreutils
+f 0755 0 0 /usr/bin/csplit.coreutils
+l 0777 0 0 /usr/bin/cut -> /usr/bin/cut.coreutils
+f 0755 0 0 /usr/bin/cut.coreutils
+f 0755 0 0 /usr/bin/dbus-cleanup-sockets
+f 0755 0 0 /usr/bin/dbus-daemon
+f 0755 0 0 /usr/bin/dbus-launch
+f 0755 0 0 /usr/bin/dbus-monitor
+f 0755 0 0 /usr/bin/dbus-run-session
+f 0755 0 0 /usr/bin/dbus-send
+f 0755 0 0 /usr/bin/dbus-update-activation-environment
+f 0755 0 0 /usr/bin/dbus-uuidgen
+l 0777 0 0 /usr/bin/dc -> /bin/busybox
+f 0755 0 0 /usr/bin/dcp-blob-create
+l 0777 0 0 /usr/bin/deallocvt -> /bin/busybox
+f 0755 0 0 /usr/bin/df.coreutils
+f 0755 0 0 /usr/bin/dhcp_lease_time
+f 0755 0 0 /usr/bin/dhcp_release
+f 0755 0 0 /usr/bin/dhcp_release6
+l 0777 0 0 /usr/bin/diff -> /bin/busybox
+l 0777 0 0 /usr/bin/dir -> /usr/bin/dir.coreutils
+f 0755 0 0 /usr/bin/dir.coreutils
+l 0777 0 0 /usr/bin/dircolors -> /usr/bin/dircolors.coreutils
+f 0755 0 0 /usr/bin/dircolors.coreutils
+l 0777 0 0 /usr/bin/dirname -> /usr/bin/dirname.coreutils
+f 0755 0 0 /usr/bin/dirname.coreutils
+f 0755 0 0 /usr/bin/dnsmasq
+l 0777 0 0 /usr/bin/docker-runc -> runc
+l 0777 0 0 /usr/bin/du -> /usr/bin/du.coreutils
+f 0755 0 0 /usr/bin/du.coreutils
+l 0777 0 0 /usr/bin/dumpleases -> /bin/busybox
+l 0777 0 0 /usr/bin/eject -> /usr/bin/eject.util-linux
+f 0755 0 0 /usr/bin/eject.util-linux
+l 0777 0 0 /usr/bin/env -> /usr/bin/env.coreutils
+f 0755 0 0 /usr/bin/env.coreutils
+l 0777 0 0 /usr/bin/expand -> /usr/bin/expand.coreutils
+f 0755 0 0 /usr/bin/expand.coreutils
+f 4755 0 0 /usr/bin/expiry
+l 0777 0 0 /usr/bin/expr -> /usr/bin/expr.coreutils
+f 0755 0 0 /usr/bin/expr.coreutils
+l 0777 0 0 /usr/bin/factor -> /usr/bin/factor.coreutils
+f 0755 0 0 /usr/bin/factor.coreutils
+f 0755 0 0 /usr/bin/fadvise
+f 0755 0 0 /usr/bin/faillog
+f 0755 0 0 /usr/bin/fallbear-cmd
+l 0777 0 0 /usr/bin/fallocate -> /usr/bin/fallocate.util-linux
+f 0755 0 0 /usr/bin/fallocate.util-linux
+f 0755 0 0 /usr/bin/fcntl-lock
+f 0755 0 0 /usr/bin/fincore
+l 0777 0 0 /usr/bin/find -> /bin/busybox
+f 0755 0 0 /usr/bin/findmnt
+l 0777 0 0 /usr/bin/flock -> /usr/bin/flock.util-linux
+f 0755 0 0 /usr/bin/flock.util-linux
+l 0777 0 0 /usr/bin/fmt -> /usr/bin/fmt.coreutils
+f 0755 0 0 /usr/bin/fmt.coreutils
+l 0777 0 0 /usr/bin/fold -> /usr/bin/fold.coreutils
+f 0755 0 0 /usr/bin/fold.coreutils
+l 0777 0 0 /usr/bin/free -> /bin/busybox
+l 0777 0 0 /usr/bin/fuser -> /bin/busybox
+f 0755 0 0 /usr/bin/getsubids
+f 4755 0 0 /usr/bin/gpasswd
+l 0777 0 0 /usr/bin/groups -> /usr/bin/groups.shadow
+f 0755 0 0 /usr/bin/groups.coreutils
+f 0755 0 0 /usr/bin/groups.shadow
+f 0755 0 0 /usr/bin/hardlink
+l 0777 0 0 /usr/bin/head -> /usr/bin/head.coreutils
+f 0755 0 0 /usr/bin/head.coreutils
+l 0777 0 0 /usr/bin/hexdump -> /usr/bin/hexdump.util-linux
+f 0755 0 0 /usr/bin/hexdump.util-linux
+l 0777 0 0 /usr/bin/hostid -> /usr/bin/hostid.coreutils
+f 0755 0 0 /usr/bin/hostid.coreutils
+l 0777 0 0 /usr/bin/i386 -> setarch
+l 0777 0 0 /usr/bin/id -> /usr/bin/id.coreutils
+f 0755 0 0 /usr/bin/id.coreutils
+l 0777 0 0 /usr/bin/install -> /usr/bin/install.coreutils
+f 0755 0 0 /usr/bin/install.coreutils
+l 0777 0 0 /usr/bin/ionice -> /usr/bin/ionice.util-linux
+f 0755 0 0 /usr/bin/ionice.util-linux
+f 0755 0 0 /usr/bin/ipcmk
+l 0777 0 0 /usr/bin/ipcrm -> /usr/bin/ipcrm.util-linux
+f 0755 0 0 /usr/bin/ipcrm.util-linux
+l 0777 0 0 /usr/bin/ipcs -> /usr/bin/ipcs.util-linux
+f 0755 0 0 /usr/bin/ipcs.util-linux
+f 0755 0 0 /usr/bin/irqtop
+f 0755 0 0 /usr/bin/isosize
+l 0777 0 0 /usr/bin/join -> /usr/bin/join.coreutils
+f 0755 0 0 /usr/bin/join.coreutils
+l 0777 0 0 /usr/bin/killall -> /bin/busybox
+l 0777 0 0 /usr/bin/last -> /usr/bin/last.sysvinit
+f 0755 0 0 /usr/bin/last.sysvinit
+f 0755 0 0 /usr/bin/last.util-linux
+l 0777 0 0 /usr/bin/lastb -> /usr/bin/lastb.sysvinit
+l 0777 0 0 /usr/bin/lastb.sysvinit -> last.sysvinit
+l 0777 0 0 /usr/bin/lastb.util-linux -> last.util-linux
+f 0755 0 0 /usr/bin/lbracket.coreutils
+l 0777 0 0 /usr/bin/less -> /bin/busybox
+l 0777 0 0 /usr/bin/link -> /usr/bin/link.coreutils
+f 0755 0 0 /usr/bin/link.coreutils
+l 0777 0 0 /usr/bin/linux32 -> setarch
+l 0777 0 0 /usr/bin/linux64 -> setarch
+l 0777 0 0 /usr/bin/logger -> /usr/bin/logger.util-linux
+f 0755 0 0 /usr/bin/logger.util-linux
+l 0777 0 0 /usr/bin/logname -> /usr/bin/logname.coreutils
+f 0755 0 0 /usr/bin/logname.coreutils
+f 0755 0 0 /usr/bin/look
+f 0755 0 0 /usr/bin/lsblk
+f 0755 0 0 /usr/bin/lscpu
+f 0755 0 0 /usr/bin/lsfd
+f 0755 0 0 /usr/bin/lsipc
+f 0755 0 0 /usr/bin/lsirq
+f 0755 0 0 /usr/bin/lslocks
+f 0755 0 0 /usr/bin/lslogins
+f 0755 0 0 /usr/bin/lsmem
+f 0755 0 0 /usr/bin/lsns
+l 0777 0 0 /usr/bin/lspci -> /bin/busybox
+l 0777 0 0 /usr/bin/lsusb -> /bin/busybox
+f 0755 0 0 /usr/bin/lxc-console
+f 0755 0 0 /usr/bin/lxc-info
+f 0755 0 0 /usr/bin/lxc-ls
+f 0755 0 0 /usr/bin/lxc-top
+l 0777 0 0 /usr/bin/lzcat -> /bin/busybox
+l 0777 0 0 /usr/bin/mcookie -> /usr/bin/mcookie.util-linux
+f 0755 0 0 /usr/bin/mcookie.util-linux
+l 0777 0 0 /usr/bin/md5sum -> /usr/bin/md5sum.coreutils
+f 0755 0 0 /usr/bin/md5sum.coreutils
+l 0777 0 0 /usr/bin/mesg -> /usr/bin/mesg.sysvinit
+f 0755 0 0 /usr/bin/mesg.sysvinit
+f 0755 0 0 /usr/bin/mesg.util-linux
+l 0777 0 0 /usr/bin/microcom -> /bin/busybox
+l 0777 0 0 /usr/bin/mkfifo -> /usr/bin/mkfifo.coreutils
+f 0755 0 0 /usr/bin/mkfifo.coreutils
+f 0755 0 0 /usr/bin/mktemp.coreutils
+f 0755 0 0 /usr/bin/namei
+l 0777 0 0 /usr/bin/nc -> /usr/bin/nc.netcat-openbsd
+f 0755 0 0 /usr/bin/nc.netcat-openbsd
+f 4755 0 0 /usr/bin/newgidmap
+l 0777 0 0 /usr/bin/newgrp -> /usr/bin/newgrp.shadow
+f 4755 0 0 /usr/bin/newgrp.shadow
+f 4755 0 0 /usr/bin/newuidmap
+f 0755 0 0 /usr/bin/nice.coreutils
+l 0777 0 0 /usr/bin/nl -> /usr/bin/nl.coreutils
+f 0755 0 0 /usr/bin/nl.coreutils
+l 0777 0 0 /usr/bin/nohup -> /usr/bin/nohup.coreutils
+f 0755 0 0 /usr/bin/nohup.coreutils
+l 0777 0 0 /usr/bin/nproc -> /usr/bin/nproc.coreutils
+f 0755 0 0 /usr/bin/nproc.coreutils
+l 0777 0 0 /usr/bin/nsenter -> /usr/bin/nsenter.util-linux
+f 0755 0 0 /usr/bin/nsenter.util-linux
+l 0777 0 0 /usr/bin/nslookup -> /bin/busybox
+f 0755 0 0 /usr/bin/numfmt
+l 0777 0 0 /usr/bin/od -> /usr/bin/od.coreutils
+f 0755 0 0 /usr/bin/od.coreutils
+l 0777 0 0 /usr/bin/openvt -> /bin/busybox
+f 0755 0 0 /usr/bin/pantavisor
+l 0777 0 0 /usr/bin/passwd -> /usr/bin/passwd.shadow
+f 4755 0 0 /usr/bin/passwd.shadow
+l 0777 0 0 /usr/bin/paste -> /usr/bin/paste.coreutils
+f 0755 0 0 /usr/bin/paste.coreutils
+l 0777 0 0 /usr/bin/patch -> /bin/busybox
+l 0777 0 0 /usr/bin/pathchk -> /usr/bin/pathchk.coreutils
+f 0755 0 0 /usr/bin/pathchk.coreutils
+l 0777 0 0 /usr/bin/pgrep -> /bin/busybox
+l 0777 0 0 /usr/bin/pinky -> /usr/bin/pinky.coreutils
+f 0755 0 0 /usr/bin/pinky.coreutils
+f 0755 0 0 /usr/bin/pipesz
+l 0777 0 0 /usr/bin/pr -> /usr/bin/pr.coreutils
+f 0755 0 0 /usr/bin/pr.coreutils
+f 0755 0 0 /usr/bin/printenv.coreutils
+l 0777 0 0 /usr/bin/printf -> /usr/bin/printf.coreutils
+f 0755 0 0 /usr/bin/printf.coreutils
+l 0777 0 0 /usr/bin/prlimit -> /usr/bin/prlimit.util-linux
+f 0755 0 0 /usr/bin/prlimit.util-linux
+l 0777 0 0 /usr/bin/ptx -> /usr/bin/ptx.coreutils
+f 0755 0 0 /usr/bin/ptx.coreutils
+f 0755 0 0 /usr/bin/pv-appengine
+f 0755 0 0 /usr/bin/pv-xconnect
+f 0755 0 0 /usr/bin/pvcontrol
+f 0755 0 0 /usr/bin/pvcurl
+f 0755 0 0 /usr/bin/pventer
+f 0755 0 0 /usr/bin/pvtx
+f 0755 0 0 /usr/bin/readbootlog
+l 0777 0 0 /usr/bin/readlink -> /usr/bin/readlink.coreutils
+f 0755 0 0 /usr/bin/readlink.coreutils
+l 0777 0 0 /usr/bin/realpath -> /usr/bin/realpath.coreutils
+f 0755 0 0 /usr/bin/realpath.coreutils
+f 0755 0 0 /usr/bin/rename
+l 0777 0 0 /usr/bin/renice -> /usr/bin/renice.util-linux
+f 0755 0 0 /usr/bin/renice.util-linux
+l 0777 0 0 /usr/bin/reset -> /bin/busybox
+l 0777 0 0 /usr/bin/resize -> /bin/busybox
+l 0777 0 0 /usr/bin/rev -> /usr/bin/rev.util-linux
+f 0755 0 0 /usr/bin/rev.util-linux
+l 0777 0 0 /usr/bin/rpcinfo -> /usr/bin/rpcinfo.rpcbind
+f 0755 0 0 /usr/bin/rpcinfo.rpcbind
+f 0755 0 0 /usr/bin/runc
+l 0777 0 0 /usr/bin/runcon -> /usr/bin/runcon.coreutils
+f 0755 0 0 /usr/bin/runcon.coreutils
+f 0755 0 0 /usr/bin/script
+f 0755 0 0 /usr/bin/scriptlive
+l 0777 0 0 /usr/bin/scriptreplay -> /usr/bin/scriptreplay.util-linux
+f 0755 0 0 /usr/bin/scriptreplay.util-linux
+l 0777 0 0 /usr/bin/seq -> /usr/bin/seq.coreutils
+f 0755 0 0 /usr/bin/seq.coreutils
+f 0755 0 0 /usr/bin/setarch
+l 0777 0 0 /usr/bin/setpriv -> /usr/bin/setpriv.util-linux
+f 0755 0 0 /usr/bin/setpriv.util-linux
+l 0777 0 0 /usr/bin/setsid -> /usr/bin/setsid.util-linux
+f 0755 0 0 /usr/bin/setsid.util-linux
+f 0755 0 0 /usr/bin/setterm
+l 0777 0 0 /usr/bin/sg -> newgrp.shadow
+l 0777 0 0 /usr/bin/sha1sum -> /usr/bin/sha1sum.coreutils
+f 0755 0 0 /usr/bin/sha1sum.coreutils
+l 0777 0 0 /usr/bin/sha224sum -> /usr/bin/sha224sum.coreutils
+f 0755 0 0 /usr/bin/sha224sum.coreutils
+l 0777 0 0 /usr/bin/sha256sum -> /usr/bin/sha256sum.coreutils
+f 0755 0 0 /usr/bin/sha256sum.coreutils
+l 0777 0 0 /usr/bin/sha384sum -> /usr/bin/sha384sum.coreutils
+f 0755 0 0 /usr/bin/sha384sum.coreutils
+l 0777 0 0 /usr/bin/sha512sum -> /usr/bin/sha512sum.coreutils
+f 0755 0 0 /usr/bin/sha512sum.coreutils
+l 0777 0 0 /usr/bin/shred -> /usr/bin/shred.coreutils
+f 0755 0 0 /usr/bin/shred.coreutils
+l 0777 0 0 /usr/bin/shuf -> /usr/bin/shuf.coreutils
+f 0755 0 0 /usr/bin/shuf.coreutils
+l 0777 0 0 /usr/bin/sort -> /usr/bin/sort.coreutils
+f 0755 0 0 /usr/bin/sort.coreutils
+l 0777 0 0 /usr/bin/split -> /usr/bin/split.coreutils
+f 0755 0 0 /usr/bin/split.coreutils
+f 0755 0 0 /usr/bin/stdbuf
+l 0777 0 0 /usr/bin/strings -> /bin/busybox
+l 0777 0 0 /usr/bin/sum -> /usr/bin/sum.coreutils
+f 0755 0 0 /usr/bin/sum.coreutils
+l 0777 0 0 /usr/bin/tac -> /usr/bin/tac.coreutils
+f 0755 0 0 /usr/bin/tac.coreutils
+l 0777 0 0 /usr/bin/tail -> /usr/bin/tail.coreutils
+f 0755 0 0 /usr/bin/tail.coreutils
+l 0777 0 0 /usr/bin/taskset -> /usr/bin/taskset.util-linux
+f 0755 0 0 /usr/bin/taskset.util-linux
+l 0777 0 0 /usr/bin/tee -> /usr/bin/tee.coreutils
+f 0755 0 0 /usr/bin/tee.coreutils
+l 0777 0 0 /usr/bin/telnet -> /bin/busybox
+l 0777 0 0 /usr/bin/test -> /usr/bin/test.coreutils
+f 0755 0 0 /usr/bin/test.coreutils
+l 0777 0 0 /usr/bin/tftp -> /bin/busybox
+l 0777 0 0 /usr/bin/time -> /bin/busybox
+l 0777 0 0 /usr/bin/timeout -> /usr/bin/timeout.coreutils
+f 0755 0 0 /usr/bin/timeout.coreutils
+l 0777 0 0 /usr/bin/top -> /bin/busybox
+l 0777 0 0 /usr/bin/tr -> /usr/bin/tr.coreutils
+f 0755 0 0 /usr/bin/tr.coreutils
+l 0777 0 0 /usr/bin/traceroute -> /bin/busybox
+l 0777 0 0 /usr/bin/truncate -> /usr/bin/truncate.coreutils
+f 0755 0 0 /usr/bin/truncate.coreutils
+l 0777 0 0 /usr/bin/ts -> /bin/busybox
+l 0777 0 0 /usr/bin/tsort -> /usr/bin/tsort.coreutils
+f 0755 0 0 /usr/bin/tsort.coreutils
+l 0777 0 0 /usr/bin/tty -> /usr/bin/tty.coreutils
+f 0755 0 0 /usr/bin/tty.coreutils
+f 0755 0 0 /usr/bin/uclampset
+f 0755 0 0 /usr/bin/udevadm
+f 0755 0 0 /usr/bin/ul
+l 0777 0 0 /usr/bin/uname26 -> setarch
+l 0777 0 0 /usr/bin/unexpand -> /usr/bin/unexpand.coreutils
+f 0755 0 0 /usr/bin/unexpand.coreutils
+l 0777 0 0 /usr/bin/uniq -> /usr/bin/uniq.coreutils
+f 0755 0 0 /usr/bin/uniq.coreutils
+l 0777 0 0 /usr/bin/unlink -> /usr/bin/unlink.coreutils
+f 0755 0 0 /usr/bin/unlink.coreutils
+l 0777 0 0 /usr/bin/unshare -> /usr/bin/unshare.util-linux
+f 0755 0 0 /usr/bin/unshare.util-linux
+l 0777 0 0 /usr/bin/unzip -> /bin/busybox
+f 0755 0 0 /usr/bin/update-alternatives
+l 0777 0 0 /usr/bin/uptime -> /usr/bin/uptime.coreutils
+f 0755 0 0 /usr/bin/uptime.coreutils
+l 0777 0 0 /usr/bin/users -> /usr/bin/users.coreutils
+f 0755 0 0 /usr/bin/users.coreutils
+l 0777 0 0 /usr/bin/utmpdump -> /usr/bin/utmpdump.sysvinit
+f 0755 0 0 /usr/bin/utmpdump.sysvinit
+f 0755 0 0 /usr/bin/utmpdump.util-linux
+l 0777 0 0 /usr/bin/uuidgen -> /usr/bin/uuidgen.util-linux
+f 0755 0 0 /usr/bin/uuidgen.util-linux
+f 0755 0 0 /usr/bin/uuidparse
+l 0777 0 0 /usr/bin/vdir -> /usr/bin/vdir.coreutils
+f 0755 0 0 /usr/bin/vdir.coreutils
+l 0777 0 0 /usr/bin/vlock -> /bin/busybox
+f 0755 0 0 /usr/bin/waitpid
+l 0777 0 0 /usr/bin/wall -> /usr/bin/wall.sysvinit
+f 0755 0 0 /usr/bin/wall.sysvinit
+f 0755 0 0 /usr/bin/wall.util-linux
+l 0777 0 0 /usr/bin/wc -> /usr/bin/wc.coreutils
+f 0755 0 0 /usr/bin/wc.coreutils
+f 0755 0 0 /usr/bin/wdctl
+l 0777 0 0 /usr/bin/wget -> /bin/busybox
+f 0755 0 0 /usr/bin/whereis
+l 0777 0 0 /usr/bin/which -> /bin/busybox
+l 0777 0 0 /usr/bin/who -> /usr/bin/who.coreutils
+f 0755 0 0 /usr/bin/who.coreutils
+l 0777 0 0 /usr/bin/whoami -> /usr/bin/whoami.coreutils
+f 0755 0 0 /usr/bin/whoami.coreutils
+f 0755 0 0 /usr/bin/write
+l 0777 0 0 /usr/bin/x86_64 -> setarch
+l 0777 0 0 /usr/bin/xargs -> /bin/busybox
+l 0777 0 0 /usr/bin/xzcat -> /bin/busybox
+l 0777 0 0 /usr/bin/yes -> /usr/bin/yes.coreutils
+f 0755 0 0 /usr/bin/yes.coreutils
+d 0755 0 0 /usr/games
+d 0755 0 0 /usr/include
+d 0755 0 0 /usr/lib
+d 0755 0 0 /usr/lib/coreutils
+f 0755 0 0 /usr/lib/coreutils/libstdbuf.so
+f 0755 0 0 /usr/lib/e2initrd_helper
+l 0777 0 0 /usr/lib/libX11.so.6 -> libX11.so.6.4.0
+f 0755 0 0 /usr/lib/libX11.so.6.4.0
+l 0777 0 0 /usr/lib/libXau.so.6 -> libXau.so.6.0.0
+f 0755 0 0 /usr/lib/libXau.so.6.0.0
+l 0777 0 0 /usr/lib/libXdmcp.so.6 -> libXdmcp.so.6.0.0
+f 0755 0 0 /usr/lib/libXdmcp.so.6.0.0
+l 0777 0 0 /usr/lib/libacl.so.1 -> libacl.so.1.1.2302
+f 0755 0 0 /usr/lib/libacl.so.1.1.2302
+l 0777 0 0 /usr/lib/libattr.so.1 -> libattr.so.1.1.2501
+f 0755 0 0 /usr/lib/libattr.so.1.1.2501
+l 0777 0 0 /usr/lib/libavahi-common.so.3 -> libavahi-common.so.3.5.4
+f 0755 0 0 /usr/lib/libavahi-common.so.3.5.4
+l 0777 0 0 /usr/lib/libavahi-core.so.7 -> libavahi-core.so.7.1.0
+f 0755 0 0 /usr/lib/libavahi-core.so.7.1.0
+l 0777 0 0 /usr/lib/libbsd.so.0 -> libbsd.so.0.12.1
+f 0755 0 0 /usr/lib/libbsd.so.0.12.1
+l 0777 0 0 /usr/lib/libcrypt.so.2 -> libcrypt.so.2.0.0
+f 0755 0 0 /usr/lib/libcrypt.so.2.0.0
+f 0755 0 0 /usr/lib/libcrypto.so.3
+l 0777 0 0 /usr/lib/libcryptsetup.so.12 -> libcryptsetup.so.12.10.0
+f 0755 0 0 /usr/lib/libcryptsetup.so.12.10.0
+l 0777 0 0 /usr/lib/libdaemon.so.0 -> libdaemon.so.0.5.0
+f 0755 0 0 /usr/lib/libdaemon.so.0.5.0
+l 0777 0 0 /usr/lib/libdbus-1.so.3 -> libdbus-1.so.3.32.4
+f 0755 0 0 /usr/lib/libdbus-1.so.3.32.4
+f 0555 0 0 /usr/lib/libdevmapper.so.1.02
+l 0777 0 0 /usr/lib/libdrop_ambient.so.0 -> libdrop_ambient.so.0.0.0
+f 0755 0 0 /usr/lib/libdrop_ambient.so.0.0.0
+l 0777 0 0 /usr/lib/libexpat.so.1 -> libexpat.so.1.10.0
+f 0755 0 0 /usr/lib/libexpat.so.1.10.0
+l 0777 0 0 /usr/lib/libgmp.so.10 -> libgmp.so.10.5.0
+f 0755 0 0 /usr/lib/libgmp.so.10.5.0
+l 0777 0 0 /usr/lib/libjson-c.so.5 -> libjson-c.so.5.3.0
+f 0755 0 0 /usr/lib/libjson-c.so.5.3.0
+l 0777 0 0 /usr/lib/libkcapi.so.1 -> libkcapi.so.1.5.0
+f 0755 0 0 /usr/lib/libkcapi.so.1.5.0
+l 0777 0 0 /usr/lib/libkmod.so.2 -> libkmod.so.2.4.1
+f 0755 0 0 /usr/lib/libkmod.so.2.4.1
+l 0777 0 0 /usr/lib/liblxc.so.1 -> liblxc.so.1.8.0
+f 0755 0 0 /usr/lib/liblxc.so.1.8.0
+l 0777 0 0 /usr/lib/liblzma.so.5 -> liblzma.so.5.4.7
+f 0755 0 0 /usr/lib/liblzma.so.5.4.7
+f 0644 0 0 /usr/lib/libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedcrypto.so.7 -> libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedtls.so.14 -> libmbedtls.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedtls.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedx509.so.1 -> libmbedx509.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedx509.so.2.28.10
+l 0777 0 0 /usr/lib/libmd.so.0 -> libmd.so.0.1.0
+f 0755 0 0 /usr/lib/libmd.so.0.1.0
+l 0777 0 0 /usr/lib/libnl-3.so.200 -> libnl-3.so.200.26.0
+f 0755 0 0 /usr/lib/libnl-3.so.200.26.0
+l 0777 0 0 /usr/lib/libnl-genl-3.so.200 -> libnl-genl-3.so.200.26.0
+f 0755 0 0 /usr/lib/libnl-genl-3.so.200.26.0
+l 0777 0 0 /usr/lib/libpopt.so.0 -> libpopt.so.0.0.2
+f 0755 0 0 /usr/lib/libpopt.so.0.0.2
+l 0777 0 0 /usr/lib/libpsx.so.2 -> libpsx.so.2.69
+f 0755 0 0 /usr/lib/libpsx.so.2.69
+f 0755 0 0 /usr/lib/libssl.so.3
+l 0777 0 0 /usr/lib/libsubid.so.4 -> libsubid.so.4.0.0
+f 0755 0 0 /usr/lib/libsubid.so.4.0.0
+l 0777 0 0 /usr/lib/libtirpc.so.3 -> libtirpc.so.3.0.0
+f 0755 0 0 /usr/lib/libtirpc.so.3.0.0
+l 0777 0 0 /usr/lib/libuuid.so.1 -> libuuid.so.1.3.0
+f 0755 0 0 /usr/lib/libuuid.so.1.3.0
+l 0777 0 0 /usr/lib/libxcb.so.1 -> libxcb.so.1.1.0
+f 0755 0 0 /usr/lib/libxcb.so.1.1.0
+l 0777 0 0 /usr/lib/libz.so.1 -> libz.so.1.3.1
+f 0755 0 0 /usr/lib/libz.so.1.3.1
+d 0755 0 0 /usr/lib/locale
+f 0644 0 0 /usr/lib/locale/locale-archive
+d 0755 0 0 /usr/lib/lxc
+d 0755 0 0 /usr/lib/lxc/rootfs
+f 0644 0 0 /usr/lib/lxc/rootfs/README
+d 0755 0 0 /usr/lib/ossl-modules
+f 0755 0 0 /usr/lib/ossl-modules/legacy.so
+d 0755 0 0 /usr/lib/pantavisor
+d 0755 0 0 /usr/lib/pantavisor/pv
+f 0755 0 0 /usr/lib/pantavisor/pv/JSON.sh
+d 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/export.sh
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/remount
+f 0755 0 0 /usr/lib/pantavisor/pv/pvcrash
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt/crypt
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity/dm
+f 0755 0 0 /usr/lib/pantavisor/pv_lxc.so
+d 0755 0 0 /usr/lib/pantavisor/skel
+d 0755 0 0 /usr/lib/pantavisor/skel/boot
+d 0755 0 0 /usr/lib/pantavisor/skel/config
+d 0755 0 0 /usr/lib/pantavisor/skel/disks
+d 0755 0 0 /usr/lib/pantavisor/skel/objects
+d 0755 0 0 /usr/lib/pantavisor/skel/trails
+d 0755 0 0 /usr/lib/pantavisor/skel/trails/0
+d 0755 0 0 /usr/lib/pantavisor/skel/trails/0/.pv
+d 0755 0 0 /usr/lib/pantavisor/skel/trails/0/.pvr
+f 0644 0 0 /usr/lib/pantavisor/skel/trails/0/.pvr/json
+d 0755 0 0 /usr/lib/ssl-3
+l 0777 0 0 /usr/lib/ssl-3/openssl.cnf -> ../../../etc/ssl/openssl.cnf
+f 0644 0 0 /usr/lib/ssl-3/openssl.cnf.dist
+d 0755 0 0 /usr/lib/systemd
+d 0755 0 0 /usr/lib/systemd/user
+f 0644 0 0 /usr/lib/systemd/user/dbus.service
+f 0644 0 0 /usr/lib/systemd/user/dbus.socket
+d 0755 0 0 /usr/lib/systemd/user/sockets.target.wants
+l 0777 0 0 /usr/lib/systemd/user/sockets.target.wants/dbus.socket -> ../dbus.socket
+d 0755 0 0 /usr/libexec
+f 4755 0 999 /usr/libexec/dbus-daemon-launch-helper
+d 0755 0 0 /usr/libexec/lxc
+d 0755 0 0 /usr/libexec/lxc/hooks
+f 0755 0 0 /usr/libexec/lxc/hooks/unmount-namespace
+f 0755 0 0 /usr/libexec/lxc/lxc-monitord
+f 4755 0 0 /usr/libexec/lxc/lxc-user-nic
+d 0755 0 0 /usr/sbin
+l 0777 0 0 /usr/sbin/addgroup -> /bin/busybox
+f 0755 0 0 /usr/sbin/addpart
+l 0777 0 0 /usr/sbin/adduser -> /bin/busybox
+f 0755 0 0 /usr/sbin/avahi-daemon
+f 0755 0 0 /usr/sbin/blkdiscard
+f 0755 0 0 /usr/sbin/blkpr
+f 0755 0 0 /usr/sbin/blkzone
+f 0755 0 0 /usr/sbin/chcpu
+f 0755 0 0 /usr/sbin/chgpasswd
+l 0777 0 0 /usr/sbin/chpasswd -> /usr/sbin/chpasswd.shadow
+f 0755 0 0 /usr/sbin/chpasswd.shadow
+l 0777 0 0 /usr/sbin/chroot -> /usr/sbin/chroot.coreutils
+f 0755 0 0 /usr/sbin/chroot.coreutils
+f 0755 0 0 /usr/sbin/cryptsetup
+l 0777 0 0 /usr/sbin/delgroup -> /bin/busybox
+f 0755 0 0 /usr/sbin/delpart
+l 0777 0 0 /usr/sbin/deluser -> /bin/busybox
+f 0555 0 0 /usr/sbin/dmsetup
+l 0777 0 0 /usr/sbin/dmstats -> dmsetup
+l 0777 0 0 /usr/sbin/fbset -> /bin/busybox
+l 0777 0 0 /usr/sbin/findfs -> /usr/sbin/findfs.util-linux
+f 0755 0 0 /usr/sbin/findfs.util-linux
+f 0755 0 0 /usr/sbin/fsck.cramfs
+l 0777 0 0 /usr/sbin/fsfreeze -> /usr/sbin/fsfreeze.util-linux
+f 0755 0 0 /usr/sbin/fsfreeze.util-linux
+f 0755 0 0 /usr/sbin/groupadd
+f 0755 0 0 /usr/sbin/groupdel
+f 0755 0 0 /usr/sbin/groupmems
+f 0755 0 0 /usr/sbin/groupmod
+f 0755 0 0 /usr/sbin/grpck
+f 0755 0 0 /usr/sbin/grpconv
+f 0755 0 0 /usr/sbin/grpunconv
+f 0755 0 0 /usr/sbin/hostapd
+f 0755 0 0 /usr/sbin/hostapd_cli
+f 0755 0 0 /usr/sbin/init.lxc
+f 0755 0 0 /usr/sbin/init.lxc.static
+f 0755 0 0 /usr/sbin/integritysetup
+f 0755 0 0 /usr/sbin/iw
+f 0755 0 0 /usr/sbin/ldattach
+l 0777 0 0 /usr/sbin/loadfont -> /bin/busybox
+f 0755 0 0 /usr/sbin/logoutd
+f 0755 0 0 /usr/sbin/mkfs
+f 0755 0 0 /usr/sbin/mkfs.cramfs
+f 0755 0 0 /usr/sbin/newusers
+f 0755 0 0 /usr/sbin/partx
+f 0755 0 0 /usr/sbin/pwck
+f 0755 0 0 /usr/sbin/pwconv
+f 0755 0 0 /usr/sbin/pwunconv
+l 0777 0 0 /usr/sbin/rdate -> /bin/busybox
+l 0777 0 0 /usr/sbin/readprofile -> /usr/sbin/readprofile.util-linux
+f 0755 0 0 /usr/sbin/readprofile.util-linux
+f 0755 0 0 /usr/sbin/resizepart
+l 0777 0 0 /usr/sbin/rfkill -> /usr/sbin/rfkill.util-linux
+f 0755 0 0 /usr/sbin/rfkill.util-linux
+f 0755 0 0 /usr/sbin/rpcbind
+l 0777 0 0 /usr/sbin/rtcwake -> /usr/sbin/rtcwake.util-linux
+f 0755 0 0 /usr/sbin/rtcwake.util-linux
+f 0755 0 0 /usr/sbin/service
+f 0755 0 0 /usr/sbin/sfdisk
+f 0755 0 0 /usr/sbin/swaplabel
+f 0755 0 0 /usr/sbin/ttyrun
+l 0777 0 0 /usr/sbin/udhcpd -> /bin/busybox
+f 0755 0 0 /usr/sbin/update-rc.d
+f 0755 0 0 /usr/sbin/useradd
+f 0755 0 0 /usr/sbin/userdel
+f 0755 0 0 /usr/sbin/usermod
+f 0755 0 0 /usr/sbin/uuidd
+f 0755 0 0 /usr/sbin/veritysetup
+f 0755 0 0 /usr/sbin/wipefs
+f 0755 0 0 /usr/sbin/zramctl
+d 0755 0 0 /usr/share
+d 0755 0 0 /usr/share/X11
+f 0644 0 0 /usr/share/X11/XErrorDB
+f 0644 0 0 /usr/share/X11/Xcms.txt
+d 0755 0 0 /usr/share/avahi
+f 0644 0 0 /usr/share/avahi/avahi-service.dtd
+d 0755 0 0 /usr/share/dbus-1
+d 0755 0 0 /usr/share/dbus-1/interfaces
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.AddressResolver.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.DomainBrowser.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.EntryGroup.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.HostNameResolver.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.RecordBrowser.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.Server.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.ServiceBrowser.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.ServiceResolver.xml
+f 0644 0 0 /usr/share/dbus-1/interfaces/org.freedesktop.Avahi.ServiceTypeBrowser.xml
+d 0755 0 0 /usr/share/dbus-1/services
+f 0644 0 0 /usr/share/dbus-1/session.conf
+d 0755 0 0 /usr/share/dbus-1/session.d
+d 0755 0 0 /usr/share/dbus-1/system-services
+f 0644 0 0 /usr/share/dbus-1/system.conf
+d 0755 0 0 /usr/share/dbus-1/system.d
+d 0755 0 0 /usr/share/dict
+d 0755 0 0 /usr/share/info
+d 0755 0 0 /usr/share/locale
+d 0755 0 0 /usr/share/locale/en_GB
+d 0755 0 0 /usr/share/locale/en_GB/LC_MESSAGES
+f 0644 0 0 /usr/share/locale/en_GB/LC_MESSAGES/avahi.mo
+d 0755 0 0 /usr/share/lxc
+d 0755 0 0 /usr/share/lxc/config
+f 0644 0 0 /usr/share/lxc/config/common.conf
+d 0755 0 0 /usr/share/lxc/config/common.conf.d
+f 0644 0 0 /usr/share/lxc/config/common.conf.d/README
+f 0644 0 0 /usr/share/lxc/config/common.seccomp
+f 0644 0 0 /usr/share/lxc/config/nesting.conf
+f 0644 0 0 /usr/share/lxc/config/oci.common.conf
+f 0644 0 0 /usr/share/lxc/config/userns.conf
+f 0644 0 0 /usr/share/lxc/lxc-patch.py
+f 0644 0 0 /usr/share/lxc/lxc.functions
+d 0755 0 0 /usr/share/man
+d 0755 0 0 /usr/share/misc
+d 0755 0 0 /usr/share/pantavisor
+f 0644 0 0 /usr/share/pantavisor/set-env
+d 0755 0 0 /usr/share/udhcpc
+f 0755 0 0 /usr/share/udhcpc/default.script
+d 0755 0 0 /usr/src
+d 0755 0 0 /var
+d 0755 0 0 /var/backups
+d 0755 0 0 /var/cache
+d 0755 0 0 /var/lib
+d 0755 999 999 /var/lib/dbus
+d 0755 0 0 /var/lib/misc
+d 0755 0 0 /var/lib/urandom
+d 0755 0 0 /var/local
+l 0777 0 0 /var/lock -> ../run/lock
+l 0777 0 0 /var/log -> volatile/log
+d 0755 0 0 /var/pantavisor
+d 0755 0 0 /var/pantavisor/storage
+d 0755 0 0 /var/pantavisor/storage/boot
+d 0755 0 0 /var/pantavisor/storage/config
+d 0755 0 0 /var/pantavisor/storage/disks
+d 0755 0 0 /var/pantavisor/storage/objects
+d 0755 0 0 /var/pantavisor/storage/trails
+d 0755 0 0 /var/pantavisor/storage/trails/0
+d 0755 0 0 /var/pantavisor/storage/trails/0/.pv
+d 0755 0 0 /var/pantavisor/storage/trails/0/.pvr
+f 0644 0 0 /var/pantavisor/storage/trails/0/.pvr/json
+l 0777 0 0 /var/run -> ../run
+d 0755 0 0 /var/spool
+d 0775 0 8 /var/spool/mail
+l 0777 0 0 /var/tmp -> volatile/tmp
+d 0755 0 0 /var/volatile
+d 0755 0 0 /var/volatile/log
+d 1777 0 0 /var/volatile/tmp

--- a/recipes-pv/images/pantavisor-initramfs.bb
+++ b/recipes-pv/images/pantavisor-initramfs.bb
@@ -3,6 +3,18 @@ inherit ${@bb.utils.contains_any('PANTAVISOR_FEATURES', 'pv-manifest-audit pv-ma
 
 PV_MANIFEST_PREFIX = "pv-initramfs"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/pv-manifests:"
+
+# Reference manifests for the upstream-supported MACHINEs. The audit
+# class only loads the one whose name matches the current
+# MACHINE/DISTRO/CODENAME; the others sit unused in WORKDIR. Listing
+# them flat here keeps the bbappend pattern simple — no per-machine
+# overrides to keep in sync.
+SRC_URI += " \
+    file://pv-initramfs_panta-raspberrypi-armv8-scarthgap.manifest.reference.txt \
+    file://pv-initramfs_panta-bananapi-m2-berry-scarthgap.manifest.reference.txt \
+"
+
 # Simple initramfs image artifact generation for tiny images.
 DESCRIPTION = "Pantavisor enabled Initramfs image for Pantavisor BSPs"
 

--- a/recipes-pv/images/pantavisor-initramfs.bb
+++ b/recipes-pv/images/pantavisor-initramfs.bb
@@ -1,4 +1,7 @@
 inherit image image-buildinfo
+inherit ${@bb.utils.contains_any('PANTAVISOR_FEATURES', 'pv-manifest-audit pv-manifest-strict', 'pv-manifest-audit', '', d)}
+
+PV_MANIFEST_PREFIX = "pv-initramfs"
 
 # Simple initramfs image artifact generation for tiny images.
 DESCRIPTION = "Pantavisor enabled Initramfs image for Pantavisor BSPs"

--- a/recipes-pv/images/pv-manifests/pv-initramfs_panta-bananapi-m2-berry-scarthgap.manifest.reference.txt
+++ b/recipes-pv/images/pv-manifests/pv-initramfs_panta-bananapi-m2-berry-scarthgap.manifest.reference.txt
@@ -1,0 +1,346 @@
+# pv-manifest-audit v1
+# format: type mode uid gid path[ -> symlink-target | major,minor]
+# machine: bananapi-m2-berry
+# distro:  panta (scarthgap)
+# prefix:  pv-initramfs
+# exclude: /var/lib/rpm /var/lib/dnf /var/lib/opkg /usr/lib/opkg /var/cache/ldconfig /var/cache/dnf /var/cache/yum
+d 0755 0 0 /bin
+l 0777 0 0 /bin/[ -> /bin/busybox.nosuid
+l 0777 0 0 /bin/[[ -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ascii -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ash -> /bin/busybox.nosuid
+l 0777 0 0 /bin/awk -> /bin/busybox.nosuid
+l 0777 0 0 /bin/base32 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/basename -> /bin/busybox.nosuid
+l 0777 0 0 /bin/bc -> /bin/busybox.nosuid
+l 0777 0 0 /bin/busybox -> busybox.nosuid
+f 0755 0 0 /bin/busybox.nosuid
+f 4755 0 0 /bin/busybox.suid
+l 0777 0 0 /bin/bzcat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/cat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/chmod -> /bin/busybox.nosuid
+l 0777 0 0 /bin/chown -> /bin/busybox.nosuid
+l 0777 0 0 /bin/chvt -> /bin/busybox.nosuid
+l 0777 0 0 /bin/clear -> /bin/busybox.nosuid
+l 0777 0 0 /bin/cp -> /bin/busybox.nosuid
+l 0777 0 0 /bin/crc32 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/cttyhack -> /bin/busybox.nosuid
+l 0777 0 0 /bin/date -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dd -> /bin/busybox.nosuid
+l 0777 0 0 /bin/deallocvt -> /bin/busybox.nosuid
+l 0777 0 0 /bin/df -> /bin/busybox.nosuid
+l 0777 0 0 /bin/diff -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dirname -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dmesg -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dnsdomainname -> /bin/busybox.nosuid
+l 0777 0 0 /bin/du -> /bin/busybox.nosuid
+l 0777 0 0 /bin/egrep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/factor -> /bin/busybox.nosuid
+l 0777 0 0 /bin/fallocate -> /bin/busybox.nosuid
+l 0777 0 0 /bin/fgconsole -> /bin/busybox.nosuid
+l 0777 0 0 /bin/fgrep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/find -> /bin/busybox.nosuid
+l 0777 0 0 /bin/grep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/gzip -> /bin/busybox.nosuid
+l 0777 0 0 /bin/head -> /bin/busybox.nosuid
+l 0777 0 0 /bin/hexdump -> /bin/busybox.nosuid
+l 0777 0 0 /bin/hexedit -> /bin/busybox.nosuid
+l 0777 0 0 /bin/iostat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/kill -> /bin/busybox.nosuid
+l 0777 0 0 /bin/killall -> /bin/busybox.nosuid
+l 0777 0 0 /bin/less -> /bin/busybox.nosuid
+l 0777 0 0 /bin/linux32 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/linux64 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ln -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ls -> /bin/busybox.nosuid
+l 0777 0 0 /bin/lsscsi -> /bin/busybox.nosuid
+l 0777 0 0 /bin/lzcat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mkdir -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mkfifo -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mknod -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mktemp -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mount -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mv -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nl -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nohup -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nproc -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nsenter -> /bin/busybox.nosuid
+l 0777 0 0 /bin/openvt -> /bin/busybox.nosuid
+l 0777 0 0 /bin/paste -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ping6 -> /bin/busybox.suid
+l 0777 0 0 /bin/printenv -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ps -> /bin/busybox.nosuid
+l 0777 0 0 /bin/pwd -> /bin/busybox.nosuid
+l 0777 0 0 /bin/reset -> /bin/busybox.nosuid
+l 0777 0 0 /bin/resize -> /bin/busybox.nosuid
+l 0777 0 0 /bin/resume -> /bin/busybox.nosuid
+l 0777 0 0 /bin/rm -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sed -> /bin/busybox.nosuid
+l 0777 0 0 /bin/setfattr -> /bin/busybox.nosuid
+l 0777 0 0 /bin/setpriv -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sh -> /bin/busybox.nosuid
+l 0777 0 0 /bin/shred -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sleep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sort -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ssl_client -> /bin/busybox.nosuid
+l 0777 0 0 /bin/stat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/stty -> /bin/busybox.nosuid
+l 0777 0 0 /bin/svc -> /bin/busybox.nosuid
+l 0777 0 0 /bin/svok -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sync -> /bin/busybox.nosuid
+l 0777 0 0 /bin/tail -> /bin/busybox.nosuid
+l 0777 0 0 /bin/telnet -> /bin/busybox.nosuid
+l 0777 0 0 /bin/top -> /bin/busybox.nosuid
+l 0777 0 0 /bin/touch -> /bin/busybox.nosuid
+l 0777 0 0 /bin/tr -> /bin/busybox.nosuid
+l 0777 0 0 /bin/true -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ts -> /bin/busybox.nosuid
+l 0777 0 0 /bin/tty -> /bin/busybox.nosuid
+l 0777 0 0 /bin/udhcpc6 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/umount -> /bin/busybox.nosuid
+l 0777 0 0 /bin/uname -> /bin/busybox.nosuid
+l 0777 0 0 /bin/unlink -> /bin/busybox.nosuid
+l 0777 0 0 /bin/unshare -> /bin/busybox.nosuid
+l 0777 0 0 /bin/vi -> /bin/busybox.nosuid
+l 0777 0 0 /bin/which -> /bin/busybox.nosuid
+l 0777 0 0 /bin/whoami -> /bin/busybox.nosuid
+l 0777 0 0 /bin/xxd -> /bin/busybox.nosuid
+l 0777 0 0 /bin/xzcat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/zcat -> /bin/busybox.nosuid
+l 0777 0 0 /configs -> run/pantavisor/configs
+d 0755 0 0 /etc
+d 0755 0 0 /etc/bash_completion.d
+f 0644 0 0 /etc/bash_completion.d/lxc
+f 0644 0 0 /etc/busybox.links.nosuid
+f 0644 0 0 /etc/busybox.links.suid
+d 0755 0 0 /etc/default
+f 0644 0 0 /etc/default/lxc
+d 0755 0 0 /etc/dnf
+f 0644 0 0 /etc/dnf/dnf.conf
+d 0755 0 0 /etc/dnf/modules.d
+d 0755 0 0 /etc/dnf/vars
+f 0644 0 0 /etc/dnf/vars/arch
+f 0644 0 0 /etc/dnf/vars/releasever
+d 0755 0 0 /etc/dropbear
+f 0644 0 0 /etc/group
+d 0755 0 0 /etc/init
+d 0755 0 0 /etc/init.d
+f 0755 0 0 /etc/init.d/run-postinsts
+f 0644 0 0 /etc/init/lxc-instance.conf
+f 0644 0 0 /etc/init/lxc-net.conf
+f 0644 0 0 /etc/init/lxc.conf
+f 0644 0 0 /etc/ld-musl-armhf.path
+d 0755 0 0 /etc/lxc
+f 0644 0 0 /etc/lxc/default.conf
+f 0644 0 0 /etc/mke2fs.conf
+d 0755 0 0 /etc/pantavisor
+f 0644 0 0 /etc/pantavisor.config
+d 0755 0 0 /etc/pantavisor/defaults
+f 0644 0 0 /etc/pantavisor/defaults/groups.json
+d 0755 0 0 /etc/pantavisor/policies
+f 0644 0 0 /etc/pantavisor/policies/prod.config
+f 0644 0 0 /etc/pantavisor/policies/test.config
+d 0755 0 0 /etc/pantavisor/pvs
+d 0755 0 0 /etc/pantavisor/pvs/trust
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-certificates.crt
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-oem-certificates.crt
+d 0755 0 0 /etc/pantavisor/ssh
+f 0644 0 0 /etc/pantavisor/ssh/README.ssh
+f 0644 0 0 /etc/passwd
+d 0755 0 0 /etc/rcS.d
+l 0777 0 0 /etc/rcS.d/S99run-postinsts -> ../init.d/run-postinsts
+f 0644 0 0 /etc/resolv.conf
+d 0755 0 0 /etc/rpm
+f 0644 0 0 /etc/rpm/macros
+f 0644 0 0 /etc/rpm/platform
+f 0644 0 0 /etc/rpmrc
+d 0755 0 0 /etc/thttp
+d 0755 0 0 /etc/thttp/certs
+f 0644 0 0 /etc/thttp/certs/isrg-root-x1-cross-signed.pem
+f 0644 0 0 /etc/thttp/certs/isrgrootx1.pem
+f 0644 0 0 /etc/version
+d 0755 0 0 /exports
+l 0777 0 0 /init -> usr/bin/pantavisor
+d 0755 0 0 /lib
+l 0777 0 0 /lib/ld-musl-armhf.so.1 -> ../usr/lib/libc.so
+l 0777 0 0 /lib/libblkid.so.1 -> libblkid.so.1.1.0
+f 0755 0 0 /lib/libblkid.so.1.1.0
+l 0777 0 0 /lib/libcap.so.2 -> libcap.so.2.69
+f 0755 0 0 /lib/libcap.so.2.69
+l 0777 0 0 /lib/libcom_err.so.2 -> libcom_err.so.2.1
+f 0755 0 0 /lib/libcom_err.so.2.1
+l 0777 0 0 /lib/libe2p.so.2 -> libe2p.so.2.3
+f 0755 0 0 /lib/libe2p.so.2.3
+l 0777 0 0 /lib/libext2fs.so.2 -> libext2fs.so.2.4
+f 0755 0 0 /lib/libext2fs.so.2.4
+f 0644 0 0 /lib/libgcc_s.so.1
+l 0777 0 0 /media -> run/pantavisor/media
+l 0777 0 0 /pv -> run/pantavisor/pv
+d 0755 0 0 /run
+d 0755 0 0 /run/pantavisor
+d 0755 0 0 /run/pantavisor/pv
+d 0755 0 0 /sbin
+l 0777 0 0 /sbin/blockdev -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/chroot -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/depmod -> /bin/busybox.nosuid
+f 0755 0 0 /sbin/dumpe2fs
+f 0755 0 0 /sbin/e2fsck
+l 0777 0 0 /sbin/fdisk -> /bin/busybox.nosuid
+f 0755 0 0 /sbin/fsck.ext2
+f 0755 0 0 /sbin/fsck.ext3
+f 0755 0 0 /sbin/fsck.ext4
+l 0777 0 0 /sbin/fsfreeze -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/getty -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/halt -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/hdparm -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/i2ctransfer -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ifconfig -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ifdown -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ifup -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/insmod -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/losetup -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mdev -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mim -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mkdosfs -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mke2fs -> /sbin/mke2fs.e2fsprogs
+f 0755 0 0 /sbin/mke2fs.e2fsprogs
+l 0777 0 0 /sbin/mkfs.ext2 -> /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext3
+f 0755 0 0 /sbin/mkfs.ext4
+l 0777 0 0 /sbin/mkswap -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/modinfo -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/modprobe -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/nologin -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/partprobe -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/pivot_root -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/poweroff -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/readahead -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/reboot -> /bin/busybox.nosuid
+f 0755 0 0 /sbin/resize2fs
+l 0777 0 0 /sbin/rfkill -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/run-init -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/setconsole -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/setlogcons -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/swapoff -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/swapon -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/tc -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/telnetd -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubiattach -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubidetach -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubimkvol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubirename -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubirmvol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubirsvol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubiupdatevol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/udhcpd -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/uevent -> /bin/busybox.nosuid
+d 0755 0 0 /usr
+d 0755 0 0 /usr/bin
+f 0755 0 0 /usr/bin/JSON.sh
+l 0777 0 0 /usr/bin/arch -> /bin/busybox.nosuid
+f 0755 0 0 /usr/bin/dcp-blob-create
+l 0777 0 0 /usr/bin/docker-runc -> runc
+f 0755 0 0 /usr/bin/fallbear-cmd
+f 0755 0 0 /usr/bin/fcntl-lock
+l 0777 0 0 /usr/bin/ldd -> ../lib/libc.so
+l 0777 0 0 /usr/bin/link -> /bin/busybox.nosuid
+f 0755 0 0 /usr/bin/lxc-console
+f 0755 0 0 /usr/bin/lxc-info
+f 0755 0 0 /usr/bin/lxc-ls
+f 0755 0 0 /usr/bin/lxc-top
+l 0777 0 0 /usr/bin/nc -> /usr/bin/nc.netcat-openbsd
+f 0755 0 0 /usr/bin/nc.netcat-openbsd
+f 0755 0 0 /usr/bin/pantavisor
+f 0755 0 0 /usr/bin/pv-xconnect
+f 0755 0 0 /usr/bin/pvcontrol
+f 0755 0 0 /usr/bin/pvcurl
+f 0755 0 0 /usr/bin/pventer
+f 0755 0 0 /usr/bin/runc
+f 0755 0 0 /usr/bin/update-alternatives
+d 0755 0 0 /usr/lib
+f 0755 0 0 /usr/lib/e2initrd_helper
+l 0777 0 0 /usr/lib/libbsd.so.0 -> libbsd.so.0.12.1
+f 0755 0 0 /usr/lib/libbsd.so.0.12.1
+f 0755 0 0 /usr/lib/libc.so
+f 0755 0 0 /usr/lib/libcrypto.so.3
+l 0777 0 0 /usr/lib/libcryptsetup.so.12 -> libcryptsetup.so.12.10.0
+f 0755 0 0 /usr/lib/libcryptsetup.so.12.10.0
+f 0555 0 0 /usr/lib/libdevmapper.so.1.02
+l 0777 0 0 /usr/lib/libjson-c.so.5 -> libjson-c.so.5.3.0
+f 0755 0 0 /usr/lib/libjson-c.so.5.3.0
+l 0777 0 0 /usr/lib/libkcapi.so.1 -> libkcapi.so.1.5.0
+f 0755 0 0 /usr/lib/libkcapi.so.1.5.0
+l 0777 0 0 /usr/lib/liblxc.so.1 -> liblxc.so.1.4.0
+f 0755 0 0 /usr/lib/liblxc.so.1.4.0
+f 0644 0 0 /usr/lib/libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedcrypto.so.7 -> libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedtls.so.14 -> libmbedtls.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedtls.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedx509.so.1 -> libmbedx509.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedx509.so.2.28.10
+l 0777 0 0 /usr/lib/libmd.so.0 -> libmd.so.0.1.0
+f 0755 0 0 /usr/lib/libmd.so.0.1.0
+l 0777 0 0 /usr/lib/libpopt.so.0 -> libpopt.so.0.0.2
+f 0755 0 0 /usr/lib/libpopt.so.0.0.2
+l 0777 0 0 /usr/lib/libpsx.so.2 -> libpsx.so.2.69
+f 0755 0 0 /usr/lib/libpsx.so.2.69
+f 0755 0 0 /usr/lib/libssl.so.3
+l 0777 0 0 /usr/lib/libstdc++.so.6 -> libstdc++.so.6.0.32
+f 0755 0 0 /usr/lib/libstdc++.so.6.0.32
+l 0777 0 0 /usr/lib/libuuid.so.1 -> libuuid.so.1.3.0
+f 0755 0 0 /usr/lib/libuuid.so.1.3.0
+l 0777 0 0 /usr/lib/libz.so.1 -> libz.so.1.3.1
+f 0755 0 0 /usr/lib/libz.so.1.3.1
+d 0755 0 0 /usr/lib/lxc
+d 0755 0 0 /usr/lib/lxc/rootfs
+f 0644 0 0 /usr/lib/lxc/rootfs/README
+d 0755 0 0 /usr/lib/pantavisor
+d 0755 0 0 /usr/lib/pantavisor/pv
+f 0755 0 0 /usr/lib/pantavisor/pv/JSON.sh
+d 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/export.sh
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/mdev.sh
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/remount
+f 0755 0 0 /usr/lib/pantavisor/pv/pv_e2fsgrow
+f 0755 0 0 /usr/lib/pantavisor/pv/pvcrash
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt/crypt
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity/dm
+f 0755 0 0 /usr/lib/pantavisor/pv_lxc.so
+d 0755 0 0 /usr/libexec
+d 0755 0 0 /usr/libexec/lxc
+d 0755 0 0 /usr/libexec/lxc/hooks
+f 0755 0 0 /usr/libexec/lxc/hooks/unmount-namespace
+f 0755 0 0 /usr/libexec/lxc/lxc-apparmor-load
+f 0755 0 0 /usr/libexec/lxc/lxc-containers
+f 0755 0 0 /usr/libexec/lxc/lxc-monitord
+f 0755 0 0 /usr/libexec/lxc/lxc-net
+f 4755 0 0 /usr/libexec/lxc/lxc-user-nic
+d 0755 0 0 /usr/sbin
+f 0755 0 0 /usr/sbin/cryptsetup
+f 0555 0 0 /usr/sbin/dmsetup
+l 0777 0 0 /usr/sbin/dmstats -> dmsetup
+l 0777 0 0 /usr/sbin/dropbear -> ./dropbearmulti
+f 0755 0 0 /usr/sbin/dropbearmulti
+f 0755 0 0 /usr/sbin/fixparts
+f 0755 0 0 /usr/sbin/gdisk
+f 0755 0 0 /usr/sbin/init.lxc
+f 0755 0 0 /usr/sbin/init.lxc.static
+f 0755 0 0 /usr/sbin/integritysetup
+f 0755 0 0 /usr/sbin/run-postinsts
+f 0755 0 0 /usr/sbin/sgdisk
+f 0755 0 0 /usr/sbin/veritysetup
+d 0755 0 0 /usr/var
+d 0755 0 0 /usr/var/cache
+d 0755 0 0 /usr/var/cache/lxc
+d 0755 0 0 /usr/var/lib
+d 0755 0 0 /usr/var/lib/lxc
+d 0755 0 0 /var
+d 0755 0 0 /var/cache
+d 0755 0 0 /var/lib
+l 0777 0 0 /var/run -> ../run
+d 0755 0 0 /volumes
+d 0755 0 0 /writable

--- a/recipes-pv/images/pv-manifests/pv-initramfs_panta-raspberrypi-armv8-scarthgap.manifest.reference.txt
+++ b/recipes-pv/images/pv-manifests/pv-initramfs_panta-raspberrypi-armv8-scarthgap.manifest.reference.txt
@@ -1,0 +1,341 @@
+# pv-manifest-audit v1
+# format: type mode uid gid path[ -> symlink-target | major,minor]
+# machine: raspberrypi-armv8
+# distro:  panta (scarthgap)
+# prefix:  pv-initramfs
+# exclude: /var/lib/rpm /var/lib/dnf /var/lib/opkg /usr/lib/opkg /var/cache/ldconfig /var/cache/dnf /var/cache/yum
+d 0755 0 0 /bin
+l 0777 0 0 /bin/[ -> /bin/busybox.nosuid
+l 0777 0 0 /bin/[[ -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ascii -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ash -> /bin/busybox.nosuid
+l 0777 0 0 /bin/awk -> /bin/busybox.nosuid
+l 0777 0 0 /bin/base32 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/basename -> /bin/busybox.nosuid
+l 0777 0 0 /bin/bc -> /bin/busybox.nosuid
+l 0777 0 0 /bin/busybox -> busybox.nosuid
+f 0755 0 0 /bin/busybox.nosuid
+f 4755 0 0 /bin/busybox.suid
+l 0777 0 0 /bin/bzcat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/cat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/chmod -> /bin/busybox.nosuid
+l 0777 0 0 /bin/chown -> /bin/busybox.nosuid
+l 0777 0 0 /bin/chvt -> /bin/busybox.nosuid
+l 0777 0 0 /bin/clear -> /bin/busybox.nosuid
+l 0777 0 0 /bin/cp -> /bin/busybox.nosuid
+l 0777 0 0 /bin/crc32 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/cttyhack -> /bin/busybox.nosuid
+l 0777 0 0 /bin/date -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dd -> /bin/busybox.nosuid
+l 0777 0 0 /bin/deallocvt -> /bin/busybox.nosuid
+l 0777 0 0 /bin/df -> /bin/busybox.nosuid
+l 0777 0 0 /bin/diff -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dirname -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dmesg -> /bin/busybox.nosuid
+l 0777 0 0 /bin/dnsdomainname -> /bin/busybox.nosuid
+l 0777 0 0 /bin/du -> /bin/busybox.nosuid
+l 0777 0 0 /bin/egrep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/factor -> /bin/busybox.nosuid
+l 0777 0 0 /bin/fallocate -> /bin/busybox.nosuid
+l 0777 0 0 /bin/fgconsole -> /bin/busybox.nosuid
+l 0777 0 0 /bin/fgrep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/find -> /bin/busybox.nosuid
+l 0777 0 0 /bin/grep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/gzip -> /bin/busybox.nosuid
+l 0777 0 0 /bin/head -> /bin/busybox.nosuid
+l 0777 0 0 /bin/hexdump -> /bin/busybox.nosuid
+l 0777 0 0 /bin/hexedit -> /bin/busybox.nosuid
+l 0777 0 0 /bin/iostat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/kill -> /bin/busybox.nosuid
+l 0777 0 0 /bin/killall -> /bin/busybox.nosuid
+l 0777 0 0 /bin/less -> /bin/busybox.nosuid
+l 0777 0 0 /bin/linux32 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/linux64 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ln -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ls -> /bin/busybox.nosuid
+l 0777 0 0 /bin/lsscsi -> /bin/busybox.nosuid
+l 0777 0 0 /bin/lzcat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mkdir -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mkfifo -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mknod -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mktemp -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mount -> /bin/busybox.nosuid
+l 0777 0 0 /bin/mv -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nl -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nohup -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nproc -> /bin/busybox.nosuid
+l 0777 0 0 /bin/nsenter -> /bin/busybox.nosuid
+l 0777 0 0 /bin/openvt -> /bin/busybox.nosuid
+l 0777 0 0 /bin/paste -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ping6 -> /bin/busybox.suid
+l 0777 0 0 /bin/printenv -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ps -> /bin/busybox.nosuid
+l 0777 0 0 /bin/pwd -> /bin/busybox.nosuid
+l 0777 0 0 /bin/reset -> /bin/busybox.nosuid
+l 0777 0 0 /bin/resize -> /bin/busybox.nosuid
+l 0777 0 0 /bin/resume -> /bin/busybox.nosuid
+l 0777 0 0 /bin/rm -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sed -> /bin/busybox.nosuid
+l 0777 0 0 /bin/setfattr -> /bin/busybox.nosuid
+l 0777 0 0 /bin/setpriv -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sh -> /bin/busybox.nosuid
+l 0777 0 0 /bin/shred -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sleep -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sort -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ssl_client -> /bin/busybox.nosuid
+l 0777 0 0 /bin/stat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/stty -> /bin/busybox.nosuid
+l 0777 0 0 /bin/svc -> /bin/busybox.nosuid
+l 0777 0 0 /bin/svok -> /bin/busybox.nosuid
+l 0777 0 0 /bin/sync -> /bin/busybox.nosuid
+l 0777 0 0 /bin/tail -> /bin/busybox.nosuid
+l 0777 0 0 /bin/telnet -> /bin/busybox.nosuid
+l 0777 0 0 /bin/top -> /bin/busybox.nosuid
+l 0777 0 0 /bin/touch -> /bin/busybox.nosuid
+l 0777 0 0 /bin/tr -> /bin/busybox.nosuid
+l 0777 0 0 /bin/true -> /bin/busybox.nosuid
+l 0777 0 0 /bin/ts -> /bin/busybox.nosuid
+l 0777 0 0 /bin/tty -> /bin/busybox.nosuid
+l 0777 0 0 /bin/udhcpc6 -> /bin/busybox.nosuid
+l 0777 0 0 /bin/umount -> /bin/busybox.nosuid
+l 0777 0 0 /bin/uname -> /bin/busybox.nosuid
+l 0777 0 0 /bin/unlink -> /bin/busybox.nosuid
+l 0777 0 0 /bin/unshare -> /bin/busybox.nosuid
+l 0777 0 0 /bin/vi -> /bin/busybox.nosuid
+l 0777 0 0 /bin/which -> /bin/busybox.nosuid
+l 0777 0 0 /bin/whoami -> /bin/busybox.nosuid
+l 0777 0 0 /bin/xxd -> /bin/busybox.nosuid
+l 0777 0 0 /bin/xzcat -> /bin/busybox.nosuid
+l 0777 0 0 /bin/zcat -> /bin/busybox.nosuid
+l 0777 0 0 /configs -> run/pantavisor/configs
+d 0755 0 0 /etc
+f 0644 0 0 /etc/busybox.links.nosuid
+f 0644 0 0 /etc/busybox.links.suid
+d 0755 0 0 /etc/dnf
+f 0644 0 0 /etc/dnf/dnf.conf
+d 0755 0 0 /etc/dnf/modules.d
+d 0755 0 0 /etc/dnf/vars
+f 0644 0 0 /etc/dnf/vars/arch
+f 0644 0 0 /etc/dnf/vars/releasever
+d 0755 0 0 /etc/dropbear
+f 0644 0 0 /etc/group
+d 0755 0 0 /etc/init.d
+f 0755 0 0 /etc/init.d/run-postinsts
+f 0644 0 0 /etc/ld-musl-aarch64.path
+d 0755 0 0 /etc/lxc
+f 0644 0 0 /etc/lxc/default.conf
+f 0644 0 0 /etc/mke2fs.conf
+d 0755 0 0 /etc/pantavisor
+f 0644 0 0 /etc/pantavisor.config
+d 0755 0 0 /etc/pantavisor/defaults
+f 0644 0 0 /etc/pantavisor/defaults/groups.json
+d 0755 0 0 /etc/pantavisor/policies
+f 0644 0 0 /etc/pantavisor/policies/prod.config
+f 0644 0 0 /etc/pantavisor/policies/test.config
+d 0755 0 0 /etc/pantavisor/pvs
+d 0755 0 0 /etc/pantavisor/pvs/trust
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-certificates.crt
+f 0644 0 0 /etc/pantavisor/pvs/trust/ca-oem-certificates.crt
+d 0755 0 0 /etc/pantavisor/ssh
+f 0644 0 0 /etc/pantavisor/ssh/README.ssh
+f 0644 0 0 /etc/passwd
+d 0755 0 0 /etc/rcS.d
+l 0777 0 0 /etc/rcS.d/S99run-postinsts -> ../init.d/run-postinsts
+f 0644 0 0 /etc/resolv.conf
+d 0755 0 0 /etc/rpm
+f 0644 0 0 /etc/rpm/macros
+f 0644 0 0 /etc/rpm/platform
+f 0644 0 0 /etc/rpmrc
+d 0755 0 0 /etc/thttp
+d 0755 0 0 /etc/thttp/certs
+f 0644 0 0 /etc/thttp/certs/isrg-root-x1-cross-signed.pem
+f 0644 0 0 /etc/thttp/certs/isrgrootx1.pem
+f 0644 0 0 /etc/version
+d 0755 0 0 /exports
+l 0777 0 0 /init -> usr/bin/pantavisor
+d 0755 0 0 /lib
+l 0777 0 0 /lib/ld-musl-aarch64.so.1 -> ../usr/lib/libc.so
+l 0777 0 0 /lib/libblkid.so.1 -> libblkid.so.1.1.0
+f 0755 0 0 /lib/libblkid.so.1.1.0
+l 0777 0 0 /lib/libcap.so.2 -> libcap.so.2.69
+f 0755 0 0 /lib/libcap.so.2.69
+l 0777 0 0 /lib/libcom_err.so.2 -> libcom_err.so.2.1
+f 0755 0 0 /lib/libcom_err.so.2.1
+l 0777 0 0 /lib/libe2p.so.2 -> libe2p.so.2.3
+f 0755 0 0 /lib/libe2p.so.2.3
+l 0777 0 0 /lib/libext2fs.so.2 -> libext2fs.so.2.4
+f 0755 0 0 /lib/libext2fs.so.2.4
+f 0644 0 0 /lib/libgcc_s.so.1
+l 0777 0 0 /media -> run/pantavisor/media
+l 0777 0 0 /pv -> run/pantavisor/pv
+d 0755 0 0 /run
+d 0755 0 0 /run/pantavisor
+d 0755 0 0 /run/pantavisor/pv
+d 0755 0 0 /sbin
+l 0777 0 0 /sbin/blockdev -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/chroot -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/depmod -> /bin/busybox.nosuid
+f 0755 0 0 /sbin/dumpe2fs
+f 0755 0 0 /sbin/e2fsck
+l 0777 0 0 /sbin/fdisk -> /bin/busybox.nosuid
+f 0755 0 0 /sbin/fsck.ext2
+f 0755 0 0 /sbin/fsck.ext3
+f 0755 0 0 /sbin/fsck.ext4
+l 0777 0 0 /sbin/fsfreeze -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/getty -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/halt -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/hdparm -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/i2ctransfer -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ifconfig -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ifdown -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ifup -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/insmod -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/losetup -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mdev -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mim -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mkdosfs -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/mke2fs -> /sbin/mke2fs.e2fsprogs
+f 0755 0 0 /sbin/mke2fs.e2fsprogs
+l 0777 0 0 /sbin/mkfs.ext2 -> /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext2.e2fsprogs
+f 0755 0 0 /sbin/mkfs.ext3
+f 0755 0 0 /sbin/mkfs.ext4
+l 0777 0 0 /sbin/mkswap -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/modinfo -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/modprobe -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/nologin -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/partprobe -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/pivot_root -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/poweroff -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/readahead -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/reboot -> /bin/busybox.nosuid
+f 0755 0 0 /sbin/resize2fs
+l 0777 0 0 /sbin/rfkill -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/run-init -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/setconsole -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/setlogcons -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/swapoff -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/swapon -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/tc -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/telnetd -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubiattach -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubidetach -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubimkvol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubirename -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubirmvol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubirsvol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/ubiupdatevol -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/udhcpd -> /bin/busybox.nosuid
+l 0777 0 0 /sbin/uevent -> /bin/busybox.nosuid
+d 0755 0 0 /usr
+d 0755 0 0 /usr/bin
+f 0755 0 0 /usr/bin/JSON.sh
+l 0777 0 0 /usr/bin/arch -> /bin/busybox.nosuid
+f 0755 0 0 /usr/bin/dcp-blob-create
+l 0777 0 0 /usr/bin/docker-runc -> runc
+f 0755 0 0 /usr/bin/fallbear-cmd
+f 0755 0 0 /usr/bin/fcntl-lock
+l 0777 0 0 /usr/bin/ldd -> ../lib/libc.so
+l 0777 0 0 /usr/bin/link -> /bin/busybox.nosuid
+f 0755 0 0 /usr/bin/lxc-console
+f 0755 0 0 /usr/bin/lxc-info
+f 0755 0 0 /usr/bin/lxc-ls
+f 0755 0 0 /usr/bin/lxc-top
+l 0777 0 0 /usr/bin/nc -> /usr/bin/nc.netcat-openbsd
+f 0755 0 0 /usr/bin/nc.netcat-openbsd
+f 0755 0 0 /usr/bin/pantavisor
+f 0755 0 0 /usr/bin/pv-xconnect
+f 0755 0 0 /usr/bin/pvcontrol
+f 0755 0 0 /usr/bin/pvcurl
+f 0755 0 0 /usr/bin/pventer
+f 0755 0 0 /usr/bin/runc
+f 0755 0 0 /usr/bin/update-alternatives
+d 0755 0 0 /usr/lib
+f 0755 0 0 /usr/lib/e2initrd_helper
+l 0777 0 0 /usr/lib/libbsd.so.0 -> libbsd.so.0.12.1
+f 0755 0 0 /usr/lib/libbsd.so.0.12.1
+f 0755 0 0 /usr/lib/libc.so
+f 0755 0 0 /usr/lib/libcrypto.so.3
+l 0777 0 0 /usr/lib/libcryptsetup.so.12 -> libcryptsetup.so.12.10.0
+f 0755 0 0 /usr/lib/libcryptsetup.so.12.10.0
+f 0555 0 0 /usr/lib/libdevmapper.so.1.02
+l 0777 0 0 /usr/lib/libjson-c.so.5 -> libjson-c.so.5.3.0
+f 0755 0 0 /usr/lib/libjson-c.so.5.3.0
+l 0777 0 0 /usr/lib/libkcapi.so.1 -> libkcapi.so.1.5.0
+f 0755 0 0 /usr/lib/libkcapi.so.1.5.0
+l 0777 0 0 /usr/lib/liblxc.so.1 -> liblxc.so.1.8.0
+f 0755 0 0 /usr/lib/liblxc.so.1.8.0
+f 0644 0 0 /usr/lib/libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedcrypto.so.7 -> libmbedcrypto.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedtls.so.14 -> libmbedtls.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedtls.so.2.28.10
+l 0777 0 0 /usr/lib/libmbedx509.so.1 -> libmbedx509.so.2.28.10
+f 0644 0 0 /usr/lib/libmbedx509.so.2.28.10
+l 0777 0 0 /usr/lib/libmd.so.0 -> libmd.so.0.1.0
+f 0755 0 0 /usr/lib/libmd.so.0.1.0
+l 0777 0 0 /usr/lib/libpopt.so.0 -> libpopt.so.0.0.2
+f 0755 0 0 /usr/lib/libpopt.so.0.0.2
+l 0777 0 0 /usr/lib/libpsx.so.2 -> libpsx.so.2.69
+f 0755 0 0 /usr/lib/libpsx.so.2.69
+l 0777 0 0 /usr/lib/libstdc++.so.6 -> libstdc++.so.6.0.32
+f 0755 0 0 /usr/lib/libstdc++.so.6.0.32
+l 0777 0 0 /usr/lib/libuuid.so.1 -> libuuid.so.1.3.0
+f 0755 0 0 /usr/lib/libuuid.so.1.3.0
+l 0777 0 0 /usr/lib/libz.so.1 -> libz.so.1.3.1
+f 0755 0 0 /usr/lib/libz.so.1.3.1
+d 0755 0 0 /usr/lib/lxc
+d 0755 0 0 /usr/lib/lxc/rootfs
+f 0644 0 0 /usr/lib/lxc/rootfs/README
+d 0755 0 0 /usr/lib/pantavisor
+d 0755 0 0 /usr/lib/pantavisor/pv
+f 0755 0 0 /usr/lib/pantavisor/pv/JSON.sh
+d 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/export.sh
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/mdev.sh
+f 0755 0 0 /usr/lib/pantavisor/pv/hooks_lxc-mount.d/remount
+f 0755 0 0 /usr/lib/pantavisor/pv/pv_e2fsgrow
+f 0755 0 0 /usr/lib/pantavisor/pv/pvcrash
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/crypt/crypt
+d 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity
+f 0755 0 0 /usr/lib/pantavisor/pv/volmount/verity/dm
+f 0755 0 0 /usr/lib/pantavisor/pv_lxc.so
+d 0755 0 0 /usr/libexec
+d 0755 0 0 /usr/libexec/lxc
+d 0755 0 0 /usr/libexec/lxc/hooks
+f 0755 0 0 /usr/libexec/lxc/hooks/unmount-namespace
+f 0755 0 0 /usr/libexec/lxc/lxc-monitord
+f 4755 0 0 /usr/libexec/lxc/lxc-user-nic
+d 0755 0 0 /usr/sbin
+f 0755 0 0 /usr/sbin/cryptsetup
+f 0555 0 0 /usr/sbin/dmsetup
+l 0777 0 0 /usr/sbin/dmstats -> dmsetup
+l 0777 0 0 /usr/sbin/dropbear -> ./dropbearmulti
+f 0755 0 0 /usr/sbin/dropbearmulti
+f 0755 0 0 /usr/sbin/fixparts
+f 0755 0 0 /usr/sbin/gdisk
+f 0755 0 0 /usr/sbin/init.lxc
+f 0755 0 0 /usr/sbin/init.lxc.static
+f 0755 0 0 /usr/sbin/integritysetup
+f 0755 0 0 /usr/sbin/run-postinsts
+f 0755 0 0 /usr/sbin/sgdisk
+f 0755 0 0 /usr/sbin/veritysetup
+d 0755 0 0 /usr/share
+d 0755 0 0 /usr/share/lxc
+d 0755 0 0 /usr/share/lxc/config
+f 0644 0 0 /usr/share/lxc/config/common.conf
+d 0755 0 0 /usr/share/lxc/config/common.conf.d
+f 0644 0 0 /usr/share/lxc/config/common.conf.d/README
+f 0644 0 0 /usr/share/lxc/config/common.seccomp
+f 0644 0 0 /usr/share/lxc/config/nesting.conf
+f 0644 0 0 /usr/share/lxc/config/oci.common.conf
+f 0644 0 0 /usr/share/lxc/config/userns.conf
+f 0644 0 0 /usr/share/lxc/lxc-patch.py
+f 0644 0 0 /usr/share/lxc/lxc.functions
+d 0755 0 0 /var
+d 0755 0 0 /var/cache
+d 0755 0 0 /var/lib
+l 0777 0 0 /var/run -> ../run
+d 0755 0 0 /volumes
+d 0755 0 0 /writable


### PR DESCRIPTION
## Summary

Adds a deterministic rootfs manifest audit for pantavisor image recipes, ships the four upstream-supported reference manifests so the audit gates real drift on day one, and surfaces the audit output as a CI artifact that survives strict-mode `bb.fatal`.

Catches a class of regressions that ordinary CI does not — surprise setuid bits, stray files in `/var`, ownership flips, lost symlinks — without flagging on benign noise like sqlite write-aheads or version-driven file size changes.

### Mechanism

- New class `classes/pv-manifest-audit.bbclass` walks `${IMAGE_ROOTFS}` under pseudo and emits a sorted `type mode uid gid path[…]` listing.
- The class diffs against a reference file fetched into `${WORKDIR}` via `SRC_URI`. Drift produces a unified-diff patch that is:
  - written to `${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.manifest.patch` (lands directly in `deploy/images/<MACHINE>/`, not via `${IMGDEPLOYDIR}` staging — this matters under strict mode, see below),
  - printed in full to the bitbake log via `bb.plain` so CI captures it without artifact uploads,
  - formatted with bare-basename headers so a maintainer can apply it with `cd <layer>/pv-manifests && patch < …`.
- Two `PANTAVISOR_FEATURES` flags select behaviour:
  - `pv-manifest-audit` — advisory: WARNING + patch, build proceeds (default for `panta` and `panta-appengine` distros).
  - `pv-manifest-strict` — enforcing: ERROR + patch, build fails. Use in release/CI configs.
- Reference filename embeds DISTRO so panta vs panta-appengine vs downstream distros don't collide: `${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt`.
- `PV_MANIFEST_EXCLUDES` filters package-manager state directories (`/var/lib/rpm`, `/var/lib/dnf`, `/usr/lib/opkg`, `/var/cache/dnf`, etc.) so the reference doesn't rot on every rebuild.
- File size is **intentionally omitted** — version bumps would otherwise produce noise without behavioural meaning. Add/remove of files is still detected via path presence.
- Inherited conditionally so the class is a no-op when neither flag is set:
  - `recipes-pv/images/pantavisor-initramfs.bb` (`PV_MANIFEST_PREFIX = "pv-initramfs"`)
  - `dynamic-layers/.../pantavisor-appengine.inc` (`PV_MANIFEST_PREFIX = "pv-appengine"`)
  - `dynamic-layers/.../pantavisor-appengine-tester.bb` overrides to `"pv-appengine-tester"` so it doesn't collide with the base appengine reference (the tester rootfs is materially larger — bc, curl, jq, pantavisor-pvtest, procps, pvr, valgrind, vim-xxd).

Operator guide added at `docs/how-to-build/manifest-audit.md` and linked from CLAUDE.md.

### Reference manifests

Reference manifests live in a dedicated `pv-manifests/` directory next to each image recipe (kept out of `files/` to avoid noise). The recipes prepend that directory to `FILESEXTRAPATHS` and list every reference flat in `SRC_URI` — the audit class only loads the one whose name matches the current PREFIX/MACHINE/DISTRO/CODENAME, so the unused entries just sit in WORKDIR, no per-machine overrides to keep in sync.

```
recipes-pv/images/pv-manifests/
  pv-initramfs_panta-raspberrypi-armv8-scarthgap.manifest.reference.txt
  pv-initramfs_panta-bananapi-m2-berry-scarthgap.manifest.reference.txt

dynamic-layers/virtualization-layer/recipes-pv/images/pv-manifests/
  pv-appengine_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt
  pv-appengine-tester_panta-appengine-docker-x86_64-scarthgap.manifest.reference.txt
```

The four references were lifted directly from the first PR-298 CI run and committed as the baseline. CI is now green: the second CI run on this branch produces no drift patches and no warnings.

### CI artifact (survives `bb.fatal`)

`.github/workflows/buildkas-target.yaml` copies `*.manifest.txt` and `*.manifest.patch` out of `deploy/images/` and uploads them as `manifest-audit-<target>-<machine>`. Two correctness fixes make this work even under strict-mode failure:

- **`if: always()`** on the prepare-files and every upload-artifact step. By default GitHub Actions skips remaining steps when an earlier step fails, so a failing `kas build` (e.g. `bb.fatal` from `pv-manifest-strict`) would otherwise prevent the manifest from being uploaded — exactly when a maintainer needs the drift patch most.
- **Write to `${DEPLOY_DIR_IMAGE}` instead of `${IMGDEPLOYDIR}`.** The latter is per-recipe staging that bitbake only rsyncs into the deploy dir on successful task completion. `bb.fatal` from inside `ROOTFS_POSTPROCESS_COMMAND` aborts `do_rootfs`, so a strict-mode failure would otherwise leave the diagnostic artifact stranded in `WORKDIR` where CI never finds it. We give up atomic image deploy for the manifest, but it's a diagnostic — that's the right trade.

## Test plan

Verified locally via `kas-container build kas/build-configs/release/rpi-scarthgap.yaml --target pantavisor-initramfs` and on the PR's CI:

- [x] No flag set → class not inherited, no audit (no-op).
- [x] `pv-manifest-audit` (advisory, panta default) → build succeeds, WARNING emitted, full patch in bitbake log under `=== pv-manifest-audit PATCH (<machine>, audit) ===` banner, `.manifest.txt` + `.manifest.patch` deployed alongside the cpio.
- [x] `pv-manifest-strict` → ERROR emitted, `do_rootfs` fails (`bb.fatal`), bitbake exit 1, banner shows `STRICT`.
- [x] `vardeps` invalidate `do_rootfs` when `PANTAVISOR_FEATURES`, `PV_MANIFEST_PREFIX`, `PV_MANIFEST_REFERENCE_NAME`, or `PV_MANIFEST_EXCLUDES` change (force-rerun verified).
- [x] `PV_MANIFEST_EXCLUDES` correctly prunes `/var/lib/rpm/*`, `/var/lib/dnf/*` from manifest (393 → 378 entries on rpi-scarthgap initramfs).
- [x] Reference name includes DISTRO + underscore separator.
- [x] First PR CI run produced manifests for raspberrypi-armv8 (initramfs), bananapi-m2-berry (initramfs), docker-x86_64 (appengine + appengine-tester); committed as references in `pv-manifests/`.
- [x] CI workflow uploads `manifest-audit-<target>-<machine>` artifacts containing both `.manifest.txt` and `.manifest.patch`.
- [x] **Second CI run on this branch produces no drift patches** (run `25274398191` push + `25274399019` PR — all three machines green; references match).
- [x] **Strict-mode failure path validated end-to-end** via a temporary experimental commit (since reverted) that flipped both distros to `pv-manifest-strict` and removed the bananapi reference. Result: docker + rpi-armv8 passed, sunxi-bananapi-m2-berry failed at `do_rootfs` with the strict banner, and the `manifest-audit-…sunxi…` artifact still uploaded with a full-add patch — confirming both `if: always()` and the `DEPLOY_DIR_IMAGE` fix.
- [ ] Flip a CI config to `pv-manifest-strict` in a follow-up PR once references soak.

## Notes for reviewers

- The class registers a `ROOTFS_POSTPROCESS_COMMAND` that runs under pseudo, so recorded uid/gid match what ends up in the cpio.
- Default `panta` distro is **advisory only** so existing builds keep working until references stabilise; flip a CI config to `pv-manifest-strict` once references land to gate drift.
- Downstream layers can ship references with the same pattern in a `pantavisor-initramfs.bbappend`:
  ```bitbake
  FILESEXTRAPATHS:prepend := "${THISDIR}/pv-manifests:"
  SRC_URI += "file://pv-initramfs_<DISTRO>-<MACHINE>-<CODENAME>.manifest.reference.txt"
  ```