### PR TITLE
fix: VDSO build for rpi machine

### DIFF
--- a/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -76,22 +76,27 @@ python __anonymous () {
 }
 
 # Build a shim directory under the kernel's WORKDIR with un-prefixed
-# symlinks (`as`, `ld`, `objcopy`, `objdump`, `gcc`, `cpp`, `nm`, `ar`,
-# `ranlib`, `strip`) pointing at the v6 multiconfig's prefixed cross-
-# binaries. Without this, gcc's internal assembler invocation finds
-# the host /usr/bin/as ("as: unrecognized option '-EL'") because the
-# Yocto cross-gcc package doesn't ship `as` in its libexec — it
-# expects PATH to provide either the prefixed or un-prefixed name,
-# and Kbuild's vdso32 rules end up calling plain `as` directly.
+# symlinks for the binutils tools (`as`, `ld`, `objcopy`, `objdump`,
+# `nm`, `ar`, `ranlib`, `strip`) pointing at the v6 multiconfig's
+# prefixed cross-binaries. Without this, gcc's internal assembler
+# invocation finds the host /usr/bin/as ("as: unrecognized option
+# '-EL'") because the Yocto cross-gcc package doesn't ship `as` in
+# its libexec — it expects PATH to provide either the prefixed or
+# un-prefixed name, and Kbuild's vdso32 rules end up calling plain
+# `as` directly.
+#
+# Compiler frontends (gcc/g++/cpp) are deliberately NOT shimmed
+# un-prefixed: Kbuild always invokes them via CROSS_COMPILE_COMPAT,
+# i.e. as `arm-poky-linux-musleabi-gcc`, which the cross-gcc bin dir
+# (also on PATH) already provides. Adding un-prefixed `gcc`/`cpp`
+# symlinks here would poison HOSTCC for kernel host-tool builds
+# (scripts/dtc, etc.) — `HOSTCC=gcc` would resolve to the arm32
+# cross-gcc and fail with "stdio.h: No such file or directory".
 setup_compat_toolchain_shim () {
     install -d ${COMPAT_SHIM_DIR}
-    for tool in as ld objcopy objdump nm ar ranlib strip cpp; do
+    for tool in as ld objcopy objdump nm ar ranlib strip; do
         ln -sf "${COMPAT_BUTILS_BIN_DIR}/${COMPAT_TRIPLET}-$tool" \
             "${COMPAT_SHIM_DIR}/$tool"
-    done
-    for tool in gcc g++ cpp; do
-        ln -sf "${COMPAT_GCC_BIN_DIR}/${COMPAT_TRIPLET}-$tool" \
-            "${COMPAT_SHIM_DIR}/$tool" 2>/dev/null || true
     done
     export PATH="${COMPAT_SHIM_DIR}:${COMPAT_GCC_BIN_DIR}:${COMPAT_BUTILS_BIN_DIR}:${PATH}"
 }


### PR DESCRIPTION
## Summary

Minimal follow-up to #295 that fixes the kernel `do_compile` regression
exposed by the `028-rc6` ontag CI run for `rpi-scarthgap`.

The compat-vDSO PATH shim symlinked un-prefixed `gcc`/`g++`/`cpp` at
the arm32 cross-toolchain and prepended that directory to `PATH` for
the kernel's `do_compile`. Kbuild's host-tool build (`scripts/dtc`)
invokes `HOSTCC=gcc`, which on a clean (no-sstate) build then resolved
to `arm-poky-linux-musleabi-gcc` instead of host gcc and failed with:

    scripts/dtc/dtc.h:9:10: fatal error: stdio.h: No such file or directory
    gcc-cross-arm/.../include/stdint.h:9:26: error: no include path in
        which to search for stdint.h

Local rpi-scarthgap builds did not hit this because either sstate
satisfied `do_compile` or the prior incremental `work-shared`
kernel-source already had `scripts/dtc/*.o` built with a clean HOSTCC.
The ontag CI is the first cold build for these commits and exposed it.

Fix: drop the un-prefixed `gcc`/`g++`/`cpp` symlinks from the shim.
Kbuild's vdso32 path always invokes the compiler via
`CROSS_COMPILE_COMPAT`, i.e. as `arm-poky-linux-musleabi-gcc`, which
`COMPAT_GCC_BIN_DIR` on PATH already provides. Only the binutils
tools (`as`, `ld`, `objcopy`, …) still need un-prefixed entries,
since gcc's internal assembler/linker invocations call them by plain
name.

## Test plan
- [x] Local `rpi-scarthgap` build with `pantavisor-bsp` target — all
  12640 tasks succeeded, including `mc:rpi-kernel8:linux-raspberrypi
  do_compile` and `do_compile_kernelmodules` which were the failing
  tasks in CI.
- [ ] CI `rpi-scarthgap` job goes green.