### PR TITLE
docs(testplan): xconnect rest + lifecycle checks; app-group example pairs

### DIFF
--- a/docs/testing/testplans/testplan-xconnect.md
+++ b/docs/testing/testplans/testplan-xconnect.md
@@ -11,10 +11,15 @@ For pv-ctrl API tests (daemons, graph, metadata, objects, etc.), see [testplan-p
 ### Build Appengine Image
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
 
 docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
 ```
+
+> To test local pantavisor changes, build with the `:kas/with-workspace.yaml`
+> overlay. `externalsrc` does not change task signatures, so force a fresh
+> compile or sstate may serve a stale binary:
+> `./kas-container shell <cfg>:kas/with-workspace.yaml -c "bitbake -c cleansstate pantavisor && bitbake pantavisor-appengine-distro"`
 
 ### Common Setup
 
@@ -40,7 +45,7 @@ docker volume rm storage-test
 ### Setup
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-unix-server \
     --target pv-example-unix-client
 
@@ -97,7 +102,7 @@ docker exec pva-test ls -la /proc/$CLIENT_PID/root/run/pv/services/
 ### Setup
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-dbus-server \
     --target pv-example-dbus-client
 
@@ -146,11 +151,53 @@ docker exec pva-test cat /var/pantavisor/storage/logs/0/pv-example-dbus-client/l
 
 ---
 
-## Test 3: DRM Device Injection
+## Test 3: REST Service Mesh
+
+**Purpose**: Verify pv-xconnect proxies HTTP-over-Unix-socket between consumer and provider.
+
+### Setup
+
+```bash
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
+    --target pv-example-rest-server \
+    --target pv-example-rest-client
+
+rm -f pvtx.d/*.pvrexport.tgz
+cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-rest-server.pvrexport.tgz pvtx.d/
+cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-rest-client.pvrexport.tgz pvtx.d/
+```
+
+### Execute
+
+Same as Test 1 (run `pva-test`, start `pv-appengine`, wait).
+
+### Verify
+
+```bash
+docker exec pva-test pvcontrol graph ls
+# Expected: type=rest link (service network-manager)
+
+docker exec pva-test cat /var/pantavisor/storage/logs/0/pv-example-rest-client/lxc/console.log | tail -10
+# Expected: JSON response body from the network-manager service
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Server / Client status | RUNNING |
+| xconnect graph | Shows rest link |
+| REST call | Client logs show provider's JSON response |
+
+---
+
+## Test 4: DRM Device Injection
 
 **Purpose**: Verify pv-xconnect injects DRM device nodes into consumer containers.
 
-**Note**: Requires VKMS kernel module or real GPU hardware.
+**Note**: Requires VKMS kernel module or real GPU hardware. The `wayland`
+plugin shares this teardown path; its example additionally requires a
+`drm-master` provider, so deploy the DRM pair alongside it.
 
 ### Setup
 
@@ -158,7 +205,7 @@ docker exec pva-test cat /var/pantavisor/storage/logs/0/pv-example-dbus-client/l
 # Load VKMS on host (if no real GPU)
 sudo modprobe vkms
 
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-drm-provider \
     --target pv-example-drm-master
 
@@ -204,6 +251,57 @@ docker exec pva-test ls -la /proc/$MASTER_PID/root/dev/dri/
 
 ---
 
+## Proxy Lifecycle Checks (unix / rest / dbus / wayland)
+
+The stream proxies share one teardown path. These checks guard it against
+two regressions: an fd leak when a provider holds its connection open after
+the consumer leaves, and a truncated response when a client half-closes its
+write side and then reads. Run against a live rest mesh (Test 3).
+
+```bash
+# Reach a consumer's injected socket from the host via /proc/<pid>/root
+RPID=$(docker exec pva-test lxc-info -n pv-example-rest-client -p | awk '{print $2}')
+SOCK=/proc/$RPID/root/run/pv/services/network-manager.sock
+XPID=$(docker exec pva-test sh -c 'for p in /proc/[0-9]*; do
+  grep -qa pv-xconnect "$p/cmdline" 2>/dev/null && { echo ${p##*/}; break; }; done')
+```
+
+**Normal request/response** — full body:
+```bash
+docker exec pva-test sh -c "printf 'GET /info HTTP/1.0\r\n\r\n' | nc -U $SOCK"
+# Expected: HTTP/1.0 200 OK + JSON body
+```
+
+**Half-close** (`nc -N` shuts the write side then reads) — must still return
+the full body:
+```bash
+docker exec pva-test sh -c "printf 'GET /info HTTP/1.0\r\n\r\n' | nc -N -U $SOCK"
+# Expected: same full body. Empty output = the proxy tore the response path
+# down on the client's EOF (regression; this is what pvcurl POST uses).
+```
+
+**No fd leak** — xconnect fds stay bounded under repeated connects:
+```bash
+docker exec pva-test sh -c "
+  base=\$(ls /proc/$XPID/fd | wc -l); n=0
+  while [ \$n -lt 100 ]; do n=\$((n+1))
+    printf 'GET /info HTTP/1.0\r\n\r\n' | nc -N -U $SOCK >/dev/null 2>&1
+  done
+  echo \"fds: \$base -> \$(ls /proc/$XPID/fd | wc -l)\""
+# Expected: end count near base, not base + 100. (A half-open session whose
+# provider never closes is reclaimed after an inactivity linger, ~60s.)
+```
+
+### Expected Results
+
+| Check | Expected |
+|-------|----------|
+| Normal request | Full HTTP response body |
+| Half-close request | Same full body (not empty) |
+| fd count after 100 connects | Bounded near baseline, not climbing |
+
+---
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -212,3 +310,4 @@ docker exec pva-test ls -la /proc/$MASTER_PID/root/dev/dri/
 | Container not starting | Check pantavisor.log | `docker exec pva-test cat /var/pantavisor/storage/logs/0/pantavisor/pantavisor.log` |
 | xconnect-graph empty | pv-xconnect not running | `docker exec pva-test pvcontrol daemons ls` |
 | Socket not injected | Provider not ready | Wait longer, check provider status |
+| pantavisor restart loop | A platform's required service is missing (e.g. wayland needs `drm-master`) | Deploy the required provider, or omit that example |

--- a/recipes-containers/pv-examples/pv-example-dbus-client-nobody_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-dbus-client-nobody_1.0.bb
@@ -5,6 +5,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-dbus-client-nobody"
+
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
 PVRIMAGE_AUTO_MDEV = "0"
 
 RDEPENDS:${PN} += "dbus"

--- a/recipes-containers/pv-examples/pv-example-dbus-client_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-dbus-client_1.0.bb
@@ -6,6 +6,10 @@ inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-dbus-client"
 
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
+
 PVRIMAGE_AUTO_MDEV = "0"
 
 

--- a/recipes-containers/pv-examples/pv-example-dbus-server_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-dbus-server_1.0.bb
@@ -6,6 +6,10 @@ inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-dbus-server"
 
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
+
 PVRIMAGE_AUTO_MDEV = "0"
 
 

--- a/recipes-containers/pv-examples/pv-example-rest-client_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-rest-client_1.0.bb
@@ -5,6 +5,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-rest-client"
+
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
 PVRIMAGE_AUTO_MDEV = "0"
 
 RDEPENDS:${PN} += "curl"

--- a/recipes-containers/pv-examples/pv-example-rest-server_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-rest-server_1.0.bb
@@ -5,6 +5,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-rest-server"
+
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
 PVRIMAGE_AUTO_MDEV = "0"
 
 IMAGE_INSTALL += "python3-core python3-netserver python3-json busybox"

--- a/recipes-containers/pv-examples/pv-example-unix-client_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-unix-client_1.0.bb
@@ -6,6 +6,10 @@ inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-unix-client"
 
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
+
 PVRIMAGE_AUTO_MDEV = "0"
 
 IMAGE_INSTALL += "socat busybox"

--- a/recipes-containers/pv-examples/pv-example-unix-server_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-unix-server_1.0.bb
@@ -6,6 +6,10 @@ inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-unix-server"
 
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
+
 PVRIMAGE_AUTO_MDEV = "0"
 
 IMAGE_INSTALL += "socat busybox"

--- a/recipes-containers/pv-examples/pv-example-wayland-client_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-wayland-client_1.0.bb
@@ -5,6 +5,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-wayland-client"
+
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
 PVRIMAGE_AUTO_MDEV = "0"
 
 RDEPENDS:${PN} += "wayland-utils"

--- a/recipes-containers/pv-examples/pv-example-wayland-server_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-wayland-server_1.0.bb
@@ -5,6 +5,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 inherit core-image container-pvrexport
 
 IMAGE_BASENAME = "pv-example-wayland-server"
+
+# Place xconnect example client/server in the app group so they are
+# lifecycle-controllable (container restart policy, stop/start via API).
+PVR_APP_ADD_GROUP = "app"
 PVRIMAGE_AUTO_MDEV = "0"
 
 RDEPENDS:${PN} += "weston"


### PR DESCRIPTION
## What
- Add a **REST service-mesh** test and a **Proxy Lifecycle Checks** section (normal / half-close / fd-leak probes) to the xconnect testplan.
- Fix the dead config path `.github/configs/release/` → `kas/build-configs/release/`.
- Place the xconnect example client/server pairs (unix/rest/dbus/wayland) in the **app** group via `PVR_APP_ADD_GROUP = "app"`.

## Why the app-group change
The lifecycle checks need to stop/start the example containers. System-group containers (root/platform) **reboot the device** on stop/kill and can't be driven via the lifecycle API, so proxy teardown/restart paths were untestable. App-group placement (container restart policy) makes them controllable — and surfaced a real link re-establishment bug now fixed in pantavisor#731.

## Test
Built the pairs for armhf and deployed to a live Raspberry Pi 5; the lifecycle checks exercise stop/start of each peer and confirm the proxy recovers with bounded fds.
