### PR TITLE
fix(appengine): silence restart noise, configurable delay, and dm-crypt cleanup

### DIFF
--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -61,11 +61,11 @@ jobs:
           echo "------------------------------------------------------"
 
           if [[ -z "$TEST_TARGET" ]]; then
-            ./test.docker.sh -v run --retry 3 -w $PVTEST_WORKSPACE
+            ./test.docker.sh -v run -V --retry 3 -w $PVTEST_WORKSPACE
           elif [[ "$TEST_TARGET" == remote* ]]; then
-            ./test.docker.sh -v run "$TEST_TARGET" --retry 3 -w $PVTEST_WORKSPACE
+            ./test.docker.sh -v run -V "$TEST_TARGET" --retry 3 -w $PVTEST_WORKSPACE
           else
-            ./test.docker.sh -v run "$TEST_TARGET" -w $PVTEST_WORKSPACE
+            ./test.docker.sh -v run -V "$TEST_TARGET" -w $PVTEST_WORKSPACE
           fi
 
       - name: Show Tests Summary

--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -63,9 +63,9 @@ jobs:
           if [[ -z "$TEST_TARGET" ]]; then
             ./test.docker.sh -v run -V --retry 3 -w $PVTEST_WORKSPACE
           elif [[ "$TEST_TARGET" == remote* ]]; then
-            ./test.docker.sh -v run -V "$TEST_TARGET" --retry 3 -w $PVTEST_WORKSPACE
+            ./test.docker.sh -v run "$TEST_TARGET" -V --retry 3 -w $PVTEST_WORKSPACE
           else
-            ./test.docker.sh -v run -V "$TEST_TARGET" -w $PVTEST_WORKSPACE
+            ./test.docker.sh -v run "$TEST_TARGET" -V -w $PVTEST_WORKSPACE
           fi
 
       - name: Show Tests Summary

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
@@ -357,8 +357,8 @@ object count: 6
   },
   {
     "key": "PV_LOG_SERVER_OUTPUTS",
-    "value": "132",
-    "modified": "pv conf file"
+    "value": "196",
+    "modified": "env"
   },
   {
     "key": "PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT",

--- a/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
@@ -538,11 +538,11 @@ run_test() {
 		done
 	fi
 
+	set +x
+	echo "======================================================="
+	echo "======================= SUMMARY ======================="
+	echo "======================================================="
 	if [ "$verbose" = "true" ]; then
-		set +x
-		echo "======================================================="
-		echo "======================= SUMMARY ======================="
-		echo "======================================================="
 		echo "Info: workspace=$work_path"
 		echo "Info: logs=$work_path/test.docker.log"
 		if [ "$valgrind" = "true" ]; then
@@ -550,10 +550,20 @@ run_test() {
 		fi
 		echo "Info: Pantavisor storage=$work_path/storage"
 		echo ""
-		grep "^Info: 'local\|^Info: 'remote" "$work_path/test.docker.log"
-		echo "======================================================="
-		set -h
 	fi
+	grep "^Info: 'local\|^Info: 'remote" "$work_path/test.docker.log"
+	grep "^Info: '.*FAILED" "$work_path/test.docker.log" \
+		| sed "s/^Info: '//; s/'[[:space:]].*//" \
+		| sort -u \
+		| while read -r test_id; do
+			diff_file="$work_path/storage/$test_id/diff"
+			[ -s "$diff_file" ] || continue
+			printf "\n--- diff: %s ---\n" "$test_id"
+			cat "$diff_file"
+			printf "--- end diff ---\n"
+		done
+	echo "======================================================="
+	set -h
 
 	# make summary available to the run path for the CI
 	cp $work_path/test.docker.log ./test.docker.log


### PR DESCRIPTION
## Summary

- Configurable restart delay (`-d SECS`) in `pv-appengine`, with `-d 0` suppressing both the delay and the "restarting in N seconds…" message — used by `pvtest-run` to eliminate noise between test phases.
- Robust dm-crypt cleanup after PV restarts, including the crash case where volumes are left mounted.
- pvtest diff capture to storage so CI summaries can surface failures inline without grep through the full log.

## Changes

### `appengine/pv-appengine.in`

- **`-d SECS` flag** (default: 5). Controls the restart delay; passing `-d 0` suppresses both the sleep and the log line. `pvtest-run` passes `-d 0` so restarts between test phases produce no log noise.
- **`cleanup_cryptdisk` hardened**: before calling `cryptsetup close versatile`, all bind-mounts sourced from within the dm-crypt volume are lazily unmounted by parsing `/proc/mounts`. Without this, a PV crash (e.g. the libevent `evhttp_connection_reset_hard_` assert during a non-reboot transition) leaves those sub-mounts open, `cryptsetup close` fails silently, and the next PV start gets "versatile still exists / Unable to create/open crypt device". Fixes `remote/control/always-remote-{disabled,enabled}`, `remote/lifecycle/insufficient-disk-space`, and `remote/lifecycle/rollback-cloud-status` — all use `PV_STORAGE_PHCONFIG_VOL=1`.
- **`cleanup_cryptdisk` + `cleanup_cgroup` in the restart loop**: called after each PV exit so state doesn't accumulate across restarts.
- **Silent umount**: `umount /volumes` and `umount /storage` replaced with `umount -l ... || true` so a busy mount no longer aborts the restart loop.
- **Null-byte stripping** when reading `uboot.txt` (`tr -d '\0'`) to prevent awk misparsing on stale boot entries.

### `pvtest/pvtest-run.in`

- `start_pv()` now passes `-d 0` to `pv-appengine`.
- `eval_test()` tees the diff output to `/var/pantavisor/storage/diff` and checks `PIPESTATUS[0]` rather than `$?` so the diff result isn't masked by `tee`. The `diff` file is mounted on the host at `$work_path/storage/$test_id/diff` and displayed inline by the summary section of `test.docker.sh`.