### PR TITLE
feat(pvtx): include libpvtx.so in pantavisor-pvtx package

### DIFF
--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -48,6 +48,8 @@ FILES:${PN} += " /init"
 
 # pvtx packages
 FILES:${PN}-pvtx += " ${bindir}/pvtx"
+FILES:${PN}-pvtx += " ${libdir}/libpvtx.so.*"
+RPROVIDES:${PN}-pvtx += "libpvtx.so"
 RPROVIDES:${PN}-pvtx += "pvcontrol-pvtx"
 RREPLACES:${PN}-pvtx += "pvcontrol-pvtx"
 RCONFLICTS:${PN}-pvtx += "pvcontrol-pvtx"


### PR DESCRIPTION
## Summary

- Add `${libdir}/libpvtx.so` to `FILES:${PN}-pvtx` so the shared library
  built by pantavisor#698 is packaged in `pantavisor-pvtx` rather than
  auto-assigned to `pantavisor-dev` by Yocto's SOLIBSDEV mechanism.
- Add `RPROVIDES` for `libpvtx.so` so other recipes can express a runtime
  dependency on the library by name.