### PR TITLE
fix(pv-example-norole): create /tmp in rootfs

### DIFF
--- a/recipes-containers/pv-examples/pv-example-norole.bb
+++ b/recipes-containers/pv-examples/pv-example-norole.bb
@@ -22,6 +22,7 @@ SRC_URI += "file://pv-app.sh"
 install_scripts() {
     install -d ${IMAGE_ROOTFS}${bindir}
     install -m 0755 ${WORKDIR}/pv-app.sh ${IMAGE_ROOTFS}${bindir}/pv-app
+    install -d -m 1777 ${IMAGE_ROOTFS}/tmp
 }
 
 ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "


### PR DESCRIPTION
## Summary
- pvcurl writes to /tmp/http_req; the norole container had no /tmp, causing pvcontrol to fail with "can't create /tmp/http_req: nonexistent directory"
- Regression introduced by pantavisor bde4e29, which made pvcontrol prefer pvcurl over curl by default

## Changes
- Add `install -d -m 1777 ${IMAGE_ROOTFS}/tmp` to the rootfs post-process step in pv-example-norole.bb