### PR TITLE
docs: fix Toradex install references and impose sidebar reading order

### DIFF
--- a/docs/ci/builds.md
+++ b/docs/ci/builds.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Build Pipeline
 
 ## Build Engines

--- a/docs/ci/changelog.md
+++ b/docs/ci/changelog.md
@@ -1,7 +1,10 @@
+---
+sidebar_position: 7
+---
 # Per-release CHANGELOG
 
 Each meta-pantavisor release ships with a section in
-[`CHANGELOG/CHANGELOG-NNN.md`](../../CHANGELOG/) summarizing what changed
+[`CHANGELOG/CHANGELOG-NNN.md`](https://github.com/pantavisor/meta-pantavisor/tree/master/CHANGELOG) summarizing what changed
 relative to the previous release in the same stream. The format is modeled on
 the [Kubernetes changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md).
 
@@ -9,9 +12,9 @@ the [Kubernetes changelog](https://github.com/kubernetes/kubernetes/blob/master/
 
 | Piece | Path |
 |---|---|
-| Generator | [`.github/scripts/make-changelog.sh`](../../.github/scripts/make-changelog.sh) |
-| Component map (JSON) | [`.github/scripts/components.json`](../../.github/scripts/components.json) |
-| CI workflow | [`.github/workflows/tag-changelogs.yaml`](../../.github/workflows/tag-changelogs.yaml) |
+| Generator | [`.github/scripts/make-changelog.sh`](https://github.com/pantavisor/meta-pantavisor/blob/master/.github/scripts/make-changelog.sh) |
+| Component map (JSON) | [`.github/scripts/components.json`](https://github.com/pantavisor/meta-pantavisor/blob/master/.github/scripts/components.json) |
+| CI workflow | [`.github/workflows/tag-changelogs.yaml`](https://github.com/pantavisor/meta-pantavisor/blob/master/.github/workflows/tag-changelogs.yaml) |
 | Output | `CHANGELOG/CHANGELOG-<MAJOR>.md` (e.g. `CHANGELOG-028.md`) |
 
 The generator is a single bash script using `git`, `curl`, `jq`, and `awk`.
@@ -34,7 +37,7 @@ For tag `T` (e.g. `028-rc7`):
    artifacts to S3, after which they activate at exactly those URLs. SHA256
    columns are blank in predicted mode (the hashes aren't known yet).
 2. **Component versions** — for every recipe in
-   [`components.json`](../../.github/scripts/components.json), the `SRCREV` is
+   [`components.json`](https://github.com/pantavisor/meta-pantavisor/blob/master/.github/scripts/components.json), the `SRCREV` is
    read at the source rev (HEAD in pre-tag mode, the tag in historical mode)
    and at the previous tag in the stream. Each row shows previous SHA, current
    SHA, and a `compare` URL when they differ.
@@ -179,7 +182,7 @@ git commit -m "changelogs(028): backfill"
 
 ## Adding a new component
 
-Append an entry to [`components.json`](../../.github/scripts/components.json):
+Append an entry to [`components.json`](https://github.com/pantavisor/meta-pantavisor/blob/master/.github/scripts/components.json):
 
 ```json
 {

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -14,8 +14,9 @@ Documentation for the meta-pantavisor CI system: how workflows are organized, ho
 2. [Machines](machines.md) — the `.github/machines.json` schema and how to add or modify a machine; always run `makeworkflows` after editing
 3. [Builds](builds.md) — per-machine build workflows, sstate sharing, S3 artifact layout, and badge generation
 4. [Status](status.md) — reading build status badges and CI run summaries
-5. [Tag Sync](tag-sync.md) — how `meta-pantavisor` tags are mirrored to `pantavisor/pantavisor` and the PAT setup required
-6. [Changelog](changelog.md) — per-release `CHANGELOG-NNN.md` generator: format, tag conventions, and regen procedure
+5. [Versioning](versioning.md) — how `DISTRO_VERSION` is derived from git tags and how to cut a new release tag
+6. [Tag Sync](tag-sync.md) — how `meta-pantavisor` tags are mirrored to `pantavisor/pantavisor` and the PAT setup required
+7. [Changelog](changelog.md) — per-release `CHANGELOG-NNN.md` generator: format, tag conventions, and regen procedure
 
 ## Key Rule
 

--- a/docs/ci/machines.md
+++ b/docs/ci/machines.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Machine Configuration
 
 All CI behavior is controlled by `.github/machines.json`. Adding, removing, or reconfiguring a machine means editing this file and regenerating the workflows — no manual YAML editing required.

--- a/docs/ci/overview.md
+++ b/docs/ci/overview.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # CI Overview
 
 The CI system builds Yocto images for all supported machines, runs integration tests, mirrors release tags, and publishes artifacts to S3. All behavior is driven from a single source of truth — `.github/machines.json` — from which most workflow files are generated.

--- a/docs/ci/status.md
+++ b/docs/ci/status.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 4
+---
 # CI Status
 
 ## Workflow Status

--- a/docs/ci/tag-sync.md
+++ b/docs/ci/tag-sync.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 6
+---
 # Tag sync: meta-pantavisor → pantavisor
 
 When a release tag is pushed to `meta-pantavisor`, a workflow mirrors that tag

--- a/docs/ci/versioning.md
+++ b/docs/ci/versioning.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 5
+---
 # Versioning
 
 `meta-pantavisor` uses dynamic versioning tied to its own git repository. This means the `DISTRO_VERSION` variable automatically reflects the latest git tag and commit state of your local `meta-pantavisor` checkout.

--- a/docs/examples/xconnect-examples.md
+++ b/docs/examples/xconnect-examples.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # xconnect Example Containers
 
 The `pv-examples` containers in `recipes-containers/pv-examples/` demonstrate pv-xconnect service mesh patterns. For the underlying xconnect concepts and manifest format, see the [pantavisor xconnect overview](../../pantavisor/overview/xconnect.md) and [reference](../../pantavisor/reference/pantavisor-xconnect.md).

--- a/docs/how-to-build/bootchartd.md
+++ b/docs/how-to-build/bootchartd.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 7
+---
 # Bootchartd
 
 Pantavisor supports [bootchartd](https://github.com/mmeeks/bootchart) for boot time profiling. When enabled, Pantavisor generates a `bootchartd.tgz` tarball capturing the boot sequence.

--- a/docs/how-to-build/component-docs.md
+++ b/docs/how-to-build/component-docs.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 6
+---
 # Component Documentation Packaging
 
 meta-pantavisor ships two BitBake classes that together form a documentation

--- a/docs/how-to-build/container-development.md
+++ b/docs/how-to-build/container-development.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 4
+---
 # Container Development
 
 ## Creating Example Containers

--- a/docs/how-to-build/get-started.md
+++ b/docs/how-to-build/get-started.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Get Started
 
 ## Prerequisites

--- a/docs/how-to-build/manifest-audit.md
+++ b/docs/how-to-build/manifest-audit.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 5
+---
 # Pantavisor Manifest Audit
 
 `pv-manifest-audit.bbclass` produces a deterministic listing of every entry in

--- a/docs/how-to-build/pantavisor-development.md
+++ b/docs/how-to-build/pantavisor-development.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Pantavisor Development
 
 Use `kas/with-workspace.yaml` to develop pantavisor source locally while rebuilding through the Yocto layer.

--- a/docs/how-to-build/supported-device.md
+++ b/docs/how-to-build/supported-device.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Supported Devices
 
 This document outlines the devices (machines) currently supported by meta-pantavisor, including those that are built automatically by our CI infrastructure.
@@ -21,7 +24,7 @@ The following machines are configured in our CI pipeline (`.github/machines.json
 | `docker-x86_64` | AppEngine testing container (x86_64) |
 
 > [!NOTE]
-> For an up-to-date programmatic list of what is built, always refer to [`.github/machines.json`](../../.github/machines.json). If you add a new machine, remember to run `.github/scripts/makeworkflows` to regenerate the GitHub Actions workflows.
+> For an up-to-date programmatic list of what is built, always refer to [`.github/machines.json`](https://github.com/pantavisor/meta-pantavisor/blob/master/.github/machines.json). If you add a new machine, remember to run `.github/scripts/makeworkflows` to regenerate the GitHub Actions workflows.
 
 ## Downloading Images
 
@@ -39,4 +42,4 @@ To learn how to build an image for one of these supported devices, check out the
 Once you have built an image for your device, you need to flash it or install it on the target hardware. The installation process varies by board type:
 
 - See the [**How to Install Overview**](../how-to-install/index.md) for general flashing instructions.
-- Refer to board-specific guides such as [SD Card installation](../how-to-install/sdcard.md), [Toradex Easy Installer (Tezi)](../how-to-install/tezi.md), or [NXP UUU](../how-to-install/uuu.md) depending on your target machine.
+- Refer to board-specific guides such as [SD Card installation](../how-to-install/sdcard.md), [Toradex flashing (UUU + pv-flash-bundle)](../how-to-install/toradex.md), or [NXP UUU](../how-to-install/uuu.md) depending on your target machine.

--- a/docs/how-to-install/boards/index.md
+++ b/docs/how-to-install/boards/index.md
@@ -10,8 +10,8 @@ Board-specific guides supplement the generic [install methods](../). Each page c
 
 ## Supported Boards
 
-1. [Toradex Colibri iMX6ULL](colibri-imx6ull.md) — Tezi install, boot-mode jumper for EVB and other carrier boards
-2. [Toradex Verdin iMX8MM](verdin-imx8mm.md) — Tezi install, boot-mode selection for Verdin Development Board
+1. [Toradex Colibri iMX6ULL](colibri-imx6ull.md) — UUU flash via pv-flash-bundle, boot-mode jumper for EVB and other carrier boards
+2. [Toradex Verdin iMX8MM](verdin-imx8mm.md) — UUU flash via pv-flash-bundle, boot-mode selection for Verdin Development Board
 3. [Variscite iMX8MN VAR-SOM](imx8mn-var-som.md) — UUU flash, boot-mode DIP switches, carrier board notes
 4. [Variscite iMX8MM VAR-DART](imx8mm-var-dart.md) — UUU flash, boot-mode DIP switches, carrier board notes
 

--- a/docs/how-to-install/docker.md
+++ b/docs/how-to-install/docker.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Running Pantavisor AppEngine
 
 Pantavisor AppEngine init mode lets you run Pantavisor in your already set up

--- a/docs/how-to-install/index.md
+++ b/docs/how-to-install/index.md
@@ -12,7 +12,7 @@ Guides for getting a Pantavisor image onto a device, from SD card flashing to bo
 
 1. [SD Card](sdcard.md) — write a `.wic` image to an SD card using `pvflasher` or `dd`; the generic method for most boards
 2. [Docker / Local Target](docker.md) — run Pantavisor locally with Docker for development and testing without hardware
-3. [Tezi](tezi.md) — install using Toradex Easy Installer for Toradex Colibri and Verdin modules
+3. [Toradex](toradex.md) — flash Toradex Colibri and Verdin modules with UUU and the self-contained `pv-flash-bundle`
 4. [UUU](uuu.md) — flash NXP i.MX targets using the Universal Update Utility
 5. [Board Guides](boards/) — board-specific wiring, boot-mode selection, and install notes
 
@@ -21,6 +21,6 @@ Guides for getting a Pantavisor image onto a device, from SD card flashing to bo
 | Target | Method |
 |--------|--------|
 | Most boards (SD card slot) | [SD Card](sdcard.md) |
-| Toradex Colibri / Verdin | [Tezi](tezi.md) |
+| Toradex Colibri / Verdin | [Toradex (UUU + pv-flash-bundle)](toradex.md) |
 | NXP i.MX EVK / SOM | [UUU](uuu.md) |
 | Local development | [Docker](docker.md) |

--- a/docs/how-to-install/sdcard.md
+++ b/docs/how-to-install/sdcard.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Flashing via SD Card (WIC images)
 
 Most Pantavisor machines produce a `.wic` image that can be written directly

--- a/docs/how-to-install/toradex.md
+++ b/docs/how-to-install/toradex.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Flashing Toradex Modules
 
 Both supported Toradex modules use **UUU + pv-flash-bundle** for factory flashing.

--- a/docs/how-to-install/uuu.md
+++ b/docs/how-to-install/uuu.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 4
+---
 # Flashing via NXP uuu (Universal Update Utility)
 
 Some i.MX-based boards support flashing via **uuu** (Universal Update Utility),

--- a/docs/overview/build-system.md
+++ b/docs/overview/build-system.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Build System Overview
 
 ## KAS Configuration Hierarchy

--- a/docs/overview/ci.md
+++ b/docs/overview/ci.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 4
+---
 # CI/CD Overview
 
 GitHub Actions workflows in `.github/workflows/` automate builds for all supported machines.

--- a/docs/overview/meta-pantavisor.md
+++ b/docs/overview/meta-pantavisor.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # meta-pantavisor Overview
 
 meta-pantavisor is the Yocto/OpenEmbedded layer that builds Pantavisor-based BSP images for embedded Linux products. It provides recipes, BitBake classes, and KAS configurations for producing initramfs images and container pvrexport bundles.

--- a/docs/overview/pantavisor.md
+++ b/docs/overview/pantavisor.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Pantavisor
 
 Pantavisor is an open-source, container-based embedded Linux system runtime.

--- a/docs/testing/automated-workflow.md
+++ b/docs/testing/automated-workflow.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Automated Test Workflow
 
 Structured testing using `test.docker.sh` — the test runner bundled inside the `pantavisor-appengine-distro` build target. Use this for collecting valgrind results and CI validation. For the manual development workflow (quick iteration while coding), including test plans, see [development-workflow.md](development-workflow.md).
@@ -262,7 +265,7 @@ cp <workdir>/$SCOPE/$CATEGORY/$NAME/output \
 
 Iterate between steps 4–6 until the test passes cleanly.
 
-**7.** Add the test to the [test plan table](#test-plan) below and mark `[x]` in `TODO.md`.
+**7.** Add the test to the [todo list](#todo-list) below and mark `[x]` in `TODO.md`.
 
 ### Updating expected output for an existing test
 

--- a/docs/testing/development-workflow.md
+++ b/docs/testing/development-workflow.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Development Workflow
 
 The appengine is a Docker-based environment for running and testing Pantavisor locally without real hardware. This document covers the manual workflow used during development. For structured automated testing with `test.docker.sh`, see [automated-workflow.md](automated-workflow.md).


### PR DESCRIPTION
## Summary

Companion to pantavisor/pantavisor#735 — prepares the `docs/` tree for the Docusaurus reference instance on docs.pantavisor.io, where this repo's docs are published alongside the pantavisor repo's.

- **Toradex install fix**: the install index and supported-device guide pointed at a nonexistent `tezi.md` and described the install as "Toradex Easy Installer" — but Toradex Colibri/Verdin modules are flashed with UUU + pv-flash-bundle (see `docs/how-to-install/toradex.md`, which explicitly says Tezi is not used). Retargeted the links and reworded the stale "Tezi install" descriptions in the board guides index.
- **Repo source links**: links to `.github/machines.json`, `.github/scripts/*`, and `CHANGELOG/` converted to full GitHub URLs, since only `docs/` content exists on the published site.
- **CI index**: added the missing Versioning page to the CI section index.
- **Anchor fix**: `#test-plan` in the automated workflow guide now points at the actual Todo list section.
- **Sidebar order**: added `sidebar_position` frontmatter to all section pages so the docs.pantavisor.io sidebar follows each index's reading order instead of alphabetical order.

## Test plan

- Cloned [docs.pantavisor](https://github.com/pantavisor/docs.pantavisor), staged this branch's `docs/` (together with the pantavisor#735 branch) into the generated reference instance, and ran the full Docusaurus build: **zero broken links or anchors** in the current reference instance.