### PR TITLE
ci: skip builds for draft PRs + fix pvtest firmware-vol output

### DIFF
--- a/.github/scripts/make-onpush-matrix.py
+++ b/.github/scripts/make-onpush-matrix.py
@@ -45,15 +45,29 @@ if pvtest_machines:
 
 lines += [
     f"      - '.github/workflows/onpush-{branch}.yaml'",
-    "  # NOTE: no 'pull_request:' trigger. Pushes to same-repo branches",
-    "  # already emit check runs bound to the head SHA, so PRs show",
-    "  # those results in their checks tab without a duplicate run.",
-    "  # Fork PRs intentionally do NOT trigger CI on our self-hosted",
-    "  # runners — a maintainer must push the branch into this repo",
-    "  # to get a build.",
+    "  pull_request:",
+    "    types: [ready_for_review]",
+    "",
+    "concurrency:",
+    "  group: ${{ github.workflow }}-${{ github.ref }}",
+    "  cancel-in-progress: true",
     "",
     "jobs:",
+    "  check-draft:",
+    "    runs-on: ubuntu-latest",
+    "    outputs:",
+    "      is_draft: ${{ steps.check.outputs.is_draft }}",
+    "    steps:",
+    "      - id: check",
+    "        env:",
+    "          GH_TOKEN: ${{ github.token }}",
+    "        run: |",
+    "          draft=$(gh pr list --repo ${{ github.repository }} --head ${{ github.ref_name }} --json isDraft --jq '.[0].isDraft // false')",
+    '          echo "is_draft=$draft" >> $GITHUB_OUTPUT',
+    "",
     "  build-hw:",
+    "    needs: check-draft",
+    "    if: needs.check-draft.outputs.is_draft != 'true'",
     '    name: "build (${{ matrix.machine_name }})"',
     "    strategy:",
     "      fail-fast: false",
@@ -99,6 +113,8 @@ for m in pvtest_machines:
     lines += [
         "",
         f"  {job_id}:",
+        "    needs: check-draft",
+        "    if: needs.check-draft.outputs.is_draft != 'true'",
         f'    name: "build ({name}-{branch})"',
         "    uses: ./.github/workflows/buildkas-target.yaml",
         "    with:",
@@ -123,11 +139,8 @@ for m in pvtest_machines:
         ]
 
 all_build_job_ids = ["build-hw"] + pvtest_build_job_ids
-needs_str = (
-    all_build_job_ids[0]
-    if len(all_build_job_ids) == 1
-    else f"[{', '.join(all_build_job_ids)}]"
-)
+summary_needs = ["check-draft"] + all_build_job_ids
+needs_str = f"[{', '.join(summary_needs)}]"
 
 lines += [
     "",

--- a/.github/workflows/onpush-scarthgap.yaml
+++ b/.github/workflows/onpush-scarthgap.yaml
@@ -21,15 +21,29 @@ on:
       - '.github/workflows/buildkas-target.yaml'
       - '.github/workflows/call-pvtests.yaml'
       - '.github/workflows/onpush-scarthgap.yaml'
-  # NOTE: no 'pull_request:' trigger. Pushes to same-repo branches
-  # already emit check runs bound to the head SHA, so PRs show
-  # those results in their checks tab without a duplicate run.
-  # Fork PRs intentionally do NOT trigger CI on our self-hosted
-  # runners — a maintainer must push the branch into this repo
-  # to get a build.
+  pull_request:
+    types: [ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  check-draft:
+    runs-on: ubuntu-latest
+    outputs:
+      is_draft: ${{ steps.check.outputs.is_draft }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          draft=$(gh pr list --repo ${{ github.repository }} --head ${{ github.ref_name }} --json isDraft --jq '.[0].isDraft // false')
+          echo "is_draft=$draft" >> $GITHUB_OUTPUT
+
   build-hw:
+    needs: check-draft
+    if: needs.check-draft.outputs.is_draft != 'true'
     name: "build (${{ matrix.machine_name }})"
     strategy:
       fail-fast: false
@@ -55,6 +69,8 @@ jobs:
     secrets: inherit
 
   build-docker:
+    needs: check-draft
+    if: needs.check-draft.outputs.is_draft != 'true'
     name: "build (docker-x86_64-scarthgap)"
     uses: ./.github/workflows/buildkas-target.yaml
     with:
@@ -73,7 +89,7 @@ jobs:
     secrets: inherit
 
   summary:
-    needs: [build-hw, build-docker]
+    needs: [check-draft, build-hw, build-docker]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ PANTAVISOR_FEATURES:append = " appengine"
 
 ## Development Guidelines
 
+- **Pull requests**: Always open as drafts (`gh pr create --draft`); promote to ready only when CI passes and the branch is review-ready.
 - **Commits**: Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) v1.0.0
 - **Kconfig changes**: Run `.github/scripts/makemachines` after modifying Kconfig
 - **Storage state**: Use fresh storage volumes when testing pvtx.d changes (`docker volume rm storage-test`)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -48,6 +48,7 @@ PANTAVISOR_FEATURES:append = " appengine"
 
 ## Development Guidelines
 
+- **Pull requests**: Always open as drafts (`gh pr create --draft`); promote to ready only when CI passes and the branch is review-ready.
 - **Commits**: Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) v1.0.0
 - **Kconfig changes**: Run `.github/scripts/makemachines` after modifying Kconfig
 - **Storage state**: Use fresh storage volumes when testing pvtx.d changes (`docker volume rm storage-test`)

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
@@ -484,6 +484,11 @@ object count: 6
     "modified": "default"
   },
   {
+    "key": "PV_STORAGE_FIRMWARE_VOL",
+    "value": "0",
+    "modified": "default"
+  },
+  {
     "key": "PV_STORAGE_PHCONFIG_VOL",
     "value": "0",
     "modified": "default"

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
@@ -476,6 +476,11 @@ object count: 6
     "modified": "default"
   },
   {
+    "key": "PV_STORAGE_FIRMWARE_VOL",
+    "value": "0",
+    "modified": "default"
+  },
+  {
     "key": "PV_STORAGE_PHCONFIG_VOL",
     "value": "0",
     "modified": "default"


### PR DESCRIPTION
## Summary

- Add `pull_request: types: [ready_for_review]` trigger so CI reruns automatically when a draft PR is promoted to ready
- Add `check-draft` job: build/pvtest jobs skip when PR is still draft, so pushes during development don't burn runner time
- Add concurrency group to cancel superseded push runs
- Fix `basic-endpoints` / `basic-endpoints-curl` expected output to include `PV_STORAGE_FIRMWARE_VOL` added in pantavisor@04aecad
- Document the always-draft PR convention in CLAUDE.md and GEMINI.md

## Changes

- `.github/scripts/make-onpush-matrix.py`: pull_request trigger, concurrency group, check-draft job, if: conditions on build/pvtest jobs
- `.github/workflows/onpush-scarthgap.yaml`: regenerated from updated script
- `recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints{,-curl}/output`: insert `PV_STORAGE_FIRMWARE_VOL` entry before `PV_STORAGE_PHCONFIG_VOL`
- `CLAUDE.md`, `GEMINI.md`: add always-draft PR guideline
