### PR TITLE
fix(ci): fix PR body exceeding GitHub 65536 character limit in schedule-updatemachines

### DIFF
--- a/.github/workflows/schedule-updatemachines.yaml
+++ b/.github/workflows/schedule-updatemachines.yaml
@@ -37,7 +37,9 @@ jobs:
         run: |
           .github/scripts/makecommit && \
           git push origin -f autopr/machine-update-$GITHUB_REF_NAME-next && \
-          gh pr create --base $GITHUB_REF_NAME --fill || \
+          gh pr create --base $GITHUB_REF_NAME \
+            --title "AutoPR: update kas meta layers to latest branch commits" \
+            --body "Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog." || \
           gh pr edit autopr/machine-update-$GITHUB_REF_NAME-next --title "AutoPR: update kas meta layers to latest branch commits"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The `schedule-updatemachines` workflow was failing with:

```
pull request create failed: GraphQL: Body is too long (maximum is 65536 characters) (createPullRequest)
```

`gh pr create --fill` dumps the full commit message into the PR body. The `makecommit` script builds that message by running `git log --oneline` across every tracked repo's commit range — with enough repos and commits this easily exceeds GitHub's limit.

## Fix

Replace `--fill` with an explicit short `--body` string. All the per-repo detail is still available in the commit message on the PR branch.