### PR TITLE
ci(pvtests): add commit input to manual-pvtests workflow

### DIFF
--- a/.github/workflows/buildkas-target.yaml
+++ b/.github/workflows/buildkas-target.yaml
@@ -18,6 +18,10 @@ on:
       sdk:
         required: false
         type: number
+      ref:
+        description: 'Specific git ref (commit SHA, branch, tag) to build; defaults to the triggering SHA'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -31,16 +35,20 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Fetch tags
         run: |
           git config --global --add safe.directory '*'
           git fetch --tags --force --depth=${{ inputs.fetch-depth || 1 }}
       - name: setup workspace
+        env:
+          EFFECTIVE_REF: ${{ inputs.ref || github.sha }}
         run: |
           chown -R builder:builder $RUNNER_WORKSPACE
           chown -R builder:builder /__w
           mkdir -p /shared/sstate && chown builder:builder /shared/sstate && mkdir -p /shared/dldir && chown builder:builder /shared/dldir
-          su - builder -c "cd $GITHUB_WORKSPACE && git fetch origin $GITHUB_SHA && git reset --hard $GITHUB_SHA && rm -rf build/ && git clean -f -f -d -x "
+          su - builder -c "cd $GITHUB_WORKSPACE && git fetch origin $EFFECTIVE_REF && git reset --hard $EFFECTIVE_REF && rm -rf build/ && git clean -f -f -d -x "
           git config --global --add safe.directory /__w/meta-pantavisor/meta-pantavisor
 
       - name: build

--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -10,6 +10,10 @@ on:
       test_path:
         required: false
         type: string
+      commit:
+        description: 'Commit SHA that was built; used to name the artifact. Defaults to github.sha.'
+        required: false
+        type: string
 jobs:
 
   validate:
@@ -87,7 +91,7 @@ jobs:
         run: |
           suffix="${{ inputs.test_path }}"
           suffix="${suffix//\//-}"
-          sha="${{ github.sha }}"
+          sha="${{ inputs.commit || github.sha }}"
           sha="${sha:0:7}"
           echo "PVTEST_ARTIFACT_NAME=pvtest-workspace-${sha}-${suffix:-all}" >> $GITHUB_ENV
 

--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -7,6 +7,10 @@ env:
 on:
   workflow_call:
     inputs:
+      commit:
+        description: 'Commit SHA that was built; used to name the artifact. Defaults to github.sha.'
+        required: false
+        type: string
       test_path:
         required: false
         type: string
@@ -111,7 +115,7 @@ jobs:
         run: |
           suffix="${{ inputs.test_path }}"
           suffix="${suffix//\//-}"
-          sha="${{ github.sha }}"
+          sha="${{ inputs.commit || github.sha }}"
           sha="${sha:0:7}"
           echo "PVTEST_ARTIFACT_NAME=pvtest-workspace-${sha}-${suffix:-all}" >> $GITHUB_ENV
 

--- a/.github/workflows/manual-pvtests.yaml
+++ b/.github/workflows/manual-pvtests.yaml
@@ -9,6 +9,11 @@ on:
         required: false
         type: string
 
+      commit:
+        description: 'Specific commit SHA to build from; defaults to the dispatched branch/tag tip'
+        required: false
+        type: string
+
 jobs:
 
   build-docker-x86_64-scarthgap:
@@ -19,6 +24,7 @@ jobs:
       build_target: pantavisor-appengine-distro
       output: pantavisor-appengine-distro-*.tar.gz
       sdk: 0
+      ref: ${{ inputs.commit }}
     secrets: inherit
 
   start-pvtest:
@@ -26,4 +32,5 @@ jobs:
     uses: ./.github/workflows/call-pvtests.yaml
     with:
       test_path: ${{ inputs.test_path }}
+      commit: ${{ inputs.commit }}
     secrets: inherit

--- a/.github/workflows/manual-pvtests.yaml
+++ b/.github/workflows/manual-pvtests.yaml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
     inputs:
 
+      commit:
+        description: 'Specific commit SHA to build from; defaults to the dispatched branch/tag tip'
+        required: false
+        type: string
+
       test_path:
         description: 'Test path to run (e.g. "local/lifecycle"); leave empty to run all tests'
         required: false
@@ -25,12 +30,14 @@ jobs:
       build_target: pantavisor-appengine-distro
       output: pantavisor-appengine-distro-*.tar.gz
       sdk: 0
+      ref: ${{ inputs.commit }}
     secrets: inherit
 
   start-pvtest:
     needs: build-docker-x86_64-scarthgap
     uses: ./.github/workflows/call-pvtests.yaml
     with:
+      commit: ${{ inputs.commit }}
       test_path: ${{ inputs.test_path }}
       parallel: ${{ inputs.parallel }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- manual-pvtests.yaml gains an optional `commit` input so users can pin a
  build+test run to a specific SHA rather than always using the branch tip
- The SHA is threaded through to the build step (via a new `ref` input on
  buildkas-target.yaml) and to artifact naming (via a new `commit` input on
  call-pvtests.yaml)
- When no commit is supplied all three workflows behave exactly as before

## Changes
- manual-pvtests.yaml: add optional `commit` dispatch input; pass as `ref`
  to buildkas-target and as `commit` to call-pvtests
- buildkas-target.yaml: add optional `ref` input; use it in actions/checkout
  and as EFFECTIVE_REF in the git fetch/reset step (GITHUB_SHA is not
  updated by checkout and must be replaced explicitly)
- call-pvtests.yaml: add optional `commit` input; use it in the workspace
  artifact name so the artifact reflects the tested SHA, not the branch tip