### PR TITLE
fix(rpi): isolate compat-vDSO toolchain shim off PATH

### DIFF
--- a/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,9 +1,11 @@
 
 # meta-pantavisor/dynamic-layers/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
 #
-# Enable CONFIG_COMPAT_VDSO=y for arm64 kernels by exposing a 32-bit
-# ARM cross-toolchain (gcc + binutils) to Kbuild via PATH +
-# CROSS_COMPILE_COMPAT.
+# Enable CONFIG_COMPAT_VDSO=y for arm64 kernels by pointing
+# CROSS_COMPILE_COMPAT at a WORKDIR-private shim of the 32-bit ARM
+# cross-toolchain (gcc + binutils) sourced from the rpi-kernel
+# multiconfig. PATH is intentionally NOT modified — see the comment
+# on setup_compat_toolchain_shim for why.
 #
 # Background: arch/arm64/Kconfig defines COMPAT_VDSO as default-y, but
 # only if either (CC_IS_CLANG && LD_IS_LLD) or CROSS_COMPILE_COMPAT is
@@ -29,9 +31,9 @@
 #    ... but not enabled in BBMULTICONFIG?"
 #
 # Therefore the entire compat-vDSO setup (mcdepends, EXTRA_OEMAKE,
-# the PATH shim) is gated on rpi-kernel actually being part of
-# BBMULTICONFIG. On a non-multiconfig arm64 build this bbappend is
-# a no-op.
+# the shim materialization) is gated on rpi-kernel actually being
+# part of BBMULTICONFIG. On a non-multiconfig arm64 build this
+# bbappend is a no-op.
 
 # The cross-toolchain triplet's libc suffix depends on the distro's
 # C library (musl vs glibc). Pantavisor builds against musl, so the
@@ -43,9 +45,9 @@ COMPAT_TRIPLET = "arm${TARGET_VENDOR}-linux-${COMPAT_LIBC_SUFFIX}"
 # The 32-bit ARM cross-gcc and cross-binutils are produced by the
 # rpi-kernel multiconfig (MACHINE=raspberrypi). Each multiconfig has
 # an isolated `recipe-sysroot-native`, so the arm64 kernel build
-# can't see the v6 multiconfig's binaries on PATH by default. Add
-# both component bin dirs to PATH at compile time so Kbuild's
-# vdso32 step can find arm-poky-linux-musleabi-{gcc,as,ld,...}.
+# can't see the v6 multiconfig's binaries by default. We reference
+# both component bin dirs directly via absolute paths inside the
+# shim (no PATH manipulation).
 COMPAT_GCC_BIN_DIR  = "${TOPDIR}/tmp-${DISTRO_CODENAME}-rpi-kernel-raspberrypi/sysroots-components/${BUILD_ARCH}/gcc-cross-arm/usr/bin/${COMPAT_TRIPLET}"
 COMPAT_BUTILS_BIN_DIR = "${TOPDIR}/tmp-${DISTRO_CODENAME}-rpi-kernel-raspberrypi/sysroots-components/${BUILD_ARCH}/binutils-cross-arm/usr/bin/${COMPAT_TRIPLET}"
 
@@ -56,6 +58,7 @@ COMPAT_SHIM_DIR = "${WORKDIR}/compat-toolchain-shim"
 # read this and become no-ops otherwise.
 PV_COMPAT_VDSO_ENABLED ?= "0"
 
+
 python __anonymous () {
     bbmc = (d.getVar('BBMULTICONFIG') or '').split()
     if 'rpi-kernel' not in bbmc:
@@ -63,8 +66,16 @@ python __anonymous () {
     if d.getVar('TARGET_ARCH') != 'aarch64':
         return
     d.setVar('PV_COMPAT_VDSO_ENABLED', '1')
+    # CROSS_COMPILE_COMPAT points at the WORKDIR shim dir, not at the
+    # multiconfig sysroots. The shim contains only PREFIXED names:
+    # a wrapper for gcc/g++/cpp that adds `-B<binutils-dir>/`, and
+    # plain symlinks for the binutils tools. This means no directory
+    # is ever prepended to PATH, so HOSTCC (scripts/dtc et al.) keeps
+    # the clean host PATH and never picks up the arm cross binutils.
+    shim = d.getVar('COMPAT_SHIM_DIR')
     triplet = d.getVar('COMPAT_TRIPLET')
-    d.appendVar('EXTRA_OEMAKE', ' CROSS_COMPILE_COMPAT=%s-' % triplet)
+    d.appendVar('EXTRA_OEMAKE',
+        ' CROSS_COMPILE_COMPAT=%s/%s-' % (shim, triplet))
     # mcdepends across multiconfig boundary; safe to add only when
     # rpi-kernel is actually enabled in BBMULTICONFIG.
     d.appendVarFlag('do_compile', 'mcdepends',
@@ -75,37 +86,65 @@ python __anonymous () {
         ' mc::rpi-kernel:binutils-cross-arm:do_populate_sysroot')
 }
 
-# Build a shim directory under the kernel's WORKDIR with un-prefixed
-# symlinks for the binutils tools (`as`, `ld`, `objcopy`, `objdump`,
-# `nm`, `ar`, `ranlib`, `strip`) pointing at the v6 multiconfig's
-# prefixed cross-binaries. Without this, gcc's internal assembler
-# invocation finds the host /usr/bin/as ("as: unrecognized option
-# '-EL'") because the Yocto cross-gcc package doesn't ship `as` in
-# its libexec — it expects PATH to provide either the prefixed or
-# un-prefixed name, and Kbuild's vdso32 rules end up calling plain
-# `as` directly.
+# Build a per-build shim dir under WORKDIR containing only PREFIXED
+# names (matching CROSS_COMPILE_COMPAT). PATH is NOT modified, so the
+# rest of the do_compile task — in particular HOSTCC for kernel host
+# tools like scripts/dtc — sees the unchanged host PATH and resolves
+# host gcc + /usr/bin/as as normal.
 #
-# Compiler frontends (gcc/g++/cpp) are deliberately NOT shimmed
-# un-prefixed: Kbuild always invokes them via CROSS_COMPILE_COMPAT,
-# i.e. as `arm-poky-linux-musleabi-gcc`, which the cross-gcc bin dir
-# (also on PATH) already provides. Adding un-prefixed `gcc`/`cpp`
-# symlinks here would poison HOSTCC for kernel host-tool builds
-# (scripts/dtc, etc.) — `HOSTCC=gcc` would resolve to the arm32
-# cross-gcc and fail with "stdio.h: No such file or directory".
+# Two pieces:
+#
+#  1. A wrapper script `<triplet>-gcc` (also linked as `<triplet>-g++`
+#     and `<triplet>-cpp`) that exec's the real cross-gcc with an
+#     extra `-B${COMPAT_BUTILS_BIN_DIR}/` flag. gcc's `-B<prefix>/`
+#     lookup tries `<prefix><target>as` (= `<dir>/arm-poky-linux-
+#     musleabi-as`) first, which exists in the v6 multiconfig's
+#     binutils-cross-arm sysroot — so gcc's internal assembler
+#     invocation resolves without any PATH hint.
+#
+#  2. Plain symlinks for the binutils tools the kernel calls directly
+#     via `${CROSS_COMPILE_COMPAT}<tool>` (ld for the vdso32 link,
+#     objcopy/objdump/nm/etc. for post-processing). These are kept
+#     PREFIXED on disk so they can never be hit by an un-prefixed
+#     PATH lookup from a host-side compiler.
 setup_compat_toolchain_shim () {
     install -d ${COMPAT_SHIM_DIR}
+    # The wrapper holds absolute paths baked in at bitbake parse time;
+    # only `$@` is left for the shell to expand at runtime. The `-B`
+    # flag points at the shim dir itself, which also contains the
+    # un-prefixed binutils symlinks below — gcc's `-B<prefix>/`
+    # lookup uses `<prefix><progname>` (un-prefixed), it does NOT
+    # auto-add the cross target triplet.
+    cat > "${COMPAT_SHIM_DIR}/${COMPAT_TRIPLET}-gcc" <<EOF
+#!/bin/sh
+exec "${COMPAT_GCC_BIN_DIR}/${COMPAT_TRIPLET}-gcc" -B"${COMPAT_SHIM_DIR}/" "\$@"
+EOF
+    chmod +x "${COMPAT_SHIM_DIR}/${COMPAT_TRIPLET}-gcc"
+    # g++ and cpp use the same driver; same -B handling applies.
+    ln -sf "${COMPAT_TRIPLET}-gcc" "${COMPAT_SHIM_DIR}/${COMPAT_TRIPLET}-g++"
+    ln -sf "${COMPAT_TRIPLET}-gcc" "${COMPAT_SHIM_DIR}/${COMPAT_TRIPLET}-cpp"
+    # Binutils tools — each linked twice:
+    #   <triplet>-<tool>   so Kbuild's direct ${CROSS_COMPILE_COMPAT}<tool>
+    #                      calls (ld for vdso32 link, objcopy/objdump/nm/…)
+    #                      resolve inside the shim.
+    #   <tool>             so cross-gcc's internal `as`/`ld` lookup via
+    #                      the `-B<shim>/` prefix finds it (gcc tries
+    #                      "<prefix><progname>" un-prefixed, NOT
+    #                      "<prefix><triplet>-<progname>").
+    # Critically the shim dir is NEVER added to PATH, so the un-prefixed
+    # symlinks here cannot poison HOSTCC.
     for tool in as ld objcopy objdump nm ar ranlib strip; do
         ln -sf "${COMPAT_BUTILS_BIN_DIR}/${COMPAT_TRIPLET}-$tool" \
-            "${COMPAT_SHIM_DIR}/$tool"
+            "${COMPAT_SHIM_DIR}/${COMPAT_TRIPLET}-$tool"
+        ln -sf "${COMPAT_TRIPLET}-$tool" "${COMPAT_SHIM_DIR}/$tool"
     done
-    export PATH="${COMPAT_SHIM_DIR}:${COMPAT_GCC_BIN_DIR}:${COMPAT_BUTILS_BIN_DIR}:${PATH}"
 }
 
 # Both `do_compile` (vmlinux) AND `do_compile_kernelmodules` (in-tree
-# modules) run vdso_prepare, so both need the shim + PATH applied.
-# Without the second one, `do_compile_kernelmodules` re-fails on
-# `arm-poky-linux-musleabi-gcc: not found` even after a successful
-# `do_compile`.
+# modules) run vdso_prepare, so both need the shim materialized in
+# WORKDIR. Without the second one, `do_compile_kernelmodules` re-fails
+# on `arm-poky-linux-musleabi-gcc: not found` if WORKDIR was wiped
+# between tasks.
 do_compile:prepend:aarch64 () {
     if [ "${PV_COMPAT_VDSO_ENABLED}" = "1" ]; then
         setup_compat_toolchain_shim


### PR DESCRIPTION
## Summary

Fixes the cold-build `as: unrecognized option '--64'` failure on `mc:rpi-kernel8:linux-raspberrypi do_compile` that has been red on tagged CI since `028-rc5` (see [run 25475243954](https://github.com/pantavisor/meta-pantavisor/actions/runs/25475243954/job/74747218970)).

## Root cause

The compat-vDSO bbappend prepended a private shim dir to `PATH` for the entire kernel `do_compile` task so cross-gcc could find its un-prefixed assembler. The same task also runs HOSTCC for kernel host tools (`scripts/dtc`, `scripts/mod`, …), and host gcc looks up its assembler un-prefixed too — so HOSTCC's `as --64 ...` resolved to `arm-poky-linux-musleabi-as` and failed.

Local incremental builds didn't trip this because `scripts/dtc/*.o` predated the bbappend and Make skipped HOSTCC. Cold CI was the first build to actually run scripts/dtc under the poisoned PATH. The earlier `028-rc7` fix dropped un-prefixed `gcc/g++/cpp` from the shim but left un-prefixed binutils — the actual poisoning vector.

## Fix

Restructure so PATH is **never** modified:

- `CROSS_COMPILE_COMPAT=${COMPAT_SHIM_DIR}/${COMPAT_TRIPLET}-` points Kbuild's direct `${CROSS_COMPILE_COMPAT}<tool>` invocations at the shim by absolute prefix.
- A `<triplet>-gcc` wrapper exec's the real cross-gcc with `-B${COMPAT_SHIM_DIR}/`. gcc's `-B<prefix>/` lookup uses `<prefix><progname>` un-prefixed, so the shim also provides un-prefixed `as`, `ld`, `objcopy`, … symlinks alongside the prefixed ones — both in the same dir, but that dir is never on PATH, so HOSTCC cannot reach them.
- `<triplet>-g++` and `<triplet>-cpp` symlink to the wrapper; same driver, same `-B`.

## Test plan

Validated locally on `fix/rpi-compat-vdso-path-isolation` via `./kas-container build kas/build-configs/release/rpi-scarthgap.yaml` after `cleansstate` of all rpi arm64 kernel multiconfigs:

- [x] `mc:rpi-kernel8:linux-raspberrypi do_compile` (cold)
- [x] `mc:rpi-kernel7l:linux-raspberrypi do_compile`
- [x] `mc:rpi-kernel_2712:linux-raspberrypi do_compile`
- [x] 3× `do_compile_kernelmodules`
- [x] `pantavisor-bsp do_compile`
- [x] Full `pantavisor-starter` image — 12721 tasks attempted, 0 failed
- [x] `.config` has `CONFIG_COMPAT_VDSO=y`, `THUMB2_COMPAT_VDSO=y`, `GENERIC_COMPAT_VDSO=y`
- [x] Both `scripts/dtc/dtc.o` (HOSTCC path) and `arch/arm64/kernel/vdso32/vgettimeofday.o` (CROSS_COMPILE_COMPAT path) build cleanly in the same task
- [ ] Confirm on cold CI (tag a `028-rc8`)