### PR TITLE
ci: upload test.docker.sh workspace

### DIFF
--- a/.github/workflows/buildkas-target.yaml
+++ b/.github/workflows/buildkas-target.yaml
@@ -78,74 +78,10 @@ jobs:
           ls -l .
 
 ## File distribution
-      - name: Archive AppEngine artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: appengine-${{ inputs.machine_name }}
-          path: |
-            test.docker.sh
-            pantavisor-appengine*-docker.tar
-          if-no-files-found: ignore
-
-      - name: Archive pvtest distro (unpacked)
+      - name: Archive pvtest distro
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pvtest-distro-${{ inputs.machine_name }}
           path: pvtest-distro/
-          if-no-files-found: ignore
-
-      - name: Archive wic artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ inputs.build_target}}-${{ inputs.machine_name }}
-          path: |
-             ${{ inputs.output }}
-          if-no-files-found: ignore
-
-      - name: Archive all pvrexport artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: pvrexports-${{ inputs.machine_name }}
-          path: |
-            *pvrexport.tgz
-          if-no-files-found: ignore
-
-      - name: Archive bsp pvrexport artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: pantavisor-bsp-${{ inputs.machine_name }}
-          path: |
-            pantavisor-bsp*
-          if-no-files-found: ignore
-
-      - name: Archive tezi tar artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: tezi-${{ inputs.build_target}}-${{ inputs.machine_name }}
-          path: |
-            *pv_teziimg.tar.xz
-          if-no-files-found: ignore
-
-      - name: Archive sdk tar artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: sdk-artifact-${{ inputs.machine_name }}
-          path: panta*.sh
-          if-no-files-found: ignore
-
-      - name: Archive manifest audit artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: manifest-audit-${{ inputs.build_target }}-${{ inputs.machine_name }}
-          path: |
-            *.manifest.txt
-            *.manifest.patch
           if-no-files-found: ignore

--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -2,6 +2,7 @@ name: "run pvtests"
 
 env:
   WORKSPACE: /tmp/workspace-${{ github.run_id }}
+  PVTEST_WORKSPACE: /tmp/pvtest-workspace-${{ github.run_id }}
 
 on:
   workflow_call:
@@ -60,11 +61,11 @@ jobs:
           echo "------------------------------------------------------"
 
           if [[ -z "$TEST_TARGET" ]]; then
-            ./test.docker.sh -v run --retry 3
+            ./test.docker.sh -v run --retry 3 -w $PVTEST_WORKSPACE
           elif [[ "$TEST_TARGET" == remote* ]]; then
-            ./test.docker.sh -v run "$TEST_TARGET" --retry 3
+            ./test.docker.sh -v run "$TEST_TARGET" --retry 3 -w $PVTEST_WORKSPACE
           else
-            ./test.docker.sh -v run "$TEST_TARGET"
+            ./test.docker.sh -v run "$TEST_TARGET" -w $PVTEST_WORKSPACE
           fi
 
       - name: Show Tests Summary
@@ -81,19 +82,22 @@ jobs:
             echo "Tests Run Failed (no log found)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload workspace on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: pvtests-workspace
-          path: ${{ env.WORKSPACE }}
+      - name: Prepare pvtest workspace
+        if: always()
+        run: |
+          suffix="${{ inputs.test_path }}"
+          suffix="${suffix//\//-}"
+          echo "PVTEST_ARTIFACT_NAME=pvtest-workspace-${suffix:-all}" >> $GITHUB_ENV
 
-      - name: Upload log on success
-        if: success()
+          sudo chown -R $(id -u):$(id -g) $PVTEST_WORKSPACE || true
+
+      - name: Upload pvtest workspace
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test.docker.log
-          path: ${{ env.WORKSPACE }}/test.docker.log
+          name: ${{ env.PVTEST_ARTIFACT_NAME }}
+          path: ${{ env.PVTEST_WORKSPACE }}
+          if-no-files-found: ignore
 
       - name: Clean up
         if: always()
@@ -109,3 +113,4 @@ jobs:
           | xargs -r docker rmi -f
 
           rm -rf $WORKSPACE
+          rm -rf $PVTEST_WORKSPACE

--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -96,7 +96,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PVTEST_ARTIFACT_NAME }}
-          path: ${{ env.PVTEST_WORKSPACE }}
+          path: |
+            ${{ env.PVTEST_WORKSPACE }}/test.docker.log
+            ${{ env.PVTEST_WORKSPACE }}/storage/**/logs
+            ${{ env.PVTEST_WORKSPACE }}/valgrind
           if-no-files-found: ignore
 
       - name: Clean up
@@ -113,4 +116,4 @@ jobs:
           | xargs -r docker rmi -f
 
           rm -rf $WORKSPACE
-          rm -rf $PVTEST_WORKSPACE
+          sudo rm -rf $PVTEST_WORKSPACE

--- a/.github/workflows/onpush-scarthgap.yaml
+++ b/.github/workflows/onpush-scarthgap.yaml
@@ -22,7 +22,7 @@ on:
   # to get a build.
 
 jobs:
-  build:
+  build-hw:
     name: "build (${{ matrix.machine_name }})"
     strategy:
       fail-fast: false
@@ -38,11 +38,6 @@ jobs:
             build_target: pantavisor-starter
             output: "pantavisor-starter*.rootfs.wic*"
             sdk: 1
-          - machine_name: docker-x86_64-scarthgap
-            configs: kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/build-configs/shared-vols.yaml
-            build_target: pantavisor-appengine-distro
-            output: "pantavisor-appengine-distro-*.tar.gz"
-            sdk: 0
     uses: ./.github/workflows/buildkas-target.yaml
     with:
       configs: ${{ matrix.configs }}
@@ -52,15 +47,26 @@ jobs:
       sdk: ${{ matrix.sdk }}
     secrets: inherit
 
+  build-docker:
+    name: "build (docker-x86_64-scarthgap)"
+    uses: ./.github/workflows/buildkas-target.yaml
+    with:
+      configs: kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/build-configs/shared-vols.yaml
+      machine_name: docker-x86_64-scarthgap
+      build_target: pantavisor-appengine-distro
+      output: "pantavisor-appengine-distro-*.tar.gz"
+      sdk: 0
+    secrets: inherit
+
   pvtest-lifecycle:
-    needs: build
+    needs: build-docker
     uses: ./.github/workflows/call-pvtests.yaml
     with:
       test_path: local/lifecycle
     secrets: inherit
 
   summary:
-    needs: build
+    needs: [build-hw, build-docker]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
@@ -19,13 +19,13 @@ usage() {
 	echo "  run [path]                 Run one to many tests"
 	echo ""
 	echo "Arguments for 'run' command:"
-	echo "  -i, --interactive Run the test interactively for debugging"
-	echo "  -s, --storage     Set a path for /storage"
-	echo "  -m, --manual      Avoid starting Pantavisor for debugging"
-	echo "  -n, --netsim      Use the network simulator (experimental)"
-	echo "  -o, --overwrite   Create or overwrite the test output"
-	echo "  -r, --retry N     Retry failed tests up to N times (default: 0)"
-	echo "  -V, --valgrind    Run Pantavisor with valgrind"
+	echo "  -i, --interactive     Run the test interactively for debugging"
+	echo "  -m, --manual          Avoid starting Pantavisor for debugging"
+	echo "  -n, --netsim          Use the network simulator (experimental)"
+	echo "  -o, --overwrite       Create or overwrite the test output"
+	echo "  -r, --retry N         Retry failed tests up to N times (default: 0)"
+	echo "  -V, --valgrind        Run Pantavisor with valgrind"
+	echo "  -w, --work PATH       Set workspace path for logs/storage (default: mktemp)"
 	echo ""
 	echo "Path selectors for 'run' command:"
 	echo "  (none)                         Run all tests"
@@ -36,7 +36,7 @@ usage() {
 	echo "Environments:"
 	echo "  NETSIM_PATH      Path to docker load for netsim container"
 	echo "  TESTER_PATH      Path to docker load for tester container"
-	echo "  APPENGINE_PATH   Path to docker load for tester container"
+	echo "  APPENGINE_PATH   Path to docker load for appengine container"
 	echo "  PVTEST_DIR       Directory to pvtest sources to run"
 	echo ""
 }
@@ -339,6 +339,7 @@ exec_test() {
 		-e PH_USER="$PH_USER" \
 		-e PH_PASS="$PH_PASS" \
 		-e PVR_DISABLE_SELF_UPGRADE=true \
+		-e PV_LOG_SERVER_OUTPUTS="filetree,stdout_direct" \
 		--env-file <(echo "$env" | tr ' ' '\n') \
 		$docker_it_opt \
 		--rm \
@@ -368,7 +369,7 @@ exec_test() {
 		pantavisor-appengine-tester
 	res=$?
 
-	sudo -n chmod -R a+rx "$work_path/storage/$test_id/logs"
+	sudo -n chmod -R a+rX "$work_path/storage/$test_id/" 2>/dev/null || true
 
 	# Detach only loop devices whose backing file lives under this run's
 	# storage tree. Targets exactly what we created — leaves sibling parallel
@@ -513,6 +514,7 @@ run_test() {
 		exit 1
 	fi
 
+	mkdir -p "$work_path"
 	echo "Info: test logs can be found at $work_path/test.docker.log"
 	exec > >(tee -a "$work_path/test.docker.log") 2>&1
 


### PR DESCRIPTION
## Summary

Streamline CI artifact collection for pvtest runs by uploading only what matters for local reproduction and debugging, ensure test logs include direct stdout output, and decouple pvtest execution from hardware builds so tests start as soon as the docker x86 build finishes.

- Decouple `docker-x86_64` from the hardware build matrix so `pvtest-lifecycle` starts immediately after it completes, without waiting for raspberrypi or sunxi builds.
- Upload the full pvtest workspace (`PVTEST_WORKSPACE`) on every run — this is where valgrind output, storage logs, and per-test logs live, making it the primary debugging artifact
- Retain the `pvtest-distro` tarball — it contains everything needed to reproduce a failure locally
- Drop all other artifact uploads (appengine image, wic, pvrexport, bsp, tezi, sdk, manifest audit) — these added noise and storage cost without aiding pvtest debugging
- Enable `stdout_direct` log output via `PV_LOG_SERVER_OUTPUTS="filetree,stdout_direct"` so pantavisor logs appear in the test log files inside the workspace artifact
- Artifact name is derived from `test_path` so parallel test runs produce distinct named artifacts

## Changes

- `.github/workflows/onpush-scarthgap.yaml` — split `docker-x86_64-scarthgap` out of the build matrix into a dedicated `build-docker` job; `pvtest-lifecycle` now depends only on `build-docker`; `summary` depends on `[build-hw, build-docker]`
- `.github/workflows/buildkas-target.yaml` — remove 7 artifact upload steps, keeping only `pvtest-distro`
- `.github/workflows/call-pvtests.yaml` — introduce `PVTEST_WORKSPACE`, pass `-w $PVTEST_WORKSPACE` to all `test.docker.sh` invocations, unify artifact upload into a single always-run step with a path-derived name, clean up workspace on exit
- `recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh` — enable `stdout_direct` log output, ensure workspace dir exists before logging, broaden storage chmod to full test dir (error-silenced), update help text to match current CLI options