### PR TITLE
ci(workflow): upgrade gh CLI inside docker container

### DIFF
--- a/.github/workflows/schedule-updatemachines.yaml
+++ b/.github/workflows/schedule-updatemachines.yaml
@@ -23,6 +23,9 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v6
+      - name: Install latest GitHub CLI
+        run: |
+          curl -sSL https://github.com/cli/cli/releases/download/v2.49.2/gh_2.49.2_linux_amd64.tar.gz | tar -xz -C /usr/bin --strip-components=2 gh_2.49.2_linux_amd64/bin/gh
       - run: ls .github/scripts
       - run: pwd
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE


### PR DESCRIPTION
Updates schedule-updatemachines.yaml to pull a newer version of gh CLI in the runner container to resolve the deprecated GraphQL projectCards error