### PR TITLE
feat(pantavisor-docs): add docs tarball recipe and extract pantavisor.inc

### DIFF
--- a/.github/scripts/components.json
+++ b/.github/scripts/components.json
@@ -31,7 +31,7 @@
   },
   {
     "name": "pantavisor",
-    "recipe_glob": "recipes-pv/pantavisor/pantavisor_git.bb",
+    "recipe_glob": "recipes-pv/pantavisor/pantavisor.inc",
     "branch": "master",
     "repo_org": "pantavisor"
   },

--- a/.github/scripts/sync-pantavisor-tag.sh
+++ b/.github/scripts/sync-pantavisor-tag.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Push the meta-pantavisor tag to the upstream pantavisor repo at the SRCREV
-# pinned in recipes-pv/pantavisor/pantavisor_git.bb.
+# pinned in recipes-pv/pantavisor/pantavisor.inc (PANTAVISOR_SRCREV).
 #
 # Inputs (env):
 #   TAG_NAME  meta-pantavisor tag name (e.g. 030-rc1)
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-RECIPE="recipes-pv/pantavisor/pantavisor_git.bb"
+RECIPE="recipes-pv/pantavisor/pantavisor.inc"
 UPSTREAM="pantavisor/pantavisor"
 
 if [ -z "${TAG_NAME:-}" ]; then

--- a/.github/scripts/upload-docs.sh
+++ b/.github/scripts/upload-docs.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+AWS_KEY_ID=$1
+AWS_SECRET_KEY=$2
+AWS_S3_BUCKET=$3
+TAG=$4
+DOCS_DIR=${5:-docs-out}
+
+AWS_S3_URL="https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor"
+RELEASE_FILE="releases.json"
+
+aws configure set aws_access_key_id "$AWS_KEY_ID"
+aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
+
+if [ ! -d "$DOCS_DIR" ]; then
+    echo "error: docs directory '$DOCS_DIR' not found" >&2
+    exit 1
+fi
+
+FILES_DOCS=( "$DOCS_DIR"/pantavisor-docs-*.tar.gz )
+if [ ! -e "${FILES_DOCS[0]}" ]; then
+    echo "error: no pantavisor-docs tarball found in '$DOCS_DIR'" >&2
+    exit 1
+fi
+
+# One docs tarball per tag.
+DOCS_FILE="${FILES_DOCS[0]}"
+FILENAME=$(basename "$DOCS_FILE")
+DOCS_CSUM=$(sha256sum "$DOCS_FILE" | cut -d' ' -f1)
+echo "processing: $FILENAME ($DOCS_CSUM)"
+
+aws s3 cp "$DOCS_FILE" "s3://$AWS_S3_BUCKET/$TAG/docs/$FILENAME"
+
+# Classify the tag the same way upload.sh does.
+if [[ "$TAG" == *"-rc"* ]]; then
+    RELEASE_TYPE="release-candidate"
+elif [[ "$TAG" =~ ^[0-9] ]]; then
+    RELEASE_TYPE="stable"
+else
+    echo "WARN: the type for tag '$TAG' could not be determined." >&2
+    RELEASE_TYPE="unknown"
+fi
+
+aws s3 cp "s3://$AWS_S3_BUCKET/$RELEASE_FILE" "$RELEASE_FILE" || echo "{}" > "$RELEASE_FILE"
+
+# Upsert a {docs: {name, url, sha256}} entry into the tag's array in
+# releases.json, keeping all other entries (machines, timestamp) intact.
+jq --arg type "$RELEASE_TYPE" \
+   --arg tag "$TAG" \
+   --arg name "$FILENAME" \
+   --arg url "$AWS_S3_URL/$TAG/docs/$FILENAME" \
+   --arg sha "$DOCS_CSUM" \
+   '
+     .[$type] //= {} |
+     .[$type][$tag] //= [] |
+     (.[$type][$tag] | map(has("docs")) | index(true)) as $docs_idx |
+     if $docs_idx == null then
+       .[$type][$tag] += [{docs: {name: $name, url: $url, sha256: $sha}}]
+     else
+       .[$type][$tag][$docs_idx] = {docs: {name: $name, url: $url, sha256: $sha}}
+     end
+   ' "$RELEASE_FILE" > temp.json && mv temp.json "$RELEASE_FILE"
+
+aws s3 cp "$RELEASE_FILE" "s3://$AWS_S3_BUCKET/$RELEASE_FILE"

--- a/.github/workflows/schedule-updatemachines.yaml
+++ b/.github/workflows/schedule-updatemachines.yaml
@@ -1,5 +1,9 @@
 name: 'schedule: update machines'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:
@@ -7,7 +11,7 @@ on:
   push:
     paths:
       - .github/scripts/**
-      - .github/workflows/updatemachines.yaml
+      - .github/workflows/schedule-updatemachines.yaml
     branches:
       - master
 
@@ -30,6 +34,10 @@ jobs:
       - run: git checkout -b autopr/machine-update-$GITHUB_REF_NAME-next
       - name: make PR
         if: github.ref_name == 'master'
-        run: .github/scripts/makecommit && git push origin -f autopr/machine-update-$GITHUB_REF_NAME-next && gh pr create --base $GITHUB_REF_NAME --fill 2>&1 | grep github.com.*pull || true
+        run: |
+          .github/scripts/makecommit && \
+          git push origin -f autopr/machine-update-$GITHUB_REF_NAME-next && \
+          gh pr create --base $GITHUB_REF_NAME --fill || \
+          gh pr edit autopr/machine-update-$GITHUB_REF_NAME-next --title "AutoPR: update kas meta layers to latest branch commits"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/tag-docs-scarthgap.yaml
+++ b/.github/workflows/tag-docs-scarthgap.yaml
@@ -1,0 +1,66 @@
+name: "ontag: build and upload docs"
+
+# Runs after "ontag: sync and release" (tag-scarthgap.yaml) completes.
+# Builds the pantavisor-docs tarball and uploads it to S3 under the same
+# tag name used by the release, e.g.:
+#   s3://<bucket>/<tag>/docs/pantavisor-docs-<ver>.tar.gz
+on:
+  workflow_run:
+    workflows: ["ontag: sync and release"]
+    types:
+      - completed
+
+jobs:
+  build-docs:
+    # tag-scarthgap.yaml only triggers on tag pushes, so head_branch is the tag.
+    if: github.event.workflow_run.conclusion == 'success'
+    env:
+      TMPDIR: "tmp-scarthgap"
+    runs-on: ["self-hosted"]
+    container:
+      image: ghcr.io/pantacor/kas/kas:next-v7
+      volumes:
+        - shared:/shared
+      options: --user root
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Fetch tags
+        run: |
+          git config --global --add safe.directory '*'
+          git fetch --tags --force
+      - name: setup workspace
+        run: |
+          chown -R builder:builder $RUNNER_WORKSPACE
+          chown -R builder:builder /__w
+          mkdir -p /shared/sstate && chown builder:builder /shared/sstate && mkdir -p /shared/dldir && chown builder:builder /shared/dldir
+          su - builder -c "cd $GITHUB_WORKSPACE && git fetch origin $GITHUB_SHA && git reset --hard $GITHUB_SHA && rm -rf build/ && git clean -f -f -d -x"
+          git config --global --add safe.directory /__w/meta-pantavisor/meta-pantavisor
+
+      - name: build docs
+        run: |
+          su - builder -c "cd $GITHUB_WORKSPACE && env && kas build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/build-configs/shared-vols.yaml --target pantavisor-docs"
+
+      - name: collect docs tarball
+        run: |
+          chmod -R 777 $GITHUB_WORKSPACE
+          mkdir -p docs-out
+          find build/${{ env.TMPDIR }}/deploy/images/ -name "pantavisor-docs-*.tar.gz" -exec cp {} docs-out/ \;
+          ls -l docs-out
+
+      - name: Archive docs tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: pantavisor-docs
+          path: docs-out/
+          if-no-files-found: ignore
+
+      - name: Upload to S3
+        run: |
+          .github/scripts/upload-docs.sh \
+            ${{ secrets.AWS_ACCESS_KEY_ID }} \
+            ${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            ${{ secrets.AWS_S3_BUCKET }} \
+            ${{ github.event.workflow_run.head_branch }} \
+            docs-out

--- a/docs/ci/builds.md
+++ b/docs/ci/builds.md
@@ -59,6 +59,7 @@ Every build produces some subset of the following:
 s3://<BUCKET>/meta-pantavisor/
   <tag>/
     <machine>/          ← bundle for this specific tag + machine
+    docs/               ← pantavisor-docs tarball for this tag
   latest/
     stable/
       badges/           ← per-machine badge JSON, updated after every stable tag build
@@ -74,6 +75,60 @@ s3://<BUCKET>/meta-pantavisor/
 |---|---|---|
 | `028`, `029` | stable | `latest/stable/` |
 | `028-rc1`, `028-rc9` | release-candidate | `latest/release-candidate/` |
+
+## Documentation Tarball (tag-docs-scarthgap.yaml)
+
+`tag-docs-scarthgap.yaml` runs via `workflow_run` after the `ontag: sync and
+release` workflow (`tag-scarthgap.yaml`) completes successfully. It is
+independent of the per-machine build matrix.
+
+The job:
+
+1. Checks out the tagged commit (`workflow_run.head_sha`) so the docs match
+   the release.
+2. Builds the `pantavisor-docs` target with `kas` inside the KAS container —
+   the `pantavisor-docs` recipe bundles `docs/` from this layer plus docs
+   pulled from the `pantavisor`, `pantacor/docs`, and `pvr` repos into a
+   single `pantavisor-docs-<ver>.tar.gz`.
+3. Collects the tarball from `build/tmp-scarthgap/deploy/images/` and uploads
+   it as a GitHub artifact.
+4. Calls `upload-docs.sh` to push the tarball to S3.
+
+`upload-docs.sh` uploads the tarball to:
+
+```
+s3://<BUCKET>/meta-pantavisor/<TAG>/docs/pantavisor-docs-<ver>.tar.gz
+```
+
+It then upserts a `docs` entry into the existing `releases.json` under the
+tag's array, alongside the per-machine entries already written by `upload.sh`:
+
+```json
+{
+  "release-candidate": {
+    "028-rc10": [
+      { "name": "sunxi-orange-pi-3lts-scarthgap", "full_image": {}, ... },
+      ...
+      { "docs": {
+          "name": "pantavisor-docs-028-rc10.tar.gz",
+          "url": "https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor/028-rc10/docs/pantavisor-docs-028-rc10.tar.gz",
+          "sha256": "<sha256>"
+        }
+      },
+      { "timestamp": "2026-05-13T21:27+00:00" }
+    ]
+  }
+}
+```
+
+The script downloads `releases.json`, finds the item with a `docs` key and
+replaces it (or appends one if absent), then writes the file back. All other
+entries — machine bundles and the timestamp — are left intact.
+
+The tag is taken from `workflow_run.head_branch` (the tag that triggered
+`tag-scarthgap.yaml`). Because `workflow_run` only fires for workflow files
+present on the default branch, this workflow takes effect once it is on
+`master`.
 
 ## CI Badges (upload-badges)
 

--- a/docs/ci/overview.md
+++ b/docs/ci/overview.md
@@ -17,6 +17,9 @@ TAG PUSH  (0*  or  *-rc*)
   tag-changelogs.yaml  (workflow_run, fires after tag-scarthgap completes)
     └── changelog       render CHANGELOG-NNN.md, update GitHub Release, open PR to master
 
+  tag-docs-scarthgap.yaml  (workflow_run, fires after tag-scarthgap completes)
+    └── build-docs      kas build pantavisor-docs → upload tarball to S3
+
 
 ON PUSH  (master)
   onpush-scarthgap.yaml
@@ -52,6 +55,7 @@ SCHEDULED
 | `tag-scarthgap.yaml` | tag push | Orchestrator: sync → release |
 | `release.yaml` | `workflow_call` | Build matrix + pvtests + badge upload |
 | `tag-changelogs.yaml` | `workflow_run` after tag-scarthgap | Changelog generation and GitHub Release |
+| `tag-docs-scarthgap.yaml` | `workflow_run` after tag-scarthgap | Build `pantavisor-docs` tarball, upload to S3 |
 | `sync-pantavisor.yaml` | `workflow_call` | Mirror tag to pantavisor/pantavisor |
 | `onpush-scarthgap.yaml` | push to master | Build matrix for onpush machines |
 | `manual-scarthgap.yaml` | `workflow_dispatch` | Build any machine on demand |
@@ -75,6 +79,7 @@ SCHEDULED
 | `makecommit` | Audit layer changes and draft PR description |
 | `update-components.sh` | Fetch latest SRCREVs for tracked components |
 | `upload.sh` | Push build artifacts and update `releases.json` on S3 |
+| `upload-docs.sh` | Push the `pantavisor-docs` tarball to S3 and upsert its metadata into `releases.json` |
 | `upload-badges` | Write per-machine badge JSON to S3 after a tag build |
 | `sync-pantavisor-tag.sh` | Push the tag to `pantavisor/pantavisor` via PAT |
 | `make-changelog.sh` | Render a CHANGELOG section for a given tag |

--- a/docs/ci/tag-sync.md
+++ b/docs/ci/tag-sync.md
@@ -3,7 +3,7 @@
 When a release tag is pushed to `meta-pantavisor`, a workflow mirrors that tag
 to the upstream [pantavisor/pantavisor](https://github.com/pantavisor/pantavisor)
 repo, pointing at the exact `SRCREV` recorded in
-`recipes-pv/pantavisor/pantavisor_git.bb`.
+`recipes-pv/pantavisor/pantavisor.inc` (`PANTAVISOR_SRCREV`).
 
 This gives upstream a marker linking each pantavisor commit back to the BSP
 release that shipped it.
@@ -24,7 +24,7 @@ failures do not block tag sync.
 
 ## What the script does
 
-1. Parses `SRCREV` from `recipes-pv/pantavisor/pantavisor_git.bb`.
+1. Parses `PANTAVISOR_SRCREV` from `recipes-pv/pantavisor/pantavisor.inc`.
 2. Verifies the SHA is reachable on `pantavisor/pantavisor` (fails if the
    recipe is pinned to an unpublished commit).
 3. Checks whether the tag already exists upstream:
@@ -71,12 +71,12 @@ the secret at run time — there is no caching to invalidate.
 If the upstream tag already exists at a different SHA, the workflow exits
 non-zero with both SHAs in the log. Common causes:
 
-- The recipe `SRCREV` was bumped after the upstream tag was created manually.
+- `PANTAVISOR_SRCREV` in `pantavisor.inc` was bumped after the upstream tag was created manually.
 - An earlier sync ran with a recipe that pointed at a different commit.
 
 To recover, decide which SHA is correct:
 
-- **Upstream tag is correct** — bump `SRCREV` in the recipe to match, retag
+- **Upstream tag is correct** — bump `PANTAVISOR_SRCREV` in `pantavisor.inc` to match, retag
   meta-pantavisor.
 - **Recipe is correct** — delete the upstream tag, then re-run the workflow:
 

--- a/docs/how-to-build/pantavisor-development.md
+++ b/docs/how-to-build/pantavisor-development.md
@@ -110,10 +110,11 @@ docker exec pva-test pvcontrol graph ls
 
 ### Bumping pantavisor SRCREV
 
-When updating `SRCREV` in `recipes-pv/pantavisor/pantavisor_git.bb`:
+When bumping the pantavisor commit:
 
-1. **Verify the hash against the actual remote** — squash merges rewrite hashes, so a branch SHA won't match the merged master SHA
-2. **Update `PKGV`** to match the latest tag reachable from the new SRCREV (e.g. if latest tag is `026`, set `PKGV = "026+git0+${GITPKGV}"`)
+1. **Update `PANTAVISOR_SRCREV`** in `recipes-pv/pantavisor/pantavisor.inc` — the actual hash lives there; `pantavisor_git.bb` just forwards it via `SRCREV = "${PANTAVISOR_SRCREV}"`
+2. **Verify the hash against the actual remote** — squash merges rewrite hashes, so a branch SHA won't match the merged master SHA
+3. **Update `PKGV`** in `pantavisor_git.bb` to match the latest tag reachable from the new SRCREV (e.g. if latest tag is `026`, set `PKGV = "026+git0+${GITPKGV}"`)
 
 ## Adding Workspace Packages
 

--- a/docs/overview/meta-pantavisor.md
+++ b/docs/overview/meta-pantavisor.md
@@ -27,7 +27,7 @@ meta-pantavisor/
 
 | Recipe | Description |
 |--------|-------------|
-| `recipes-pv/pantavisor/pantavisor_git.bb` | Core Pantavisor runtime (C, cmake-based) |
+| `recipes-pv/pantavisor/pantavisor_git.bb` | Core Pantavisor runtime (C, cmake-based); `SRCREV` forwarded from `pantavisor.inc` |
 | `recipes-pv/images/pantavisor-initramfs.bb` | Initramfs image |
 | `recipes-pv/images/pantavisor-bsp.bb` | BSP image (generates pvrexport bundles) |
 | `recipes-pv/pvr/pvr_*.bb` | PVR CLI tool (Go-based) |

--- a/recipes-pv/pantavisor-docs/pantavisor-docs_git.bb
+++ b/recipes-pv/pantavisor-docs/pantavisor-docs_git.bb
@@ -1,0 +1,73 @@
+SUMMARY = "meta-pantavisor documentation tarball"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit nopackages deploy
+
+DEPENDS += "jq-native"
+
+# docs/ lives at the layer root, two levels above this recipe
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../:"
+
+require recipes-pv/pantavisor/pantavisor.inc
+
+PV = "1.0+git${SRCPV}"
+
+SRC_URI = "file://docs \
+           ${PANTAVISOR_URI};branch=${PANTAVISOR_BRANCH};name=pantavisor;destsuffix=pantavisor-git \
+           git://gitlab.com/pantacor/docs.git;protocol=https;branch=master;name=pantacor-docs;destsuffix=pantacor-docs-git \
+           git://github.com/pantacor/pvr.git;protocol=https;branch=master;name=pvr;destsuffix=pvr-git \
+           "
+
+SRCREV_FORMAT        = "pantavisor_pantacor-docs_pvr"
+SRCREV_pantavisor    = "${PANTAVISOR_SRCREV}"
+SRCREV_pantacor-docs = "073294044a4802279bbc7693f207473c73098707"
+SRCREV_pvr           = "09601ee16ff061a6b5b1eff1cd5c66ba9b2c15d5"
+
+do_install[noexec] = "1"
+
+do_deploy() {
+    # Resolve a human-readable version from each SCM (tag or short hash)
+    pv_ver=$(git -C "${WORKDIR}/pantavisor-git" describe --tags --always 2>/dev/null \
+             || git -C "${WORKDIR}/pantavisor-git" rev-parse --short HEAD)
+    docs_ver=$(git -C "${WORKDIR}/pantacor-docs-git" describe --tags --always 2>/dev/null \
+               || git -C "${WORKDIR}/pantacor-docs-git" rev-parse --short HEAD)
+    pvr_ver=$(git -C "${WORKDIR}/pvr-git" describe --tags --always 2>/dev/null \
+              || git -C "${WORKDIR}/pvr-git" rev-parse --short HEAD)
+    layer_ver=$(git -C "${THISDIR}/../.." describe --tags --always 2>/dev/null \
+                || git -C "${THISDIR}/../.." rev-parse --short HEAD)
+
+    # Build staging tree: docs/{versions.json,meta-pantavisor/,pantavisor/,legacy/,pvr/}
+    stage="${WORKDIR}/docs-stage/docs"
+    install -d "${stage}/meta-pantavisor"
+    install -d "${stage}/pantavisor"
+    install -d "${stage}/legacy"
+    install -d "${stage}/pvr"
+
+    jq -n \
+        --arg meta_pantavisor "${layer_ver}" \
+        --arg pantavisor      "${pv_ver}" \
+        --arg pantacor_docs   "${docs_ver}" \
+        --arg pvr             "${pvr_ver}" \
+        '{"meta-pantavisor": $meta_pantavisor, "pantavisor": $pantavisor, "pantacor-docs": $pantacor_docs, "pvr": $pvr}' \
+        > "${stage}/versions.json"
+
+    cp -r "${WORKDIR}/docs/." "${stage}/meta-pantavisor/"
+
+    if [ -d "${WORKDIR}/pantavisor-git/docs" ]; then
+        cp -r "${WORKDIR}/pantavisor-git/docs/." "${stage}/pantavisor/"
+    fi
+
+    if [ -d "${WORKDIR}/pantacor-docs-git/content" ]; then
+        cp -r "${WORKDIR}/pantacor-docs-git/content/." "${stage}/legacy/"
+    fi
+
+    if [ -f "${WORKDIR}/pvr-git/README.md" ]; then
+        cp "${WORKDIR}/pvr-git/README.md" "${stage}/pvr/"
+    fi
+
+    tar -czf "${DEPLOYDIR}/${PN}-${pv_ver}.tar.gz" -C "${WORKDIR}/docs-stage" .
+}
+
+addtask deploy after do_compile before do_build
+do_deploy[dirs] += "${DEPLOYDIR}"

--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,0 +1,3 @@
+PANTAVISOR_BRANCH ??= "master"
+PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
+PANTAVISOR_SRCREV = "cfe4807018bde49eaa8902ee074e2d4f88c17d34"

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -27,14 +27,13 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}_${PV}:"
 
 S = "${WORKDIR}/git"
 
-# TODO: restore "master" + update SRCREV once pantavisor#680 is merged
-PANTAVISOR_BRANCH ??= "master"
+require recipes-pv/pantavisor/pantavisor.inc
 
-SRC_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https;branch=${PANTAVISOR_BRANCH} \
+SRC_URI = "${PANTAVISOR_URI};branch=${PANTAVISOR_BRANCH} \
            file://rev0json \
            "
 
-SRCREV = "cfe4807018bde49eaa8902ee074e2d4f88c17d34"
+SRCREV = "${PANTAVISOR_SRCREV}"
 
 PE = "1"
 PKGV = "026+git0+${GITPKGV}"


### PR DESCRIPTION
## Summary

This PR lands the pantavisor-docs documentation tarball pipeline: a new BitBake recipe that aggregates docs from all Pantavisor repos, a CI workflow that builds and publishes it on every release tag, and a metadata entry in \`releases.json\` so consumers can discover the tarball alongside build artifacts.

It also fixes a silent bug that had been preventing \`schedule-updatemachines.yaml\` from opening PRs since April 9.

---

### New recipe: \`recipes-pv/pantavisor-docs/pantavisor-docs_git.bb\`

Builds a single \`pantavisor-docs-<ver>.tar.gz\` tarball from four documentation sources:

| Tarball path | Source |
|---|---|
| \`meta-pantavisor/\` | \`docs/\` from this layer |
| \`pantavisor/\` | \`docs/\` from \`github.com/pantavisor/pantavisor\` at \`PANTAVISOR_SRCREV\` |
| \`legacy/\` | \`content/\` from \`gitlab.com/pantacor/docs\` |
| \`pvr/\` | \`README.md\` from \`github.com/pantacor/pvr\` |

Also includes a \`versions.json\` with the resolved tag/hash of each source at build time.

### New include: \`recipes-pv/pantavisor/pantavisor.inc\`

Extracts \`PANTAVISOR_BRANCH\`, \`PANTAVISOR_URI\`, and \`PANTAVISOR_SRCREV\` from \`pantavisor_git.bb\` into a shared \`.inc\` required by both \`pantavisor_git.bb\` and \`pantavisor-docs_git.bb\`. A SRCREV bump now only needs to happen in one place.

\`components.json\` and \`sync-pantavisor-tag.sh\` updated to read from \`pantavisor.inc\`.

### New CI workflow: \`tag-docs-scarthgap.yaml\` + \`upload-docs.sh\`

Triggered via \`workflow_run\` after the tag build (\`tag-scarthgap.yaml\`) completes:

1. Checks out the tagged commit and builds \`pantavisor-docs\` with kas.
2. Uploads the tarball to S3: \`s3://<bucket>/<tag>/docs/pantavisor-docs-<ver>.tar.gz\`
3. Upserts a \`docs\` entry into the tag's array in \`releases.json\`:

```json
{
  "docs": {
    "name": "pantavisor-docs-028-rc10.tar.gz",
    "url": "https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor/028-rc10/docs/pantavisor-docs-028-rc10.tar.gz",
    "sha256": "<sha256>"
  }
}
```

The docs metadata lives alongside the per-machine entries in the existing \`releases.json\` — no separate index file.

### Fix: \`schedule-updatemachines.yaml\` PR creation restored

Missing \`permissions: pull-requests: write\` caused \`gh pr create\` to fail with "resource not accessible by integration" since April 9. The error was silently swallowed by \`2>&1 | grep ... || true\`. Also adds a \`gh pr edit\` fallback for when a PR already exists on the branch, and corrects a stale push-trigger path.

---

## Test plan

- [x] \`bitbake pantavisor-docs\` produces tarball in \`DEPLOYDIR\` with correct directory layout
- [x] \`bitbake pantavisor\` still builds cleanly via \`pantavisor.inc\`
- [x] \`update-components.sh\` correctly detects and bumps \`PANTAVISOR_SRCREV\` in \`pantavisor.inc\`
- [x] \`sync-pantavisor-tag.sh\` correctly parses SHA from \`pantavisor.inc\`
- [x] \`upload-docs.sh\` run manually: tarball uploaded to \`028-rc10/docs/\`, \`docs\` entry present in live \`releases.json\`
- [x] \`schedule-updatemachines\` manual run completes without error; PR creation verified once merged to master