### PR TITLE
fix(pvtest): clean up orphan dm-crypt devices before each test run

### DIFF
--- a/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro/test.docker.sh
@@ -259,6 +259,35 @@ teardown_network() {
 	sudo -n modprobe -r mac80211_hwsim
 }
 
+# Remove orphan dm-crypt devices whose backing loop file has been deleted.
+# These are left over from a previously crashed test container: the storage
+# tmpfs was torn down (deleting the image file) but the dm-crypt mapping and
+# its loop device were never closed.  Active containers always have a live
+# backing file, so matching on '(deleted)' is safe even with parallel runs.
+cleanup_orphan_dmcrypt() {
+	echo "cleanup_orphan_dmcrypt: scanning /dev/mapper ..."
+	sudo -n dmsetup ls --noheadings 2>&1 | awk '{print $1}' \
+		| while IFS= read -r _dm_dev; do
+			_backing=$(sudo -n dmsetup table "$_dm_dev" 2>&1 | awk '{print $7}')
+			echo "cleanup_orphan_dmcrypt: dev=$_dm_dev backing=$_backing"
+			echo "$_backing" | grep -qE '^7:[0-9]+$' || { echo "cleanup_orphan_dmcrypt: skip $_dm_dev (not loop-backed)"; continue; }
+			_lo="/dev/loop${_backing#7:}"
+			_back_file=$(sudo -n losetup -nO BACK-FILE "$_lo" 2>&1 || true)
+			echo "cleanup_orphan_dmcrypt: lo=$_lo back_file=$_back_file"
+			case "$_back_file" in
+				*"(deleted)"*)
+					echo "cleanup_orphan_dmcrypt: removing orphan $_dm_dev (backing file deleted)"
+					sudo -n dmsetup remove --force "$_dm_dev" 2>&1 || true
+					sudo -n losetup -d "$_lo" 2>&1 || true
+					;;
+				*)
+					echo "cleanup_orphan_dmcrypt: skip $_dm_dev (backing file still live)"
+					;;
+			esac
+		done
+	echo "cleanup_orphan_dmcrypt: done"
+}
+
 exec_test() {
 	local json_path=$1
 	local interactive=$2
@@ -320,6 +349,8 @@ exec_test() {
 	unused_lo=$(sudo -n losetup -f)
 
 	start=$(date +%s)
+
+	cleanup_orphan_dmcrypt
 
 	setup_network0
 


### PR DESCRIPTION
## Summary

- Add \`cleanup_orphan_dmcrypt()\` to \`test.docker.sh\`, called at the start of \`exec_test()\` before the container launches
- The function removes dm-crypt devices whose backing loop file is marked \`(deleted)\` — the reliable fingerprint of an orphan left by a previously crashed or cancelled container
- Fixes test failures caused by \`/dev/mapper/versatile\` name collisions that blocked \`cryptsetup open\` inside the next test's container

## Why test.docker.sh and not pv-appengine.in

\`pv-appengine.in\` already has \`cleanup_cryptdisk()\`, which runs before and after each pantavisor restart. Traditionally, host-level cleanup has been handled there, but this case is different: \`cleanup_cryptdisk\` runs **inside** the Docker test container, which is only given access to its own pre-allocated loop device. It cannot reach loop devices allocated by previous container runs. When a prior container crashed — or when a GitHub Actions workflow was manually cancelled — without tearing down its dm-crypt device, the leftover mapping references an inaccessible loop device. \`cryptsetup close\` and \`dmsetup remove --force\` both fail silently from inside the new container.

\`test.docker.sh\` runs on the host with full \`sudo\` access and sees all loop devices, making it the right layer to clean up inter-run host state regardless of how the previous run ended.

## How it works

For each dm device, the function reads field 7 of \`dmsetup table\` (the backing \`major:minor\`), resolves it to a loop device, then checks \`losetup -nO BACK-FILE\`. If the path ends with \`(deleted)\`, the image file is gone but the kernel mapping was never closed — this is always an orphan. The function then runs \`dmsetup remove --force\` and \`losetup -d\` to fully tear it down. The \`(deleted)\` check makes it safe to run with parallel test slots, since active containers never have a deleted backing file.