### PR TITLE
fix(libevent): null-guard freed conn callbacks and demote replacefd assert

### DIFF
--- a/recipes-pv/libevent/files/evhttp-null-guard-freed-conn.patch
+++ b/recipes-pv/libevent/files/evhttp-null-guard-freed-conn.patch
@@ -1,0 +1,63 @@
+From: Pantacor <dev@pantacor.com>
+Subject: [PATCH] evhttp: guard callbacks against NULL evcon; demote replacefd assert
+
+Two fixes for evhttp used with SSL (mbedTLS) bufferevents:
+
+1. When evhttp_connection_free() is called while a deferred bufferevent
+   callback is still queued, the cbarg is zeroed before the callback fires.
+   All three evhttp bufferevent callbacks dereference evcon immediately,
+   causing a NULL+16 SIGSEGV.  Add a NULL guard at the top of each callback
+   so that stale deferred events are silently ignored.
+
+2. evhttp_connection_reset_hard_ calls bufferevent_replacefd(bev, -1) to
+   detach the fd before reconnecting.  SSL bufferevents (mbedTLS) do not
+   support replacefd and return an error, triggering the fatal
+   EVUTIL_ASSERT(!err && "setfd") and crashing the process.  The libevent
+   authors left a FIXME comment on that line.  Demote the assertion to a
+   debug log so the process survives — the SSL bufferevent cleans up the
+   underlying fd correctly on its own when freed.
+
+Signed-off-by: Pantacor <dev@pantacor.com>
+---
+ http.c | 9 +++++++++
+ 1 file changed, 9 insertions(+), 0 deletions(-)
+
+--- a/http.c
++++ b/http.c
+@@ -907,6 +907,8 @@
+ evhttp_write_cb(struct bufferevent *bufev, void *arg)
+ {
+ 	struct evhttp_connection *evcon = arg;
++	if (!evcon)
++		return;
+
+ 	/* Activate our call back */
+ 	if (evcon->cb != NULL)
+@@ -1232,6 +1234,8 @@
+ evhttp_read_cb(struct bufferevent *bufev, void *arg)
+ {
+ 	struct evhttp_connection *evcon = arg;
++	if (!evcon)
++		return;
+ 	struct evhttp_request *req = TAILQ_FIRST(&evcon->requests);
+
+ 	/* Cancel if it's pending. */
+@@ -1448,7 +1452,8 @@
+
+ 	/** FIXME: manipulating with fd is unwanted */
+ 	err = bufferevent_replacefd(evcon->bufev, -1);
+-	EVUTIL_ASSERT(!err && "setfd");
++	if (err)
++		event_debug(("%s: bufferevent_replacefd failed (SSL bufferevent?)", __func__));
+
+ 	/* we need to clean up any buffered data */
+ 	tmp = bufferevent_get_output(evcon->bufev);
+@@ -1592,6 +1597,8 @@
+ evhttp_error_cb(struct bufferevent *bufev, short what, void *arg)
+ {
+ 	struct evhttp_connection *evcon = arg;
++	if (!evcon)
++		return;
+ 	struct evhttp_request *req = TAILQ_FIRST(&evcon->requests);
+
+ 	switch (evcon->state) {

--- a/recipes-pv/libevent/libevent_2.2.1.bb
+++ b/recipes-pv/libevent/libevent_2.2.1.bb
@@ -15,6 +15,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=eaea438df011ea096feec284927c59e0"
 GITHUB_BASE_URI ?= "https://github.com/${BPN}/${BPN}/releases/"
 SRC_URI = "${GITHUB_BASE_URI}/download/release-2.2.1-alpha/libevent-2.2.1-alpha-dev.tar.gz \
 	file://undef_ssl_renegotiation.patch \
+	file://evhttp-null-guard-freed-conn.patch \
 "
 SRC_URI[sha256sum] = "36d0726e570fc2ee61a0a27cfb6bf2799e14a28d030a7473a7a2411f7533d359"
 


### PR DESCRIPTION
## Problem

Two crashes in pantavisor's evhttp/SSL path, both in libevent's `http.c`:

### 1. NULL deref in deferred bufferevent callbacks

`evhttp_connection_free()` zeroes the `cbarg` before a deferred bufferevent callback fires. All three evhttp callbacks (`evhttp_write_cb`, `evhttp_read_cb`, `evhttp_error_cb`) dereference `evcon` immediately — NULL+16 offset → SIGSEGV.

```
  ==549== Process terminating with default action of signal 11 (SIGSEGV)
  ==549==  Access not within mapped region at address 0x10   ← NULL+16 offset into evcon
  ==549==    at 0x142DFA: ??? (evhttp_read_cb dereferences evcon)
  ==549==    by 0x1966D9: ??? 
  ==549==    by 0x1809E7: bufferevent_run_readcb_            ← deferred callback fired after conn freed
  ==549==    by 0x185E29: ???
  ==549==    by 0x1869F6: event_base_loop
```

### 2. Fatal assert on SSL bufferevent replacefd

`evhttp_connection_reset_hard_()` calls `bufferevent_replacefd(bev, -1)` to detach the fd before reconnecting. SSL bufferevents (mbedTLS) do not support `replacefd` and return an error, triggering `EVUTIL_ASSERT(!err && "setfd")` — a fatal abort.

```
  [pantavisor] 4213007 ERROR -- [event]: http.c:1451: Assertion !err && "setfd" failed in evhttp_connection_reset_hard_
```

The libevent authors left a `/** FIXME: manipulating with fd is unwanted */` comment on that exact line, acknowledging it is problematic.

This crash is triggered on every HTTPS reconnect: `Connection: close` responses cause one reconnect per request; libevent retries cause another. Even after reducing reconnect frequency (separate pantavisor PR), server-side idle-timeout closes will still trigger this path.

## Fix

Add `evhttp-null-guard-freed-conn.patch` to the libevent 2.2.1 recipe:

- **NULL-guard** `evhttp_write_cb`, `evhttp_read_cb`, `evhttp_error_cb` — return early if
  `conn` is NULL so stale deferred events are silently dropped.
- **Demote assert** — replace `EVUTIL_ASSERT(!err && "setfd")` with an `event_debug()` log
  in `evhttp_connection_reset_hard_()` so SSL bufferevents fail gracefully. The SSL
  bufferevent cleans up its underlying fd correctly on its own when freed.

## Relationship to pantavisor changes

- `fix/reduce-setfd-crash-exposure` (pantavisor) reduces reconnect frequency by removing   `Connection: close` and setting `PH_LIBEVENT_HTTP_RETRIES=0` — fewer calls to   `reset_hard_()`.
- This patch makes the remaining `reset_hard_()` calls safe — server-side idle-timeout  closes no longer kill PV.

## Files changed

- `recipes-pv/libevent/files/evhttp-null-guard-freed-conn.patch` — new patch file (9 insertions)
- `recipes-pv/libevent/libevent_2.2.1.bb` — add patch to `SRC_URI