### PR TITLE
fix(imx): add dm-versatile alias to caam/dcp disk overrides

### DIFF
--- a/recipes-pv/pantavisor/files/pv-imx-caam/device-disks.json
+++ b/recipes-pv/pantavisor/files/pv-imx-caam/device-disks.json
@@ -4,7 +4,8 @@
             "name": "dm-internal-secrets",
             "path": "-v2 /storage/dm-crypt-files/dm-internal-secrets-nxp/caam.img,2,caam_nxpkey-internal_secrets",
             "type": "dm-crypt-caam",
-            "mode": "nxp"
+            "mode": "nxp",
+            "aliases": ["dm-versatile"]
         }
     ]
 }

--- a/recipes-pv/pantavisor/files/pv-imx-dcp/device-disks.json
+++ b/recipes-pv/pantavisor/files/pv-imx-dcp/device-disks.json
@@ -5,7 +5,8 @@
             "path": "/storage/dm-crypt-files/dm-internal-secrets-nxp/dcp.img,2,dcp_key-internal_secrets",
             "migrate_keyblob": "no",
             "mode": "nxp",
-            "type": "dm-crypt-dcp"
+            "type": "dm-crypt-dcp",
+            "aliases": ["dm-versatile"]
         }
     ]
 }


### PR DESCRIPTION
## Problem

On imx8m/imx6 SoCs, boot fails with:

```
volume 'docker--var-dmcrypt-volume' requires disk 'dm-versatile' which was not found
```

The container can't start, triggering a rollback.

## Root cause

pvr-sdk's `docker--var-dmcrypt-volume` resolves against `permanent@dm-versatile`. The standard skel `device.json` defines `dm-internal-secrets` with `"aliases": ["dm-versatile"]`, but the two imx disk-override fragments (`pv-imx-caam`, `pv-imx-dcp`) never carried that alias.

`recipes-pv/pantavisor/merge-device-json.py` does `base["disks"] = fragment["disks"]` — a **wholesale replacement**, not a merge. So on every imx device the base alias was silently dropped, leaving `dm-versatile` unresolved.

## Fix

Add `"aliases": ["dm-versatile"]` to the single disk object in both imx overrides:

- `recipes-pv/pantavisor/files/pv-imx-caam/device-disks.json`
- `recipes-pv/pantavisor/files/pv-imx-dcp/device-disks.json`

Two-line addition, no other changes.