### PR TITLE
feat(device-json): add pv--firmware boot volume as default

### DIFF
--- a/recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/bananapi-m2-berry/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     },
     "network": {

--- a/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     },
     "network": {

--- a/recipes-pv/pantavisor/files/docker-x86_64/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/docker-x86_64/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     }
 }

--- a/recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/orange-pi-3lts/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     },
     "network": {

--- a/recipes-pv/pantavisor/files/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     },
     "network": {

--- a/recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/raspberrypi-armv8/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     },
     "network": {

--- a/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/rpi/pantavisor-default-skel/device.json
@@ -57,6 +57,9 @@
         "pv--phconfig": {
             "disk": "dm-internal-secrets",
             "persistence": "permanent"
+        },
+        "pv--firmware": {
+            "persistence": "boot"
         }
     },
     "network": {


### PR DESCRIPTION
## Summary

Adds a `pv--firmware` BSP volume to **all** `pantavisor-default-skel/device.json` files, making a default firmware drop-zone available on every machine.

- **Persistence:** `boot` (reset each boot)
- **Disk:** none — plain volume, no special/encrypted storage

This is the meta-pantavisor counterpart to [pantavisor#715](https://github.com/pantavisor/pantavisor/pull/715), which introduces the `PV_STORAGE_FIRMWARE_VOL` flag. When that flag is enabled, pantavisor writes the resolved mount-point of `pv--firmware` into `/sys/module/firmware_class/parameters/path`, so the kernel firmware loader searches it before falling back to `/lib/firmware`. This lets management containers deploy board-specific firmware (NVRAM, calibration data) without modifying the rootfs.

## Files changed

All 7 skel device.json files:
- pantavisor-default-skel
- rpi
- colibri-imx6ull
- raspberrypi-armv8
- docker-x86_64
- bananapi-m2-berry
- orange-pi-3lts

```json
"pv--firmware": {
    "persistence": "boot"
}
```

## Notes

Following the existing convention, only the volume declaration lives here — the enabling `PV_STORAGE_FIRMWARE_VOL` flag is part of pantavisor itself (pantavisor#715), just as `pv--phconfig` is declared here without an explicit config flag in this layer.

## Test plan

- [x] Build orange-pi-3lts release (`with-workspace`, pantavisor on pantavisor#715) and confirm the `pv--firmware` volume appears in the generated BSP `device.json`.
- [x] Deploy OTA via pvr to a real device (orange-pi-3lts, opi3_hyena, rev 167) and confirm a clean, **stable boot, no rollback**.
- [x] On device: `cat /sys/module/firmware_class/parameters/path` → `/volumes/bsp/pv--firmware`.
- [x] On device: `pv--firmware` mounted **tmpfs (rw)** at `/volumes/bsp/pv--firmware` (matches `persistence: boot`); writable confirmed; `/lib/firmware` unchanged as ro squashfs fallback.

> Note: the deployed default skel `device.json` is a strict superset of the device's prior one — the change is purely additive (`pv--firmware`, plus a `network.pools.pvcnet` block and a `dm-versatile` disk alias the older on-device json lacked). The pvcnet pool matches the running default (`lxcbr0` / `10.0.3.1`), so no networking behaviour changed.

Refs: pantavisor#715
