### PR TITLE
fix(ci): make docs release publishing resilient to tag re-push and fix secret name

### DIFF
--- a/.github/scripts/upload-docs.py
+++ b/.github/scripts/upload-docs.py
@@ -18,10 +18,11 @@ Commands:
       artifact_url — public download URL of the .docs.tar.zst file
       filename     — e.g. pantavisor-starter-raspberrypi-armv8.abc1234+v23.docs.tar.zst
       token        — GitHub token with actions:write on pantavisor/docs.pantavisor
-                     (PANTAVISOR_DOC_SYNC secret)
+                     (PANTAVISOR_DOCS_SYNC secret)
 """
 import sys
 import json
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -42,12 +43,38 @@ def _api(url, token, method="GET", data=None, content_type="application/json"):
         },
     )
     with urllib.request.urlopen(req) as resp:
-        return json.loads(resp.read())
+        body = resp.read()
+        return json.loads(body) if body else None
+
+
+def _find_release(repo, tag, token):
+    try:
+        return _api(f"https://api.github.com/repos/{repo}/releases/tags/{tag}", token)
+    except urllib.error.HTTPError as e:
+        if e.code != 404:
+            raise
+    # /releases/tags/{tag} only returns published releases; a tag re-push
+    # flips the existing release back to draft, so fall back to listing.
+    page = 1
+    while True:
+        releases = _api(
+            f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}",
+            token,
+        )
+        if not releases:
+            sys.exit(f"error: no release (published or draft) found for tag '{tag}' in {repo}")
+        for release in releases:
+            if release["tag_name"] == tag:
+                return release
+        page += 1
 
 
 def upload_asset(repo, tag, filepath, token):
     asset = Path(filepath)
-    release = _api(f"https://api.github.com/repos/{repo}/releases/tags/{tag}", token)
+    release = _find_release(repo, tag, token)
+    for existing in release.get("assets", []):
+        if existing["name"] == asset.name:
+            _api(existing["url"], token, method="DELETE")
     upload_url = release["upload_url"].split("{")[0]
     with asset.open("rb") as fh:
         _api(

--- a/.github/workflows/tag-changelogs.yaml
+++ b/.github/workflows/tag-changelogs.yaml
@@ -74,8 +74,11 @@ jobs:
         run: |
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG exists — updating notes."
+            # --draft=false re-publishes a release that GitHub flipped back
+            # to draft after a tag re-push
             gh release edit "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
+              --draft=false \
               --notes-file /tmp/release-notes.md
           else
             echo "Release $TAG does not exist — creating with notes."

--- a/.github/workflows/tag-docs-scarthgap.yaml
+++ b/.github/workflows/tag-docs-scarthgap.yaml
@@ -108,11 +108,11 @@ jobs:
 
       - name: notify docs.pantavisor to sync
         env:
-          PANTAVISOR_DOC_SYNC: ${{ secrets.PANTAVISOR_DOC_SYNC }}
+          PANTAVISOR_DOCS_SYNC: ${{ secrets.PANTAVISOR_DOCS_SYNC }}
         run: |
           TAG="${{ github.event.workflow_run.head_branch }}"
           curl -fsSL -X POST \
-            -H "Authorization: Bearer ${PANTAVISOR_DOC_SYNC}" \
+            -H "Authorization: Bearer ${PANTAVISOR_DOCS_SYNC}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -d "{\"event_type\":\"docs-release\",\"client_payload\":{\"tag\":\"${TAG}\"}}" \

--- a/docs/ci/builds.md
+++ b/docs/ci/builds.md
@@ -209,7 +209,7 @@ The job:
 7. Uploads the original (unstripped) tarball to the GitHub Release via
    `upload-docs.py upload-asset`, then sends a `repository_dispatch` event
    (`event_type: "docs-release"`, payload `{"tag": "<TAG>"}`) directly to
-   `pantavisor/docs.pantavisor` via `curl` using the `PANTAVISOR_DOC_SYNC`
+   `pantavisor/docs.pantavisor` via `curl` using the `PANTAVISOR_DOCS_SYNC`
    secret.
 
 The tag is taken from `workflow_run.head_branch` (the tag that triggered


### PR DESCRIPTION
## Problem

The `ontag: build and publish docs` workflow (`tag-docs-scarthgap.yaml`) failed for every recent tag, in two independent ways:

1. **Draft release → HTTP 404.** Re-pushing a release tag makes GitHub flip the existing release back to draft. The REST endpoint `/releases/tags/{tag}` used by `upload-docs.py upload-asset` only returns *published* releases, so the upload step died with `HTTP Error 404: Not Found` (seen on `028-rc14`, whose tag was re-pushed three times). Meanwhile `tag-changelogs.yaml` uses `gh release view`/`edit`, which *do* see drafts — so it kept updating the draft's notes on every run without ever re-publishing it, leaving the release stuck in draft.
2. **Secret name typo → HTTP 401.** The final "notify docs.pantavisor to sync" step reads `secrets.PANTAVISOR_DOC_SYNC`, but the repo secret is named `PANTAVISOR_DOCS_SYNC`. The env var was always empty, so the `repository_dispatch` call has failed with 401 since the step was introduced.

## Changes

- **`.github/scripts/upload-docs.py`**
  - When the by-tag release lookup 404s, fall back to paging `/releases`, which includes draft releases, and fail with a clear error only if no release exists at all.
  - Delete a same-named existing asset before uploading, so workflow re-runs are idempotent instead of failing with `already_exists`.
  - `_api()` now tolerates empty response bodies (the asset DELETE returns 204).
- **`.github/workflows/tag-changelogs.yaml`** — pass `--draft=false` to `gh release edit` so a release demoted to draft by a tag re-push is automatically re-published on the next changelog run.
- **`.github/workflows/tag-docs-scarthgap.yaml`**, **`docs/ci/builds.md`** — reference the actual secret name `PANTAVISOR_DOCS_SYNC`.

## Recovery already performed (outside this PR)

- Published the stuck `028-rc14` draft release and re-ran the failed docs run: build, S3 upload, `releases.json` update, and release asset upload all succeeded.
- Manually sent the missed `docs-release` dispatch to `pantavisor/docs.pantavisor`; its "Docs: release sync" run completed successfully.
- Removed a stale pre-re-push docs asset from the `028-rc14` release.

## Test plan

- [x] `python3 -m py_compile .github/scripts/upload-docs.py`
- [x] Verified the draft-release failure mode live on `028-rc14` (404 before publishing the draft, success after) — the listing fallback covers exactly this state.
- [ ] Confirm on the next tag push (or tag re-push) that the docs workflow completes end-to-end: asset attached to the release, release published, docs.pantavisor sync triggered.

Note: `workflow_run`-triggered runs check out the tag's commit, so these fixes take effect for tags created after this lands on master.