### PR TITLE
pvtest: workspace per-test dirs, split logs, inline diffs, CI artifact naming

### DIFF
--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -72,10 +72,10 @@ jobs:
         working-directory: ${{ env.WORKSPACE }}
         if: always()
         run: |
-          if [ -f test.docker.log ]; then
+          if [ -f run.log ]; then
             {
               echo '```'
-              sed -n '/SUMMARY/,$p' test.docker.log
+              sed -n '/SUMMARY/,$p' run.log
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           else
@@ -87,7 +87,9 @@ jobs:
         run: |
           suffix="${{ inputs.test_path }}"
           suffix="${suffix//\//-}"
-          echo "PVTEST_ARTIFACT_NAME=pvtest-workspace-${suffix:-all}" >> $GITHUB_ENV
+          sha="${{ github.sha }}"
+          sha="${sha:0:7}"
+          echo "PVTEST_ARTIFACT_NAME=pvtest-workspace-${sha}-${suffix:-all}" >> $GITHUB_ENV
 
           sudo chown -R $(id -u):$(id -g) $PVTEST_WORKSPACE || true
 
@@ -97,9 +99,10 @@ jobs:
         with:
           name: ${{ env.PVTEST_ARTIFACT_NAME }}
           path: |
-            ${{ env.PVTEST_WORKSPACE }}/test.docker.log
-            ${{ env.PVTEST_WORKSPACE }}/storage/**/logs
-            ${{ env.PVTEST_WORKSPACE }}/valgrind
+            ${{ env.PVTEST_WORKSPACE }}/README.md
+            ${{ env.PVTEST_WORKSPACE }}/run.log
+            ${{ env.PVTEST_WORKSPACE }}/local
+            ${{ env.PVTEST_WORKSPACE }}/remote
           if-no-files-found: ignore
 
       - name: Clean up

--- a/docs/testing/automated-workflow.md
+++ b/docs/testing/automated-workflow.md
@@ -58,107 +58,92 @@ The runner uses `sudo -n` (non-interactive) for several commands during test exe
 ./test.docker.sh -v run -V
 ```
 
-Logs land in `./test.docker.log`. Pantavisor storage is preserved at `<tmpdir>/storage/<scope>/<category>/<name>/` for post-run inspection.
+The workspace is a temporary directory. Location info (workspace path, log paths) is printed at the start of the run and written to `run.log`. A copy of `run.log` is also saved to `./run.log` in the current directory for CI consumption.
+
+## Workspace layout
+
+```
+<workspace>/
+  run.log                           <- location info, one result line per test + inline diffs, SUMMARY
+  README.md
+  <scope>/<category>/<name>/        <- first attempt
+    test.log                        <- full bash-traced output + docker output for this test
+    diff                            <- diff (expected vs actual), present only when test failed
+    valgrind/
+      valgrind.log.<pid>            <- present only when run with -V
+  <scope>/<category>/<name>.1/      <- retry attempt 1 (same structure)
+  <scope>/<category>/<name>.2/      <- retry attempt 2 (same structure)
+  storage/                          <- full Pantavisor on-device storage per test (same naming convention)
+    <scope>/<category>/<name>/
+      trails/ objects/ disks/ dm-crypt-files/ cache/ boot/ config/ logs/
+```
+
+> **Note:** `storage/` is kept on disk for local debugging but is **not** uploaded to CI artifacts. `local/` and `remote/` (with per-test logs, diffs, and valgrind results) are uploaded.
 
 ## Interpreting test results
 
-With `-v`, the run ends with a summary block:
+The run prints location info at the start, then one result line per test (with inline diffs for failures), and ends with a SUMMARY listing every test:
 
 ```
+Info: workspace=/tmp/pv_appengine.jBZqVz
+Info: readme=/tmp/pv_appengine.jBZqVz/README.md
+Info: run log=/tmp/pv_appengine.jBZqVz/run.log
+Info: test log=/tmp/pv_appengine.jBZqVz/<scope>/<category>/<name>/test.log
+Info: valgrind log=/tmp/pv_appengine.jBZqVz/<scope>/<category>/<name>/valgrind/valgrind.log.<pid>
+Info: diff=/tmp/pv_appengine.jBZqVz/<scope>/<category>/<name>/diff
+
+Info: 'local/core/legacy-config-overload' PASSED (23 s)
+Info: 'local/lifecycle/reboot-nonreboot-rollback' FAILED (110 s)
+--- diff: local/lifecycle/reboot-nonreboot-rollback ---
+-expected line
++actual line
+--- end diff ---
+Info: 'local/runtime/remount-policies' SKIPPED
 =======================================================
 ======================= SUMMARY =======================
 =======================================================
-Info: workspace=/tmp/pv_appengine.jBZqVz
-Info: logs=/tmp/pv_appengine.jBZqVz/test.docker.log
-Info: valgrind results=/tmp/pv_appengine.jBZqVz/valgrind
-Info: Pantavisor storage=/tmp/pv_appengine.jBZqVz/storage
-
 Info: 'local/core/legacy-config-overload' PASSED (23 s)
 Info: 'local/lifecycle/reboot-nonreboot-rollback' FAILED (110 s)
 Info: 'local/runtime/remount-policies' SKIPPED
 =======================================================
 ```
 
-Each test runs a script (`resources/test`) and diffs its stdout against the stored `output` file. A failure means the actual output diverged from the expected output. The diff is embedded in the framework log (see below).
+A failure means actual test output diverged from expected. Lines prefixed with `-` are expected; lines prefixed with `+` are what the test produced.
 
-### Framework log
+For failing tests, the diff is printed in `run.log` immediately after the FAILED line, and also saved to `<scope>/<category>/<name>/diff`. Retry attempts get their own directory (`<name>.1/`, `<name>.2/`).
 
-`<workspace>/test.docker.log` contains the full bash-traced output of `test.docker.sh`. To find what went wrong for a specific failing test, search for its diff block:
+### test.log
 
-```bash
-grep -A40 "--- /dev/fd" /tmp/pv_appengine.<id>/test.docker.log
-```
+`test.log` is a single interleaved stream of everything that happened during a test attempt. It mixes output from four sources:
 
-Lines prefixed with `-` are what was expected; lines prefixed with `+` are what the test produced.
+**`test.docker.sh` (`set -x` traces)**
+The host-side orchestrator running on the CI runner or developer machine. Visible as `++ docker run ...`, `++ allocate_slot`, etc. Covers container startup, loop device allocation, and concurrent slot management.
 
-### Storage
+**`pvtest-run` (`set -x` traces) + `resources/test` output**
+`pvtest-run` is the inner test runner inside the tester container. It parses `test.json`, initialises storage, starts Pantavisor via `pv-appengine`, waits for it to reach READY, then runs `resources/test` (the actual test script, with `set -x` injected at the top). The test script's stdout is captured and diffed against the stored `output` file; the diff is written to `storage/<test_id>/diff` and copied to `<test_id>/diff` in the workspace.
 
-The workspace keeps the full Pantavisor storage directory for every test that ran, under `<workspace>/storage/<scope>/<category>/<name>/`. This mirrors the on-device storage layout and is the primary place to inspect what the runtime actually did.
+**`pv-appengine` (Pantavisor runtime launcher)**
+Runs inside the tester container. Sets up cgroups, loop devices, and storage mounts, then launches the `pantavisor` binary in a restart loop to simulate device reboots between update steps.
 
-```
-<workspace>/storage/<scope>/<category>/<name>/
-  trails/         <- revision snapshots (objects, configs, per-container dirs)
-  objects/        <- content-addressed object store
-  disks/          <- persistent disk images
-  dm-crypt-files/ <- dm-crypt key material
-  cache/
-  boot/
-  config/
-  logs/           <- see below
-```
+**Pantavisor logs (`stdout_direct`)**
+Pantavisor is started with `PV_LOG_SERVER_OUTPUTS=filetree,stdout_direct`. The `stdout_direct` output mode streams Pantavisor's internal log directly to stdout as each event happens, without buffering. These lines carry the `[pantavisor] TIMESTAMP LEVEL -- [module]: message` format and are interleaved in real time with the shell traces above. The same log content is also written to `storage/<scope>/<category>/<name>/logs/` (kept on disk, not in CI artifacts).
 
-#### Logs
-
-```
-logs/
-  current/              <- live log snapshot at test end
-    pantavisor/
-      pantavisor.log    <- main Pantavisor log
-    <container>/
-      lxc/
-        lxc.log         <- LXC internals
-        console.log     <- container console output
-      var/log/
-        messages        <- syslog inside the container
-  0/                    <- rotated snapshot (first boot cycle)
-  locals/               <- per-local-revision log snapshots
-    <local-name>/
-      pantavisor/
-        pantavisor.log
-```
-
-The main log to check first is always `logs/current/pantavisor/pantavisor.log`. For tests that exercise local revisions, each revision also has its own snapshot under `logs/locals/<local-name>/`.
-
-Useful greps:
+Useful greps on a `test.log`:
 
 ```bash
-# Show only errors and warnings
-grep " ERROR\b\| WARN\b" logs/current/pantavisor/pantavisor.log
+# Pantavisor errors and warnings only
+grep " ERROR\b\| WARN\b" test.log
 
-# Exclude noisy disk-crypt stderr (routed through the WARN channel)
-grep " WARN\b" pantavisor.log | grep -v "\[disk-crypt-err\]"
+# Just the test script execution (resources/test set -x traces)
+grep "^+ \|^++ " test.log | tail -50
 ```
 
-Expected recurring WARNs that are normal in the appengine environment:
+### Valgrind logs
 
-| Source | Message | Reason |
-|--------|---------|--------|
-| `[ipam]` | `failed to enable IP forwarding` | No network namespace in appengine |
-| `[pv-xconnect-err]` | `Error connecting to pv-ctrl: Connection reset by peer` | Normal on shutdown |
-| `[platforms]` | `sent SIGKILL to logger '...'` | Loggers that don't self-exit on teardown |
-| `[network]` | `unable to create bridge dev lxcbr0: File exists` | Bridge already exists from prior test |
-
-### Valgrind results
-
-With `-V`, each process gets its own `valgrind.log.<pid>` file under `<workspace>/valgrind/<group>/<num>/`. Pantavisor forks heavily via LXC, so there will be many files. The main Pantavisor worker is typically the largest:
+With `-V`, each process gets its own `valgrind.log.<pid>` file under `<scope>/<category>/<name>/valgrind/` (and `<name>.1/valgrind/` for retries). Pantavisor forks heavily via LXC, so there will be many files. The main Pantavisor worker is typically the largest:
 
 ```bash
-ls -S /tmp/pv_appengine.<id>/valgrind/local/lifecycle/reboot-nonreboot-rollback/ | head -3
-```
-
-Each file ends with a LEAK SUMMARY and ERROR SUMMARY:
-
-```bash
+ls -S <workspace>/local/lifecycle/reboot-nonreboot-rollback/valgrind/ | head -3
 grep -E "definitely lost|possibly lost|ERROR SUMMARY" valgrind.log.<largest-pid>
 ```
 

--- a/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
@@ -292,8 +292,14 @@ exec_test() {
 
 	mkdir -p "$work_path/storage/$test_id/"
 	cd "$work_path/storage/$test_id/"; abs_storage_path=$(pwd); cd - > /dev/null
-	mkdir -p "$work_path/valgrind/$test_id/"
-	cd "$work_path/valgrind/$test_id/"; abs_valgrind_path=$(pwd); cd - > /dev/null
+	mkdir -p "$work_path/${test_id}/valgrind/"
+	cd "$work_path/${test_id}/valgrind/"; abs_valgrind_path=$(pwd); cd - > /dev/null
+
+	if [ "$interactive" = "false" ] && [ "$manual" = "false" ]; then
+		mkdir -p "$work_path/$test_id"
+		exec 3>&1 4>&2
+		exec >> "$work_path/${test_id}/test.log" 2>&1
+	fi
 
 	# Per-run slot used to disambiguate container names and host ports so
 	# multiple test.docker.sh invocations can run concurrently. Slot 0 keeps
@@ -400,15 +406,34 @@ exec_test() {
 		return
 	fi
 
+	# Copy diff to the per-test dir so it lands in the GHA artifact (storage/ stays on disk)
+	diff_src="$work_path/storage/$test_id/diff"
+	if [ -s "$diff_src" ]; then
+		cp "$diff_src" "$work_path/${test_id}/diff"
+	fi
+
+	exec 1>&3 3>&- 2>&4 4>&-
+
 	if [ $res -eq 0 ]; then
 		echo -e "Info: '$test_id' ${GREEN}PASSED${NOCOLOR} ($runtime s)"
+		echo "Info: '$test_id' PASSED ($runtime s)" >> "$work_path/run.log"
 		return 0
 	elif [ $res -eq 2 ]; then
 		echo -e "Info: '$test_id' ${ORANGE}ABORTED${NOCOLOR} ($runtime s)"
+		echo "Info: '$test_id' ABORTED ($runtime s)" >> "$work_path/run.log"
 		return 2
 	else
 		echo -e "Info: '$test_id' ${RED}FAILED${NOCOLOR} ($runtime s)"
-			return 1
+		echo "Info: '$test_id' FAILED ($runtime s)" >> "$work_path/run.log"
+		diff_file="$work_path/${test_id}/diff"
+		if [ -s "$diff_file" ]; then
+			{
+			printf "\n--- diff: %s ---\n" "$test_id"
+			cat "$diff_file"
+			printf '%s\n' "--- end diff ---"
+			} | tee -a "$work_path/run.log"
+		fi
+		return 1
 	fi
 }
 
@@ -425,7 +450,8 @@ run_with_retry() {
 			return 1
 		fi
 		test_id=$(echo "$json_path" | sed 's|^\./||; s|/test\.json$||')
-		echo "Retry: '$test_id' attempt $attempt/$max_retries after failure..."
+		echo -e "Retry: '$test_id' attempt $attempt/$max_retries after failure..."
+		echo "Retry: '$test_id' attempt $attempt/$max_retries after failure..." >> "$work_path/run.log"
 		sleep 5
 	done
 }
@@ -439,6 +465,7 @@ skip_test () {
 	skip=$(jq -r '.skip' "$json_path")
 	if [ "$skip" = "true" ]; then
 		echo -e "Info: '$test_id' ${ORANGE}SKIPPED${NOCOLOR}"
+		echo "Info: '$test_id' SKIPPED" >> "$work_path/run.log"
 		return 1
 	fi
 
@@ -519,8 +546,16 @@ run_test() {
 	fi
 
 	mkdir -p "$work_path"
-	echo "Info: test logs can be found at $work_path/test.docker.log"
-	exec > >(tee -a "$work_path/test.docker.log") 2>&1
+	{
+	echo "Info: workspace=$work_path"
+	echo "Info: readme=$work_path/README.md"
+	echo "Info: run log=$work_path/run.log"
+	echo "Info: test log=$work_path/<scope>/<category>/<name>/test.log"
+	if [ "$valgrind" = "true" ]; then
+		echo "Info: valgrind log=$work_path/<scope>/<category>/<name>/valgrind/valgrind.log.<pid>"
+	fi
+	echo "Info: diff=$work_path/<scope>/<category>/<name>/diff"
+	} | tee -a "$work_path/run.log"
 
 	if [ -z "$target_path" ]; then
 		find $test_dir/ -name "test.json" | sort | while read -r json_path; do
@@ -543,34 +578,85 @@ run_test() {
 	fi
 
 	set +x
+	{
 	echo "======================================================="
 	echo "======================= SUMMARY ======================="
 	echo "======================================================="
-	if [ "$verbose" = "true" ]; then
-		echo "Info: workspace=$work_path"
-		echo "Info: logs=$work_path/test.docker.log"
-		if [ "$valgrind" = "true" ]; then
-			echo "Info: valgrind results=$work_path/valgrind"
-		fi
-		echo "Info: Pantavisor storage=$work_path/storage"
-		echo ""
-	fi
-	grep "^Info: 'local\|^Info: 'remote" "$work_path/test.docker.log"
-	grep "^Info: '.*FAILED" "$work_path/test.docker.log" \
-		| sed "s/^Info: '//; s/'[[:space:]].*//" \
-		| sort -u \
-		| while read -r test_id; do
-			diff_file="$work_path/storage/$test_id/diff"
-			[ -s "$diff_file" ] || continue
-			printf "\n--- diff: %s ---\n" "$test_id"
-			cat "$diff_file"
-			printf '%s\n' "--- end diff ---"
-		done
+	grep "^Info: '.*\(PASSED\|FAILED\|ABORTED\|SKIPPED\)" "$work_path/run.log"
 	echo "======================================================="
+	} | tee -a "$work_path/run.log"
 	set -h
 
 	# make summary available to the run path for the CI
-	cp $work_path/test.docker.log ./test.docker.log
+	cp $work_path/run.log ./run.log
+
+	cat > "$work_path/README.md" << 'EOF'
+# Test Run Results
+
+## Workspace Layout
+
+```
+<workspace>/
+  run.log                           <- location info, one result line per test + inline diffs, SUMMARY
+  README.md
+  <scope>/<category>/<name>/
+    test.log                        <- full verbose output (see below)
+    diff                            <- diff (expected vs actual), present only when test failed
+    valgrind/
+      valgrind.log.<pid>            <- present only when run with -V
+  storage/                          <- kept on disk, not uploaded to CI artifacts
+    <scope>/<category>/<name>/
+      trails/ objects/ logs/ ...
+```
+
+## Interpreting Results
+
+A failure means actual test output diverged from expected. Lines prefixed with `-` are
+expected; lines prefixed with `+` are what the test produced.
+
+When a test fails, the diff is printed inline in `run.log` right after the FAILED line, and
+also saved to `<scope>/<category>/<name>/diff`. Retry attempts get their own directory
+(`<name>.1/`, `<name>.2/`).
+
+### test.log
+
+`test.log` is a single interleaved stream of everything that happened during a test run.
+It mixes output from four sources:
+
+**1. `test.docker.sh` (`set -x` traces)**
+The host-side orchestrator. Visible as `++ docker run ...`, `++ allocate_slot`, etc.
+Covers container startup, loop device allocation, and network setup.
+
+**2. `pvtest-run` (`set -x` traces) + `resources/test` output**
+`pvtest-run` is the inner test runner inside the tester container. It parses `test.json`,
+initialises storage, starts Pantavisor via `pv-appengine`, then runs `resources/test`
+(the actual test script, with `set -x` injected at the top). The test script's stdout
+is captured and diffed against the stored `output` file; the diff appears at the end of
+the log.
+
+**3. `pv-appengine` (Pantavisor runtime launcher)**
+Runs inside the tester container. Sets up cgroups, loop devices, and storage mounts,
+then launches the `pantavisor` binary in a restart loop (simulating device reboots).
+
+**4. Pantavisor logs (`stdout_direct`)**
+Pantavisor is started with `PV_LOG_SERVER_OUTPUTS=filetree,stdout_direct`. The
+`stdout_direct` output mode streams Pantavisor's internal log directly to stdout as
+each event happens, without buffering. These lines carry the familiar
+`[pantavisor] TIMESTAMP LEVEL -- [module]: message` format and are interleaved
+in real time with the shell traces above.
+
+### Valgrind Logs
+
+Each test's valgrind output is under `<scope>/<category>/<name>/valgrind/valgrind.log.<pid>`.
+The main Pantavisor worker is typically the largest file:
+
+    ls -S <scope>/<category>/<name>/valgrind/ | head -3
+    grep -E "definitely lost|possibly lost|ERROR SUMMARY" valgrind.log.<largest-pid>
+
+- `definitely lost` — real leaks, investigate
+- `possibly lost` — typically PV buffer pools; consistent at ~3.7 MB, not a regression
+- `ERROR SUMMARY` — mostly `Syscall param` warnings from liblxc, not pantavisor code
+EOF
 
 	if [ -f "$failed_flag" ]; then
 		return 1


### PR DESCRIPTION
## Summary

- Reorganize pvtest workspace into per-test dirs with collocated logs, diffs, and valgrind results; print inline diffs in `run.log` after FAILED lines; reformat summary so location info is in the body and SUMMARY block contains only the test list
- Per-test artifact upload in CI with build SHA in artifact names
- Update `docs/testing/automated-workflow.md` to reflect new workspace layout, SUMMARY format, and reordered test.log sources (`pvtest-run` now between `test.docker.sh` and `pv-appengine`)