### PR TITLE
test(pvtest): add basic-endpoints-curl and device-user-metadata pvtests

### DIFF
--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
@@ -1,0 +1,586 @@
++ export CURL_CMD=curl
++ CURL_CMD=curl
++ pvcontrol containers ls
++ jq -M
++ tr -d '\r'
+[
+  {
+    "name": "pvr-sdk",
+    "group": "platform",
+    "status": "STARTED",
+    "status_goal": "STARTED",
+    "restart_policy": "system",
+    "roles": [
+      "mgmt"
+    ]
+  }
+]
++ pvcontrol groups ls
++ jq -M
++ tr -d '\r'
+[
+  {
+    "name": "data",
+    "status_goal": "MOUNTED",
+    "restart_policy": "system",
+    "status": "READY"
+  },
+  {
+    "name": "root",
+    "status_goal": "STARTED",
+    "restart_policy": "system",
+    "status": "READY"
+  },
+  {
+    "name": "platform",
+    "status_goal": "STARTED",
+    "restart_policy": "system",
+    "status": "READY"
+  },
+  {
+    "name": "app",
+    "status_goal": "STARTED",
+    "restart_policy": "container",
+    "status": "READY",
+    "auto_recovery": {
+      "max_retries": 5,
+      "stable_timeout": 30,
+      "backoff_policy": "reboot"
+    }
+  }
+]
++ pvcontrol usrmeta ls
++ jq -M
++ tr -d '\r'
+{}
++ pvcontrol devmeta ls
++ jq -M 'del(.storage, .interfaces, .sysinfo, .time, .["pantavisor.uname"], .["pantavisor.cpumodel"], .["pantavisor.version"])'
++ tr -d '\r'
+{
+  "pantavisor.status": "READY",
+  "pantahub.claimed": "0",
+  "pantahub.online": "0",
+  "pantavisor.mode": "local",
+  "pantavisor.revision": "0",
+  "pantavisor.arch": "x86_64/64/EL"
+}
+++ pvcontrol objects ls
+++ jq -M length
+++ tr -d '\r'
++ echo 'object count: 6'
+object count: 6
++ pvcontrol steps ls
++ jq -M 'map(del(.date))'
++ tr -d '\r'
+[
+  {
+    "name": "0",
+    "commitmsg": "",
+    "progress": {
+      "status": "DONE",
+      "status-msg": "Factory revision",
+      "progress": 100,
+      "retries": 0
+    }
+  }
+]
++ pvcontrol conf ls
++ jq -M
++ tr -d '\r'
+[
+  {
+    "key": "PH_CREDS_HOST",
+    "value": "api.pantahub.com",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_CREDS_ID",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PH_CREDS_PORT",
+    "value": "443",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_CREDS_PROXY_HOST",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PH_CREDS_PROXY_NOPROXYCONNECT",
+    "value": "0",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_CREDS_PROXY_PORT",
+    "value": "3218",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_CREDS_PRN",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PH_CREDS_SECRET",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PH_CREDS_TYPE",
+    "value": "builtin",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_FACTORY_AUTOTOK",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PH_LIBEVENT_HTTP_TIMEOUT",
+    "value": "60",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_LIBEVENT_HTTP_RETRIES",
+    "value": "1",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_METADATA_DEVMETA_INTERVAL",
+    "value": "10",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_METADATA_USRMETA_INTERVAL",
+    "value": "5",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_ONLINE_REQUEST_THRESHOLD",
+    "value": "0",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_UPDATER_INTERVAL",
+    "value": "60",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_UPDATER_NETWORK_TIMEOUT",
+    "value": "120",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PH_UPDATER_TRANSFER_MAX_COUNT",
+    "value": "5",
+    "modified": "ph conf file"
+  },
+  {
+    "key": "PV_BOOTLOADER_FITCONFIG",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_MTD_ENV",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_MTD_ONLY",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_TYPE",
+    "value": "uboot",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_BOOTLOADER_UBOOTAB_A_NAME",
+    "value": "fitA",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_UBOOTAB_B_NAME",
+    "value": "fitB",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_UBOOTAB_ENV_NAME",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_UBOOTAB_ENV_BAK_NAME",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_UBOOTAB_ENV_OFFSET",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_BOOTLOADER_UBOOTAB_ENV_SIZE",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_CACHE_DEVMETADIR",
+    "value": "/var/pantavisor/storage/cache/devmeta",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_CACHE_USRMETADIR",
+    "value": "/var/pantavisor/storage/cache/usrmeta",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_CONTROL_REMOTE",
+    "value": "0",
+    "modified": "env"
+  },
+  {
+    "key": "PV_CONTROL_REMOTE_ALWAYS",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_DEBUG_SHELL",
+    "value": "1",
+    "modified": "default"
+  },
+  {
+    "key": "PV_DEBUG_SHELL_AUTOLOGIN",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_DEBUG_SHELL_TIMEOUT",
+    "value": "60",
+    "modified": "default"
+  },
+  {
+    "key": "PV_DEBUG_SSH",
+    "value": "0",
+    "modified": "env"
+  },
+  {
+    "key": "PV_DEBUG_SSH_AUTHORIZED_KEYS",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_DISK_EXPORTSDIR",
+    "value": "/exports",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_DISK_VOLDIR",
+    "value": "/volumes",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_DISK_WRITABLEDIR",
+    "value": "/var/run/pv/writable",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_DROPBEAR_CACHE_DIR",
+    "value": "/var/pantavisor/storage/cache/dropbear",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_LIBEVENT_DEBUG_MODE",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LIBTHTTP_CERTSDIR",
+    "value": "/etc/thttp/certs",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_LIBTHTTP_LOG_LEVEL",
+    "value": "3",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_CAPTURE",
+    "value": "1",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_CAPTURE_DMESG",
+    "value": "0",
+    "modified": "env"
+  },
+  {
+    "key": "PV_LOG_BUF_NITEMS",
+    "value": "128",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_DIR",
+    "value": "/var/pantavisor/storage/logs",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_LOG_DIR_MAXSIZE",
+    "value": "2147483647",
+    "modified": "env"
+  },
+  {
+    "key": "PV_LOG_FILETREE_TIMESTAMP_FORMAT",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_HYSTERESIS_FACTOR",
+    "value": "4",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_LEVEL",
+    "value": "4",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_LOG_LOGGERS",
+    "value": "1",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_PUSH",
+    "value": "1",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_ROTATE_FACTOR",
+    "value": "5",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_SERVER_OUTPUTS",
+    "value": "196",
+    "modified": "env"
+  },
+  {
+    "key": "PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOG_STDOUT_TIMESTAMP_FORMAT",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LXC_LOG_LEVEL",
+    "value": "2",
+    "modified": "default"
+  },
+  {
+    "key": "PV_NET_BRADDRESS4",
+    "value": "10.0.3.1",
+    "modified": "default"
+  },
+  {
+    "key": "PV_NET_BRDEV",
+    "value": "lxcbr0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_NET_BRMASK4",
+    "value": "255.255.255.0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_OEM_NAME",
+    "value": "pv-oem-developer-001",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_POLICY",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_REVISION_RETRIES",
+    "value": "10",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SECUREBOOT_CHECKSUM",
+    "value": "1",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SECUREBOOT_HANDLERS",
+    "value": "0",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SECUREBOOT_MODE",
+    "value": "disabled",
+    "modified": "env"
+  },
+  {
+    "key": "PV_SECUREBOOT_OEM_TRUSTSTORE",
+    "value": "ca-oem-certificates",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SECUREBOOT_TRUSTSTORE",
+    "value": "ca-certificates",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_DEVICE",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_FSTYPE",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_GC_KEEP_FACTORY",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_GC_RESERVED",
+    "value": "5",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_GC_THRESHOLD_DEFERTIME",
+    "value": "600",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_GC_THRESHOLD",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_LOGTEMPSIZE",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_MNTPOINT",
+    "value": "/var/pantavisor/storage",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_STORAGE_MNTTYPE",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_PHCONFIG_VOL",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_STORAGE_WAIT",
+    "value": "5",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SYSTEM_APPARMOR_PROFILES",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SYSTEM_CONFDIR",
+    "value": "/run/pantavisor/configs",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_DRIVERS_LOAD_EARLY_AUTO",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SYSTEM_ETCDIR",
+    "value": "/etc",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_ETCPANTAVISORDIR",
+    "value": "/etc/pantavisor",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SYSTEM_INIT_MODE",
+    "value": "appengine",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_LIBDIR",
+    "value": "/usr/lib/pantavisor",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_MEDIADIR",
+    "value": "/run/pantavisor/media",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_MOUNT_SECURITYFS",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_SYSTEM_RUNDIR",
+    "value": "/run/pantavisor/pv",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_DISKSDIR",
+    "value": "/run/pantavisor/disks",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_SYSTEM_USRDIR",
+    "value": "/usr",
+    "modified": "pv conf file"
+  },
+  {
+    "key": "PV_UPDATER_COMMIT_DELAY",
+    "value": "5",
+    "modified": "env"
+  },
+  {
+    "key": "PV_UPDATER_GOALS_TIMEOUT",
+    "value": "10",
+    "modified": "env"
+  },
+  {
+    "key": "PV_UPDATER_USE_TMP_OBJECTS",
+    "value": "0",
+    "modified": "default"
+  },
+  {
+    "key": "PV_VOLMOUNT_DM_EXTRA_ARGS",
+    "value": "(null)",
+    "modified": "default"
+  },
+  {
+    "key": "PV_WDT_MODE",
+    "value": "disabled",
+    "modified": "env"
+  },
+  {
+    "key": "PV_WDT_TIMEOUT",
+    "value": "15",
+    "modified": "default"
+  }
+]

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/resources/test
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/resources/test
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+source /usr/share/pantavisor/pvtest/utils
+
+export CURL_CMD=curl
+
+pvcontrol containers ls | jq -M | tr -d '\r'
+pvcontrol groups ls | jq -M | tr -d '\r'
+pvcontrol usrmeta ls | jq -M | tr -d '\r'
+pvcontrol devmeta ls | jq -M 'del(.storage, .interfaces, .sysinfo, .time, .["pantavisor.uname"], .["pantavisor.cpumodel"], .["pantavisor.version"])' | tr -d '\r'
+echo "object count: $(pvcontrol objects ls | jq -M 'length' | tr -d '\r')"
+pvcontrol steps ls | jq -M 'map(del(.date))' | tr -d '\r'
+pvcontrol conf ls | jq -M | tr -d '\r'

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/test.json
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/test.json
@@ -1,0 +1,21 @@
+{
+	"#spec": "pv-test@1",
+	"description": "control socket basic (real curl)",
+	"setup": {
+		"cmdline": "",
+		"env": "PV_CONTROL_REMOTE=0 PV_LOG_CAPTURE_DMESG=0 PV_UPDATER_GOALS_TIMEOUT=10 PV_UPDATER_COMMIT_DELAY=5 PV_SECUREBOOT_MODE=disabled PV_DEBUG_SSH=0 PV_WDT_MODE=disabled PV_LOG_DIR_MAXSIZE=2147483647 CURL_CMD=curl",
+		"pantavisor.config": "",
+		"pvs": "../../common/pvs/*.tar.gz",
+		"containers": {
+			"control": "pvr-sdk",
+			"tarballs": [
+				"../../common/tarballs/bsp.tgz",
+				"../../common/tarballs/pvr-sdk.tgz"
+			],
+			"urls": []
+		},
+		"ready-script": ""
+	},
+	"test-script": "resources/test",
+	"skip": "false"
+}

--- a/recipes-pv/pantavisor-pvtests/files/remote/control/device-user-metadata/output
+++ b/recipes-pv/pantavisor-pvtests/files/remote/control/device-user-metadata/output
@@ -1,0 +1,50 @@
++ USRMETA_KEY=pvtest-usrmeta-key
++ USRMETA_VALUE=pvtest-usrmeta-value
++ DEVMETA_KEY=pvtest-devmeta-key
++ DEVMETA_VALUE=pvtest-devmeta-value
+++ cat /var/run/pantavisor/pv/device-id
++ device_id=6a1566ded89e0d0009860480
++ wait_for_value 'pvcontrol devmeta ls | jq -r '\''."pantahub.state"'\''' idle 120
++ local 'cmd=pvcontrol devmeta ls | jq -r '\''."pantahub.state"'\'''
++ local value=idle
++ local timeout=120
++ local counter=0
++ '[' 0 -lt 120 ']'
+++ eval 'pvcontrol devmeta ls | jq -r '\''."pantahub.state"'\'''
++ local result=idle
++ '[' idle = idle ']'
++ return 0
++ curl -s -X PUT -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODAyMTk1MTcsImlkIjoiYW5pYmFsIiwibmljayI6ImFuaWJhbCIsIm9yaWdfaWF0IjoxNzc5Nzg3NTE3LCJwcm4iOiJwcm46OjphY2NvdW50czovNWJmMWI4NDA0MWIyZGQwMDA5YTg5ZjRhIiwicm9sZXMiOiJ1c2VyIiwic2NvcGVzIjoicHJuOnBhbnRhaHViLmNvbTphcGlzOi9iYXNlL2FsbCIsInR5cGUiOiJVU0VSIn0.ThfH_QuTAaW8a6dpIbr6s8CcDxX23mQumwMxt4od6DpEivp4GbxxlQwtbCZATC08AZzdoF9Ww4Zv03plqICl795XBo5XP1AW4oOr_VluWhSHaWGBcHxXDpReS68fk4ESmTAkC-h16WxtzF92j73D5SZ9eI_L_J8icIwKDy7MURSyFpz6vT0wUGkWv0SfqJut9yPlG8gu2Edo9P-Ij46C4sQVPb98zrTMJNHzosoGzP3rfg9i7ZILnARV-Nx3wMAUTinO91T8Uo3gQ6g8qZ5J31KOYeTLa7zKEerUSAiYYzCltgkiaJyvOMA-hTlN04tI5To-J2d0YIFBdKYXbLj-7Q' -H 'Content-Type: application/json' -d '{"pvtest-usrmeta-key": "pvtest-usrmeta-value"}' https://api.pantahub.com/devices/6a1566ded89e0d0009860480/user-meta
++ pvcontrol devmeta save pvtest-devmeta-key pvtest-devmeta-value
+
++ i=0
++ hub_devmeta=
++ '[' 0 -lt 3 ']'
+++ curl -s -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODAyMTk1MTcsImlkIjoiYW5pYmFsIiwibmljayI6ImFuaWJhbCIsIm9yaWdfaWF0IjoxNzc5Nzg3NTE3LCJwcm4iOiJwcm46OjphY2NvdW50czovNWJmMWI4NDA0MWIyZGQwMDA5YTg5ZjRhIiwicm9sZXMiOiJ1c2VyIiwic2NvcGVzIjoicHJuOnBhbnRhaHViLmNvbTphcGlzOi9iYXNlL2FsbCIsInR5cGUiOiJVU0VSIn0.ThfH_QuTAaW8a6dpIbr6s8CcDxX23mQumwMxt4od6DpEivp4GbxxlQwtbCZATC08AZzdoF9Ww4Zv03plqICl795XBo5XP1AW4oOr_VluWhSHaWGBcHxXDpReS68fk4ESmTAkC-h16WxtzF92j73D5SZ9eI_L_J8icIwKDy7MURSyFpz6vT0wUGkWv0SfqJut9yPlG8gu2Edo9P-Ij46C4sQVPb98zrTMJNHzosoGzP3rfg9i7ZILnARV-Nx3wMAUTinO91T8Uo3gQ6g8qZ5J31KOYeTLa7zKEerUSAiYYzCltgkiaJyvOMA-hTlN04tI5To-J2d0YIFBdKYXbLj-7Q' https://api.pantahub.com/devices/6a1566ded89e0d0009860480
+++ jq -r '."device-meta"."pvtest-devmeta-key"'
++ hub_devmeta=null
++ '[' null = pvtest-devmeta-value ']'
++ sleep 10
++ i=1
++ '[' 1 -lt 3 ']'
+++ curl -s -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODAyMTk1MTcsImlkIjoiYW5pYmFsIiwibmljayI6ImFuaWJhbCIsIm9yaWdfaWF0IjoxNzc5Nzg3NTE3LCJwcm4iOiJwcm46OjphY2NvdW50czovNWJmMWI4NDA0MWIyZGQwMDA5YTg5ZjRhIiwicm9sZXMiOiJ1c2VyIiwic2NvcGVzIjoicHJuOnBhbnRhaHViLmNvbTphcGlzOi9iYXNlL2FsbCIsInR5cGUiOiJVU0VSIn0.ThfH_QuTAaW8a6dpIbr6s8CcDxX23mQumwMxt4od6DpEivp4GbxxlQwtbCZATC08AZzdoF9Ww4Zv03plqICl795XBo5XP1AW4oOr_VluWhSHaWGBcHxXDpReS68fk4ESmTAkC-h16WxtzF92j73D5SZ9eI_L_J8icIwKDy7MURSyFpz6vT0wUGkWv0SfqJut9yPlG8gu2Edo9P-Ij46C4sQVPb98zrTMJNHzosoGzP3rfg9i7ZILnARV-Nx3wMAUTinO91T8Uo3gQ6g8qZ5J31KOYeTLa7zKEerUSAiYYzCltgkiaJyvOMA-hTlN04tI5To-J2d0YIFBdKYXbLj-7Q' https://api.pantahub.com/devices/6a1566ded89e0d0009860480
+++ jq -r '."device-meta"."pvtest-devmeta-key"'
++ hub_devmeta=pvtest-devmeta-value
++ '[' pvtest-devmeta-value = pvtest-devmeta-value ']'
++ break
++ '[' pvtest-devmeta-value '!=' pvtest-devmeta-value ']'
++ i=0
++ local_usrmeta=
++ '[' 0 -lt 3 ']'
+++ pvcontrol usrmeta ls
+++ jq -r '."pvtest-usrmeta-key"'
++ local_usrmeta=pvtest-usrmeta-value
++ '[' pvtest-usrmeta-value = pvtest-usrmeta-value ']'
++ break
++ '[' pvtest-usrmeta-value '!=' pvtest-usrmeta-value ']'
++ pvcontrol usrmeta ls
++ jq -r '."pvtest-usrmeta-key"'
+pvtest-usrmeta-value
++ curl -s -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODAyMTk1MTcsImlkIjoiYW5pYmFsIiwibmljayI6ImFuaWJhbCIsIm9yaWdfaWF0IjoxNzc5Nzg3NTE3LCJwcm4iOiJwcm46OjphY2NvdW50czovNWJmMWI4NDA0MWIyZGQwMDA5YTg5ZjRhIiwicm9sZXMiOiJ1c2VyIiwic2NvcGVzIjoicHJuOnBhbnRhaHViLmNvbTphcGlzOi9iYXNlL2FsbCIsInR5cGUiOiJVU0VSIn0.ThfH_QuTAaW8a6dpIbr6s8CcDxX23mQumwMxt4od6DpEivp4GbxxlQwtbCZATC08AZzdoF9Ww4Zv03plqICl795XBo5XP1AW4oOr_VluWhSHaWGBcHxXDpReS68fk4ESmTAkC-h16WxtzF92j73D5SZ9eI_L_J8icIwKDy7MURSyFpz6vT0wUGkWv0SfqJut9yPlG8gu2Edo9P-Ij46C4sQVPb98zrTMJNHzosoGzP3rfg9i7ZILnARV-Nx3wMAUTinO91T8Uo3gQ6g8qZ5J31KOYeTLa7zKEerUSAiYYzCltgkiaJyvOMA-hTlN04tI5To-J2d0YIFBdKYXbLj-7Q' https://api.pantahub.com/devices/6a1566ded89e0d0009860480
++ jq -r '."device-meta"."pvtest-devmeta-key"'
+pvtest-devmeta-value

--- a/recipes-pv/pantavisor-pvtests/files/remote/control/device-user-metadata/resources/test
+++ b/recipes-pv/pantavisor-pvtests/files/remote/control/device-user-metadata/resources/test
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+source /usr/share/pantavisor/pvtest/utils
+PVR_USERNAME="$PH_USER" PVR_PASSWORD="$PH_PASS" pvr login > /dev/null 2>&1
+
+USRMETA_KEY="pvtest-usrmeta-key"
+USRMETA_VALUE="pvtest-usrmeta-value"
+DEVMETA_KEY="pvtest-devmeta-key"
+DEVMETA_VALUE="pvtest-devmeta-value"
+
+device_id=$(cat /var/run/pantavisor/pv/device-id)
+{ set +x; } 2>/dev/null
+bearer=$(cat "$HOME/.pvr/auth.json" 2>/dev/null | jq -r 'first(.tokens[]) | .["access-token"] // empty')
+{ set -x; } 2>/dev/null
+
+# 1. Wait for device to be claimed and idle
+wait_for_value "pvcontrol devmeta ls | jq -r '.\"pantahub.state\"'" "idle" 120 \
+    || { echo "ERROR: timeout waiting for pantahub.state idle" >&2; exit 1; }
+
+# 2. Save both (before waiting so sync can run in parallel)
+# 2a. User-meta: cloud → device (via Hub API)
+curl -s -X PUT \
+    -H "Authorization: Bearer $bearer" \
+    -H "Content-Type: application/json" \
+    -d "{\"$USRMETA_KEY\": \"$USRMETA_VALUE\"}" \
+    "https://api.pantahub.com/devices/$device_id/user-meta" > /dev/null
+# 2b. Dev-meta: device → cloud (via pvcontrol — output intentionally NOT suppressed)
+pvcontrol devmeta save "$DEVMETA_KEY" "$DEVMETA_VALUE"
+
+# 3. Poll Hub for dev-meta (max 3 × DEVMETA_INTERVAL)
+i=0
+hub_devmeta=""
+while [ $i -lt 3 ]; do
+    hub_devmeta=$(curl -s \
+        -H "Authorization: Bearer $bearer" \
+        "https://api.pantahub.com/devices/$device_id" | \
+        jq -r ".\"device-meta\".\"$DEVMETA_KEY\"")
+    [ "$hub_devmeta" = "$DEVMETA_VALUE" ] && break
+    sleep "${PH_METADATA_DEVMETA_INTERVAL:-10}"
+    i=$((i + 1))
+done
+[ "$hub_devmeta" != "$DEVMETA_VALUE" ] \
+    && { echo "ERROR: timeout waiting for dev-meta at Hub" >&2; exit 1; }
+
+# 4. Poll device for user-meta (max 3 × USRMETA_INTERVAL)
+i=0
+local_usrmeta=""
+while [ $i -lt 3 ]; do
+    local_usrmeta=$(pvcontrol usrmeta ls | jq -r ".\"$USRMETA_KEY\"")
+    [ "$local_usrmeta" = "$USRMETA_VALUE" ] && break
+    sleep "${PH_METADATA_USRMETA_INTERVAL:-10}"
+    i=$((i + 1))
+done
+[ "$local_usrmeta" != "$USRMETA_VALUE" ] \
+    && { echo "ERROR: timeout waiting for user-meta at device" >&2; exit 1; }
+
+# 5. Print verified values
+pvcontrol usrmeta ls | jq -r ".\"$USRMETA_KEY\""
+curl -s \
+    -H "Authorization: Bearer $bearer" \
+    "https://api.pantahub.com/devices/$device_id" | \
+    jq -r ".\"device-meta\".\"$DEVMETA_KEY\""

--- a/recipes-pv/pantavisor-pvtests/files/remote/control/device-user-metadata/test.json
+++ b/recipes-pv/pantavisor-pvtests/files/remote/control/device-user-metadata/test.json
@@ -1,0 +1,22 @@
+{
+	"#spec": "pv-test@1",
+	"description": "device/user metadata exchange with Pantahub",
+	"setup": {
+		"cmdline": "",
+		"env": "PV_CONTROL_REMOTE=1 PV_LOG_CAPTURE_DMESG=0 PV_STORAGE_PHCONFIG_VOL=1 PV_UPDATER_GOALS_TIMEOUT=10 PV_UPDATER_COMMIT_DELAY=5 PV_SECUREBOOT_MODE=disabled PH_METADATA_DEVMETA_INTERVAL=10 PH_METADATA_USRMETA_INTERVAL=10 PH_UPDATER_INTERVAL=5 PV_WDT_MODE=disabled PV_DEBUG_SSH=0 PV_LOG_DIR_MAXSIZE=2147483647",
+		"pantavisor.config": "",
+		"pvs": "",
+		"containers": {
+			"control": "pvr-sdk",
+			"tarballs": [
+				"../../common/tarballs/bsp.tgz",
+				"../../common/tarballs/pvr-sdk.tgz"
+			],
+			"urls": []
+		},
+		"ready-script": "",
+		"self-claim": "true"
+	},
+	"test-script": "resources/test",
+	"skip": "false"
+}


### PR DESCRIPTION
## Summary

Adds two pvtests for control socket and metadata operations:

**1. `local/control/basic-endpoints-curl`**
- Tests basic pv-ctrl endpoints via `pvcontrol` with `CURL_CMD=curl` to exercise the curl backend
- Covers: containers, groups, user-meta, device-meta, objects, steps, conf
- `export CURL_CMD=curl` in the test script forces pvcontrol's curl path, maintaining coverage of that backend now that pvcontrol defaults to pvcurl (pantavisor #721)

**2. `remote/control/device-user-metadata`**
- Verifies bidirectional metadata sync between device and Pantahub
- User-meta: set via Hub API (`PUT /devices/{id}/user-meta`) → polled on device via `pvcontrol usrmeta ls`
- Dev-meta: set via `pvcontrol devmeta save` → polled at Hub via API
- Both directions polled every `PH_METADATA_{DEV,USR}META_INTERVAL` seconds, up to 3× before timeout
- Bearer token hidden from `set -x` trace to prevent JWT leaks in output file
- Device cleanup handled by framework (`self-claim: true`)

## Notes

`device-user-metadata` exercises the full metadata sync flow via pvcontrol using pvcurl (the new default after pantavisor #721). `basic-endpoints-curl` maintains curl-backend coverage by explicitly exporting `CURL_CMD=curl`.

## Test plan

- [x] Run `local/control/basic-endpoints-curl` and `remote/control/device-user-metadata` against pantavisor `fix/ctrl-evbuffer-double-content-type`
- [x] Capture output with `-o` and commit as reference