### PR TITLE
ci: fix changelog and docs workflows not running on pvtest failure

### DIFF
--- a/.github/workflows/tag-changelogs.yaml
+++ b/.github/workflows/tag-changelogs.yaml
@@ -16,7 +16,7 @@ name: "ontag: generate changelog and release notes"
 
 on:
   workflow_run:
-    workflows: ["ontag: make release, build all targets"]
+    workflows: ["ontag: sync and release"]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -30,8 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.event == 'push' &&
-       startsWith(github.event.workflow_run.head_branch, '0'))
+      startsWith(github.event.workflow_run.head_branch, '0')
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tag-docs-scarthgap.yaml
+++ b/.github/workflows/tag-docs-scarthgap.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-docs:
     # tag-scarthgap.yaml only triggers on tag pushes, so head_branch is the tag.
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion != 'cancelled'
     env:
       TMPDIR: "tmp-scarthgap"
     runs-on: ["self-hosted"]


### PR DESCRIPTION
## Problem

Two downstream tag workflows were silently skipped whenever pvtests failed:

- **`tag-changelogs`** listened to `"ontag: make release, build all targets"` (`release.yaml`), but `release.yaml` is a reusable workflow invoked via `workflow_call` — GitHub does not emit `workflow_run` events for reusable workflow calls. Additionally, the job condition checked `github.event.workflow_run.event == 'push'`, which would always be `'workflow_call'` in that context. The net result: changelogs only ever ran via `workflow_dispatch`.
- **`tag-docs`** correctly listened to the top-level `tag-scarthgap` workflow, but gated on `conclusion == 'success'`, so any pvtest failure blocked the docs build entirely.

Neither workflow actually depends on tests passing. `releases.json` (which provides artifact URLs and sha256 checksums for the changelog downloads table) is fully populated by `upload.sh` during the `build` matrix job — before pvtests start.

## Changes

- **`tag-changelogs`**: switch `workflow_run` trigger to `"ontag: sync and release"` (the top-level `tag-scarthgap.yaml`, which is directly triggered by tag push and does emit `workflow_run` events); drop the now-redundant `event == 'push'` guard from the job condition.
- **`tag-docs`**: replace `conclusion == 'success'` with `conclusion != 'cancelled'` so pvtest failures no longer block the docs build.

## Test plan

- Push a release tag and intentionally let pvtests fail — verify both `tag-changelogs` and `tag-docs` workflows still run to completion.
- Push a release tag with passing pvtests — verify behaviour is unchanged.
- Trigger `tag-changelogs` via `workflow_dispatch` — verify it still works.