### PR TITLE
fix(pvtest): use sudo for losetup probe/enumerate on unprivileged runners

### DIFF
--- a/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
@@ -300,11 +300,14 @@ exec_test() {
 	tester_name="pantavisor-tester-${slot}"
 	netsim_name="pantavisor-netsim-${slot}"
 	host_port=$((8222 + slot))
-	# losetup -D would detach loop devices used by sibling parallel runs.
-	# losetup -f races between concurrent callers but the container also gets
-	# /dev/loop-control + a 'b 7:* rmw' device-cgroup rule, so it can allocate
-	# its own loop devices internally regardless of which one we preview here.
-	unused_lo=$(losetup -f)
+	# losetup -D would detach loop devices used by sibling parallel runs, so
+	# we no longer call it. losetup -f needs root on CI runners where
+	# /dev/loop* is not world-readable — match the privilege the previous
+	# `sudo -n losetup -D` line ran with. The race between concurrent callers
+	# is benign: the container also gets /dev/loop-control + a 'b 7:* rmw'
+	# device-cgroup rule, so it can allocate its own loop devices internally
+	# regardless of which one we preview here.
+	unused_lo=$(sudo -n losetup -f)
 
 	start=$(date +%s)
 
@@ -370,7 +373,7 @@ exec_test() {
 	# Detach only loop devices whose backing file lives under this run's
 	# storage tree. Targets exactly what we created — leaves sibling parallel
 	# runs (and any unrelated host loop devices) untouched.
-	losetup -nO NAME,BACK-FILE 2>/dev/null \
+	sudo -n losetup -nO NAME,BACK-FILE 2>/dev/null \
 		| awk -v p="$abs_storage_path/" '$2 ~ "^"p {print $1}' \
 		| while read -r lo; do
 			[ -n "$lo" ] && sudo -n losetup -d "$lo" 2>/dev/null || :


### PR DESCRIPTION
## Summary

Fix regression introduced by the parallel-runs slot allocator (PR #308, commit 21088d406e). CI run [25599060334](https://github.com/pantavisor/meta-pantavisor/actions/runs/25599060334/job/75161366836) failed with:

```
+ losetup -f
losetup: cannot find an unused loop device: Permission denied
+ docker run ... --device '' ...
```

Before the parallel-runs commit, the script called `sudo -n losetup -D` first, which detached every loop device on the host as root. After `-D` cleared everything, bare `losetup -f` could find a free `/dev/loopN` even without root, because nothing was bound. Removing `-D` (necessary — it would have torn down sibling parallel runs) exposed that the bare `losetup -f` lacks the privilege the CI runner expects when loop devices on the host are already in use.

Match the privilege the prior `sudo -n losetup -D` line ran with:

- `unused_lo=$(sudo -n losetup -f)` — the probe used to populate `--device "$unused_lo"`.
- `sudo -n losetup -nO NAME,BACK-FILE` — the enumerate that drives the targeted cleanup. The per-device detach already used `sudo -n losetup -d`.

The runner has passwordless sudo for losetup so this is a no-op against the existing permission grant.

## Test plan

- [x] `bash -n` on the script.
- [ ] CI: re-run `pvtest-lifecycle / tests` on this branch.