### PR TITLE
fix(colibri-imx6ull): configure UBI storage bootargs for NAND boot

### DIFF
--- a/docs/how-to-install/boards/colibri-imx6ull.md
+++ b/docs/how-to-install/boards/colibri-imx6ull.md
@@ -44,6 +44,99 @@ The pv-flash-bundle UUU script writes U-Boot to `u-boot1` and `u-boot2` using
 raw byte offsets (bypassing the `ro` partition flag, which only applies in Linux
 userspace). The `boot` UBI volume holds the Pantavisor UBIFS rootfs.
 
+The script also **erases the `u-boot-env` partition** so U-Boot starts from its
+built-in default environment. A leftover env from a prior image (e.g. Toradex
+Easy Installer / TorizonCore) carries a stale `bootcmd` that looks for a UBI
+`bootscr` volume and fails with `Volume bootscr not found!`.
+
+## Boot flow
+
+Unlike Toradex's stock `ubiboot` (which expects raw `kernel`/`dtb`/`rootfs` UBI
+volumes), this build keeps a single UBIFS `boot` volume holding the whole
+Pantavisor rootfs. The default `bootcmd` (baked in via
+`recipes-bsp/u-boot/files/pv.colibri-imx6ull.cfg`) mounts that volume and sources
+the generic Pantavisor boot script from it:
+
+```
+ubi part ubi && ubifsmount ubi0:boot && setenv devtype ubi && \
+    ubifsload ${scriptaddr} /boot/boot.scr && source ${scriptaddr}
+```
+
+`boot.cmd.pvgeneric` detects `devtype=ubi` and uses `ubifsload` to pull the
+Pantavisor FIT (kernel + initramfs + dtb) from `/trails/<rev>/bsp/`. The kernel
+then attaches UBI and Pantavisor mounts its storage from `ubi0:boot`. All of
+this is driven by `PV_BOOT_OEMARGS` → `oemEnv.txt` → `${oemargs}`:
+
+```
+mtdparts=gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,512k(u-boot-env),-(ubi) ubi.mtd=ubi pv_storage.device=ubi0:boot pv_storage.fstype=ubifs
+```
+
+The `mtdparts=` entry is **required**: the colibri-imx6ull device tree declares
+no NAND partitions, so without it the kernel has no partition named `ubi` and
+`ubi.mtd=ubi` cannot attach (Pantavisor then fails to resolve `ubi0:boot`).
+Toradex's stock boot supplies the same `mtdparts` via its `setup` env; the
+Pantavisor boot script bypasses that, so it is carried here instead.
+
+> **Note:** U-Boot's UBIFS driver is read-only, so the try-boot/rollback state
+> (`pv.env`) is not persisted across reboots on NAND; the boot script skips the
+> `save` step when booting from UBI.
+
+## WiFi / Bluetooth device tree (FDT selection)
+
+The Colibri iMX6ULL **WB** modules carry a Marvell 88W8997 (SD8997) WiFi/BT chip
+on the second SD/MMC controller (`usdhc2`). That interface is only enabled by the
+`imx6ull-colibri-wifi-*` device trees; the plain `imx6ull-colibri-*` DTBs are the
+non-wireless SKU and leave `usdhc2` disabled. With the wrong DTB the kernel never
+probes the chip — `mwifiex_sdio` loads but binds nothing and no `wlan0` appears.
+
+Which DTB Pantavisor boots is decided at image-build time and baked into the BSP
+`run.json` (`"fdt": ...`). The Toradex platform sets `PV_UBOOT_AUTOFDT = "1"`,
+which makes `pantavisor-bsp.bb` pick the **first** entry of `KERNEL_DEVICETREE`.
+For colibri-imx6ull that list starts with the non-WiFi `imx6ull-colibri-aster.dtb`,
+so autofdt would always select the wireless-less tree. To boot the WiFi DTB the
+machine config (`kas/machines/colibri-imx6ull.yaml`, mirrored in the release
+build-config) pins it explicitly and disables autofdt:
+
+```bitbake
+PV_INITIAL_DTB = "imx6ull-colibri-wifi-aster.dtb"
+PV_UBOOT_AUTOFDT:colibri-imx6ull = ""
+MACHINE_FEATURES:append = " wifi"
+```
+
+Two subtleties matter here:
+
+- **Disabling autofdt is required.** If `PV_UBOOT_AUTOFDT` stays `"1"`, both the
+  `PV_INITIAL_DTB` branch and the autofdt branch run, and the autofdt branch
+  writes its `"fdt"` key *last* — silently overriding `PV_INITIAL_DTB` with the
+  first (non-WiFi) `KERNEL_DEVICETREE` entry.
+- **Use the `:colibri-imx6ull` machine override, not a plain `=`.** kas emits the
+  `platform-toradex` block (`PV_UBOOT_AUTOFDT = "1"`) *after* the machine block in
+  `local.conf`, so a plain `PV_UBOOT_AUTOFDT = ""` loses to it (last plain `=`
+  wins). The machine override is applied at BitBake finalize time, after all plain
+  assignments, so it reliably wins.
+
+Pick the DTB that matches your carrier board:
+
+| Carrier | WiFi DTB |
+|---|---|
+| Aster | `imx6ull-colibri-wifi-aster.dtb` |
+| Evaluation Board v3 | `imx6ull-colibri-wifi-eval-v3.dtb` |
+| Iris | `imx6ull-colibri-wifi-iris.dtb` |
+| Iris v2 | `imx6ull-colibri-wifi-iris-v2.dtb` |
+
+After building, confirm the BSP selected the WiFi tree before flashing:
+
+```bash
+grep -o '"fdt":"[^"]*"' \
+  build/*/work/cortexa7t2hf-neon-poky-linux-musleabi/pantavisor-bsp/1.0/pvbspstate/bsp/run.json
+# Expected: "fdt":"imx6ull-colibri-wifi-aster.dtb"
+# A "nxp/imx/..." prefix means autofdt is still winning (non-WiFi tree selected).
+```
+
+On the running board, `cat /sys/firmware/devicetree/base/model` reflects the
+active tree and `usdhc2`/`mmc1` plus a `wlan0` interface should appear once the
+WiFi DTB is booted.
+
 ## Flashing
 
 With the module in SDP mode, follow the procedure in

--- a/docs/overview/boot-flow.md
+++ b/docs/overview/boot-flow.md
@@ -1,0 +1,160 @@
+# U-Boot Boot Flow
+
+How Pantavisor boots from U-Boot via the generic boot script
+`boot.cmd.pvgeneric`. This is the U-Boot → kernel handoff that runs before
+the Pantavisor runtime takes over as init.
+
+## The Pantavisor boot model
+
+Pantavisor does not boot a normal root filesystem. Instead the kernel is
+started with a ramfs root and Pantavisor as the init process:
+
+```
+root=/dev/ram rootfstype=ramfs rdinit=/usr/bin/pantavisor
+```
+
+The kernel + initramfs + device tree are packaged as a FIT image
+(`pantavisor.fit`) that lives inside a versioned **trail revision** on the
+storage volume:
+
+```
+/trails/<rev>/bsp/pantavisor.fit          # preferred: single FIT
+/trails/<rev>/.pv/pv-kernel.img           # fallback: separate components
+/trails/<rev>/.pv/pv-initrd.img
+/trails/<rev>/.pv/pv-fdt.dtb
+```
+
+U-Boot's only job is to pick the right revision, load that revision's
+kernel/initrd/dtb into RAM, assemble the kernel command line, and jump to
+it. Once running, Pantavisor mounts its storage volume and manages
+containers (see [Pantavisor](pantavisor.md) for the trail/revision model).
+
+## How the boot script is built and deployed
+
+The script source is `recipes-bsp/u-boot/files/boot.cmd.pvgeneric`. It is
+wired into every U-Boot build by `recipes-bsp/u-boot/u-boot%.bbappend`:
+
+| Step | Mechanism |
+|------|-----------|
+| Assemble source | `do_prepcompile` concatenates `UBOOT_ENV_SRC_FRAGS` (i.e. `boot.cmd.pvgeneric`) into `boot.txt` / `boot.cmd` |
+| Compile | The U-Boot recipe wraps it with `mkimage` into `boot.scr` (`UBOOT_ENV=boot`, `UBOOT_ENV_SUFFIX=scr`) |
+| Deploy | `boot.scr` lands in `DEPLOY_DIR_IMAGE`; image recipes place it where U-Boot expects it |
+| OEM args | `do_deploy:append` renders `oemEnv.txt` from its template, substituting `@@PV_BOOT_OEMARGS@@` → `PV_BOOT_OEMARGS` |
+
+The `pvbsp` / `pvapp` multiconfigs disable the env (`UBOOT_ENV = ""`) since
+they do not produce a bootable top-level image.
+
+## Where boot.scr lives per storage backend
+
+`boot.scr` is loaded and `source`d by U-Boot's `bootcmd`. How that happens
+depends on the storage medium:
+
+| Backend | How bootcmd finds boot.scr | boot.scr placement |
+|---------|----------------------------|--------------------|
+| MMC / wic (eMMC, SD) | `distro_bootcmd` scans the FAT boot partition for `boot.scr` | `IMAGE_BOOT_FILES` puts it on the FAT partition |
+| NAND / UBIFS | A machine `bootcmd` mounts the UBI volume and sources it directly | `pantavisor-starter.bb` copies it into the rootfs `/boot/` |
+
+For NAND the default `bootcmd` (set via a machine U-Boot `.cfg` such as
+`pv.colibri-imx6ull.cfg`) is:
+
+```
+ubi part ubi && ubifsmount ubi0:boot && setenv devtype ubi && \
+    ubifsload ${scriptaddr} /boot/boot.scr && source ${scriptaddr}
+```
+
+Note `setenv devtype ubi` — the boot script keys all of its load behavior
+off `${devtype}` (see below).
+
+## The boot script, step by step
+
+1. **Base args.** Sets `pv_baseargs` (`root=/dev/ram … rdinit=/usr/bin/pantavisor`)
+   and appends `console=${console},${baudrate}` when known.
+
+2. **Pick a load method.** `${devtype}` selects how files are read:
+   - `devtype != ubi` (mmc, usb, …) → `${pv_load_boot}` / `${pv_load_data}`
+     expand to `load <devtype> <dev>:<part>` (fatload/ext4load).
+   - `devtype = ubi` → both collapse to `ubifsload` (a single UBIFS volume
+     holds everything). U-Boot's generic `load` cannot read UBIFS, so this
+     indirection is required. `pv_root` adds the leading `/` that absolute
+     UBIFS paths need for files at the volume root.
+
+3. **Load `oemEnv.txt`** and `env import` it → provides `${oemargs}`
+   (see [OEM args](#oem-args-and-pv_boot_oemargs)).
+
+4. **Locate the data partition / OEM config (MMC only).** On MMC the script
+   probes partition `${pv_ctrl}` (2) for a small Pantavisor OEM config
+   (size `0x800`) and computes `pv_mmcdata` (the rootfs/data partition).
+   On UBI this MBR probe is skipped — there is one volume.
+
+5. **Load revision state.**
+   - `/boot/uboot.txt` → `pv_rev` (the committed revision).
+   - `pv.env` → `pv_try` / `pv_trying` (try-boot markers).
+
+6. **Select `boot_rev` (try-boot / rollback).**
+   - No `pv_try` → boot the committed `pv_rev`.
+   - `pv_try` set and not yet attempted → boot `pv_try` and record it in
+     `pv.env` (first attempt of a new revision).
+   - `pv_try` set and already attempted (previous try failed) → fall back
+     to the committed `pv_rev`.
+   - The recorded state is written back with `save … pv.env`. **On UBI this
+     `save` is skipped** — U-Boot's UBIFS driver is read-only, so try-boot
+     rollback state is not persisted on NAND.
+
+7. **Boot the FIT.** Tries `/trails/${boot_rev}/bsp/pantavisor.fit`. If
+   present, selects a config node (`name_fit_config`) and `bootm`s it. The
+   config node is resolved via, in order: a platform hook
+   (`pv_plat_set_name_fit_config`), the board's `findfdt`, or `fdtfile`.
+
+8. **Fallback to discrete images.** If no FIT, loads `pv-kernel.img`,
+   `pv-initrd.img`, `pv-fdt.dtb` (plus any `pv-initrd.img.<n>` add-ons) from
+   `/trails/${boot_rev}/.pv/`, then tries `booti` → `bootz` → `bootm` →
+   `bootelf` in turn.
+
+9. **Final command line.** Assembled as:
+   ```
+   ${pv_platargs} ${pv_baseargs} pv_try=… pv_rev=… panic=2 pv_quickboot \
+       ${fdtbootargs} ${configargs} ${oemargs} ${localargs}
+   ```
+
+## OEM args and PV_BOOT_OEMARGS
+
+`PV_BOOT_OEMARGS` (set per machine) is the supported hook for injecting
+extra kernel command-line arguments. It flows:
+
+```
+PV_BOOT_OEMARGS  →  oemEnv.txt (@@PV_BOOT_OEMARGS@@)  →  env import  →  ${oemargs}  →  bootargs
+```
+
+Pantavisor reads `pv_`-prefixed cmdline keys as config overrides (e.g.
+`pv_storage.device`, `pv_storage.fstype`). Example for NAND/UBIFS:
+
+```bitbake
+PV_BOOT_OEMARGS = "mtdparts=gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,512k(u-boot-env),-(ubi) ubi.mtd=ubi pv_storage.device=ubi0:boot pv_storage.fstype=ubifs"
+```
+
+Here `ubi.mtd=ubi` tells the kernel to attach the UBI device named `ubi`, and
+the `pv_storage.*` keys tell Pantavisor which volume to mount as storage. On
+NAND boards whose device tree declares no MTD partitions, the kernel only
+learns the partition layout (and thus the `ubi` partition) from a `mtdparts=`
+on the cmdline — without it `ubi.mtd=ubi` has nothing to attach. (On boards
+that define partitions in the DT, the `mtdparts=` is unnecessary.)
+
+## Customization knobs
+
+| Knob | Where | Purpose |
+|------|-------|---------|
+| `PV_BOOT_OEMARGS` | machine yaml / release build-config | Extra kernel cmdline args via `oemEnv.txt` |
+| `PV_MACHINE_UBOOT_CONFIGS` | machine yaml / release build-config | Per-machine U-Boot `.cfg` fragments (e.g. a NAND `bootcmd`, extra commands) |
+| `pv_platargs` | U-Boot env | Platform-specific early args (default `earlyprintk`) |
+| `pv_plat_set_name_fit_config` | U-Boot env | Platform hook to choose the FIT config node |
+| `localargs` | U-Boot env | Site/local cmdline additions |
+
+> When changing a machine's `local_conf_header` (including `PV_BOOT_OEMARGS`
+> and `PV_MACHINE_UBOOT_CONFIGS`), mirror the change in **both**
+> `kas/machines/<machine>.yaml` and the release build-config under
+> `kas/build-configs/release/`, which inlines its own platform block.
+
+## See also
+
+- [docs/how-to-install/boards/colibri-imx6ull.md](../how-to-install/boards/colibri-imx6ull.md) — a worked NAND/UBIFS boot example
+- [Build System](build-system.md) — multiconfig architecture (the flashed NAND U-Boot is built in the `tezi-recovery` multiconfig)

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -13,4 +13,5 @@ Conceptual documentation for the Pantavisor runtime and the meta-pantavisor laye
 1. [Pantavisor](pantavisor.md) — what Pantavisor is: container model, atomic updates, cloud control, and the trail/revision system
 2. [meta-pantavisor](meta-pantavisor.md) — directory layout, key recipes, BitBake classes, KAS fragments, and layer conventions
 3. [Build System](build-system.md) — KAS configuration hierarchy, multiconfig architecture, and the relationship between build targets
-4. [CI](ci.md) — how CI machines, workflows, and build matrix relate to the layer structure
+4. [Boot Flow](boot-flow.md) — how `boot.cmd.pvgeneric` boots Pantavisor: FIT/trail loading, try-boot, MMC vs NAND/UBIFS, and `PV_BOOT_OEMARGS`
+5. [CI](ci.md) — how CI machines, workflows, and build matrix relate to the layer structure

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0001-ARM-dts-imx6ull-colibri-enable-dcp.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0001-ARM-dts-imx6ull-colibri-enable-dcp.patch
@@ -1,0 +1,29 @@
+From bba8be48a2786a3459c0717cf7b19888981fbb4d Mon Sep 17 00:00:00 2001
+From: Fernando Luiz Cola <fernando.luiz@pantacor.com>
+Date: Tue, 16 Jun 2026 18:00:00 -0300
+Subject: [PATCH] ARM: dts: imx6ull-colibri: enable dcp
+
+Enable the DCP hardware block for hardware-backed encryption.
+
+Signed-off-by: Fernando Luiz Cola <fernando.luiz@pantacor.com>
+---
+ arch/arm/boot/dts/nxp/imx/imx6ull-colibri.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/boot/dts/nxp/imx/imx6ull-colibri.dtsi b/arch/arm/boot/dts/nxp/imx/imx6ull-colibri.dtsi
+index e80b07e781df..8b417c8cf1ba 100644
+--- a/arch/arm/boot/dts/nxp/imx/imx6ull-colibri.dtsi
++++ b/arch/arm/boot/dts/nxp/imx/imx6ull-colibri.dtsi
+@@ -100,6 +100,10 @@ backlight: backlight {
+ 	};
+ };
+ 
++&dcp {
++	status = "okay";
++};
++
+ &adc1 {
+ 	num-channels = <4>;
+ 	vref-supply = <&reg_module_3v3_avdd>;
+-- 
+2.34.1

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0002-crypto-mxs-dcp-Add-support-for-hardware-bound-keys.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0002-crypto-mxs-dcp-Add-support-for-hardware-bound-keys.patch
@@ -1,0 +1,259 @@
+From 3d16af0b4cfac4b2c3b238e2ec37b38c2f316978 Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Wed, 3 Apr 2024 09:21:17 +0200
+Subject: [PATCH] crypto: mxs-dcp: Add support for hardware-bound keys
+
+DCP (Data Co-Processor) is able to derive private keys for a fused
+random seed, which can be referenced by handle but not accessed by
+the CPU. Similarly, DCP is able to store arbitrary keys in four
+dedicated key slots located in its secure memory area (internal SRAM).
+These keys can be used to perform AES encryption.
+
+Expose these derived keys and key slots through the crypto API via their
+handle. The main purpose is to add DCP-backed trusted keys. Other
+use cases are possible too (see similar existing paes implementations),
+but these should carefully be evaluated as e.g. enabling AF_ALG will
+give userspace full access to use keys. In scenarios with untrustworthy
+userspace, this will enable en-/decryption oracles.
+
+Co-developed-by: Richard Weinberger <richard@nod.at>
+Signed-off-by: Richard Weinberger <richard@nod.at>
+Co-developed-by: David Oberhollenzer <david.oberhollenzer@sigma-star.at>
+Signed-off-by: David Oberhollenzer <david.oberhollenzer@sigma-star.at>
+Signed-off-by: David Gstir <david@sigma-star.at>
+Acked-by: Herbert Xu <herbert@gondor.apana.org.au>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ drivers/crypto/mxs-dcp.c | 104 ++++++++++++++++++++++++++++++++++-----
+ include/soc/fsl/dcp.h    |  20 ++++++++
+ 2 files changed, 113 insertions(+), 11 deletions(-)
+ create mode 100644 include/soc/fsl/dcp.h
+
+diff --git a/drivers/crypto/mxs-dcp.c b/drivers/crypto/mxs-dcp.c
+index 2b3ebe0db3a6d9..057d73c370b735 100644
+--- a/drivers/crypto/mxs-dcp.c
++++ b/drivers/crypto/mxs-dcp.c
+@@ -15,6 +15,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/stmp_device.h>
+ #include <linux/clk.h>
++#include <soc/fsl/dcp.h>
+ 
+ #include <crypto/aes.h>
+ #include <crypto/sha1.h>
+@@ -101,6 +102,7 @@ struct dcp_async_ctx {
+ 	struct crypto_skcipher		*fallback;
+ 	unsigned int			key_len;
+ 	uint8_t				key[AES_KEYSIZE_128];
++	bool				key_referenced;
+ };
+ 
+ struct dcp_aes_req_ctx {
+@@ -155,6 +157,7 @@ static struct dcp *global_sdcp;
+ #define MXS_DCP_CONTROL0_HASH_TERM		(1 << 13)
+ #define MXS_DCP_CONTROL0_HASH_INIT		(1 << 12)
+ #define MXS_DCP_CONTROL0_PAYLOAD_KEY		(1 << 11)
++#define MXS_DCP_CONTROL0_OTP_KEY		(1 << 10)
+ #define MXS_DCP_CONTROL0_CIPHER_ENCRYPT		(1 << 8)
+ #define MXS_DCP_CONTROL0_CIPHER_INIT		(1 << 9)
+ #define MXS_DCP_CONTROL0_ENABLE_HASH		(1 << 6)
+@@ -168,6 +171,8 @@ static struct dcp *global_sdcp;
+ #define MXS_DCP_CONTROL1_CIPHER_MODE_ECB	(0 << 4)
+ #define MXS_DCP_CONTROL1_CIPHER_SELECT_AES128	(0 << 0)
+ 
++#define MXS_DCP_CONTROL1_KEY_SELECT_SHIFT	8
++
+ static int mxs_dcp_start_dma(struct dcp_async_ctx *actx)
+ {
+ 	int dma_err;
+@@ -224,13 +229,16 @@ static int mxs_dcp_run_aes(struct dcp_async_ctx *actx,
+ 	struct dcp *sdcp = global_sdcp;
+ 	struct dcp_dma_desc *desc = &sdcp->coh->desc[actx->chan];
+ 	struct dcp_aes_req_ctx *rctx = skcipher_request_ctx(req);
++	bool key_referenced = actx->key_referenced;
+ 	int ret;
+ 
+-	key_phys = dma_map_single(sdcp->dev, sdcp->coh->aes_key,
+-				  2 * AES_KEYSIZE_128, DMA_TO_DEVICE);
+-	ret = dma_mapping_error(sdcp->dev, key_phys);
+-	if (ret)
+-		return ret;
++	if (!key_referenced) {
++		key_phys = dma_map_single(sdcp->dev, sdcp->coh->aes_key,
++					  2 * AES_KEYSIZE_128, DMA_TO_DEVICE);
++		ret = dma_mapping_error(sdcp->dev, key_phys);
++		if (ret)
++			return ret;
++	}
+ 
+ 	src_phys = dma_map_single(sdcp->dev, sdcp->coh->aes_in_buf,
+ 				  DCP_BUF_SZ, DMA_TO_DEVICE);
+@@ -255,8 +263,12 @@ static int mxs_dcp_run_aes(struct dcp_async_ctx *actx,
+ 		    MXS_DCP_CONTROL0_INTERRUPT |
+ 		    MXS_DCP_CONTROL0_ENABLE_CIPHER;
+ 
+-	/* Payload contains the key. */
+-	desc->control0 |= MXS_DCP_CONTROL0_PAYLOAD_KEY;
++	if (key_referenced)
++		/* Set OTP key bit to select the key via KEY_SELECT. */
++		desc->control0 |= MXS_DCP_CONTROL0_OTP_KEY;
++	else
++		/* Payload contains the key. */
++		desc->control0 |= MXS_DCP_CONTROL0_PAYLOAD_KEY;
+ 
+ 	if (rctx->enc)
+ 		desc->control0 |= MXS_DCP_CONTROL0_CIPHER_ENCRYPT;
+@@ -270,6 +282,9 @@ static int mxs_dcp_run_aes(struct dcp_async_ctx *actx,
+ 	else
+ 		desc->control1 |= MXS_DCP_CONTROL1_CIPHER_MODE_CBC;
+ 
++	if (key_referenced)
++		desc->control1 |= sdcp->coh->aes_key[0] << MXS_DCP_CONTROL1_KEY_SELECT_SHIFT;
++
+ 	desc->next_cmd_addr = 0;
+ 	desc->source = src_phys;
+ 	desc->destination = dst_phys;
+@@ -284,9 +299,9 @@ static int mxs_dcp_run_aes(struct dcp_async_ctx *actx,
+ err_dst:
+ 	dma_unmap_single(sdcp->dev, src_phys, DCP_BUF_SZ, DMA_TO_DEVICE);
+ err_src:
+-	dma_unmap_single(sdcp->dev, key_phys, 2 * AES_KEYSIZE_128,
+-			 DMA_TO_DEVICE);
+-
++	if (!key_referenced)
++		dma_unmap_single(sdcp->dev, key_phys, 2 * AES_KEYSIZE_128,
++				 DMA_TO_DEVICE);
+ 	return ret;
+ }
+ 
+@@ -453,7 +468,7 @@ static int mxs_dcp_aes_enqueue(struct skcipher_request *req, int enc, int ecb)
+ 	struct dcp_aes_req_ctx *rctx = skcipher_request_ctx(req);
+ 	int ret;
+ 
+-	if (unlikely(actx->key_len != AES_KEYSIZE_128))
++	if (unlikely(actx->key_len != AES_KEYSIZE_128 && !actx->key_referenced))
+ 		return mxs_dcp_block_fallback(req, enc);
+ 
+ 	rctx->enc = enc;
+@@ -500,6 +515,7 @@ static int mxs_dcp_aes_setkey(struct crypto_skcipher *tfm, const u8 *key,
+ 	 * there can still be an operation in progress.
+ 	 */
+ 	actx->key_len = len;
++	actx->key_referenced = false;
+ 	if (len == AES_KEYSIZE_128) {
+ 		memcpy(actx->key, key, len);
+ 		return 0;
+@@ -516,6 +532,32 @@ static int mxs_dcp_aes_setkey(struct crypto_skcipher *tfm, const u8 *key,
+ 	return crypto_skcipher_setkey(actx->fallback, key, len);
+ }
+ 
++static int mxs_dcp_aes_setrefkey(struct crypto_skcipher *tfm, const u8 *key,
++				 unsigned int len)
++{
++	struct dcp_async_ctx *actx = crypto_skcipher_ctx(tfm);
++
++	if (len != DCP_PAES_KEYSIZE)
++		return -EINVAL;
++
++	switch (key[0]) {
++	case DCP_PAES_KEY_SLOT0:
++	case DCP_PAES_KEY_SLOT1:
++	case DCP_PAES_KEY_SLOT2:
++	case DCP_PAES_KEY_SLOT3:
++	case DCP_PAES_KEY_UNIQUE:
++	case DCP_PAES_KEY_OTP:
++		memcpy(actx->key, key, len);
++		actx->key_len = len;
++		actx->key_referenced = true;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
+ static int mxs_dcp_aes_fallback_init_tfm(struct crypto_skcipher *tfm)
+ {
+ 	const char *name = crypto_tfm_alg_name(crypto_skcipher_tfm(tfm));
+@@ -539,6 +581,13 @@ static void mxs_dcp_aes_fallback_exit_tfm(struct crypto_skcipher *tfm)
+ 	crypto_free_skcipher(actx->fallback);
+ }
+ 
++static int mxs_dcp_paes_init_tfm(struct crypto_skcipher *tfm)
++{
++	crypto_skcipher_set_reqsize(tfm, sizeof(struct dcp_aes_req_ctx));
++
++	return 0;
++}
++
+ /*
+  * Hashing (SHA1/SHA256)
+  */
+@@ -889,6 +938,39 @@ static struct skcipher_alg dcp_aes_algs[] = {
+ 		.ivsize			= AES_BLOCK_SIZE,
+ 		.init			= mxs_dcp_aes_fallback_init_tfm,
+ 		.exit			= mxs_dcp_aes_fallback_exit_tfm,
++	}, {
++		.base.cra_name		= "ecb(paes)",
++		.base.cra_driver_name	= "ecb-paes-dcp",
++		.base.cra_priority	= 401,
++		.base.cra_alignmask	= 15,
++		.base.cra_flags		= CRYPTO_ALG_ASYNC | CRYPTO_ALG_INTERNAL,
++		.base.cra_blocksize	= AES_BLOCK_SIZE,
++		.base.cra_ctxsize	= sizeof(struct dcp_async_ctx),
++		.base.cra_module	= THIS_MODULE,
++
++		.min_keysize		= DCP_PAES_KEYSIZE,
++		.max_keysize		= DCP_PAES_KEYSIZE,
++		.setkey			= mxs_dcp_aes_setrefkey,
++		.encrypt		= mxs_dcp_aes_ecb_encrypt,
++		.decrypt		= mxs_dcp_aes_ecb_decrypt,
++		.init			= mxs_dcp_paes_init_tfm,
++	}, {
++		.base.cra_name		= "cbc(paes)",
++		.base.cra_driver_name	= "cbc-paes-dcp",
++		.base.cra_priority	= 401,
++		.base.cra_alignmask	= 15,
++		.base.cra_flags		= CRYPTO_ALG_ASYNC | CRYPTO_ALG_INTERNAL,
++		.base.cra_blocksize	= AES_BLOCK_SIZE,
++		.base.cra_ctxsize	= sizeof(struct dcp_async_ctx),
++		.base.cra_module	= THIS_MODULE,
++
++		.min_keysize		= DCP_PAES_KEYSIZE,
++		.max_keysize		= DCP_PAES_KEYSIZE,
++		.setkey			= mxs_dcp_aes_setrefkey,
++		.encrypt		= mxs_dcp_aes_cbc_encrypt,
++		.decrypt		= mxs_dcp_aes_cbc_decrypt,
++		.ivsize			= AES_BLOCK_SIZE,
++		.init			= mxs_dcp_paes_init_tfm,
+ 	},
+ };
+ 
+diff --git a/include/soc/fsl/dcp.h b/include/soc/fsl/dcp.h
+new file mode 100644
+index 00000000000000..3ec335d8ca8b7a
+--- /dev/null
++++ b/include/soc/fsl/dcp.h
+@@ -0,0 +1,20 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (C) 2021 sigma star gmbh
++ *
++ * Specifies paes key slot handles for NXP's DCP (Data Co-Processor) to be used
++ * with the crypto_skcipher_setkey().
++ */
++
++#ifndef MXS_DCP_H
++#define MXS_DCP_H
++
++#define DCP_PAES_KEYSIZE 1
++#define DCP_PAES_KEY_SLOT0 0x00
++#define DCP_PAES_KEY_SLOT1 0x01
++#define DCP_PAES_KEY_SLOT2 0x02
++#define DCP_PAES_KEY_SLOT3 0x03
++#define DCP_PAES_KEY_UNIQUE 0xfe
++#define DCP_PAES_KEY_OTP 0xff
++
++#endif /* MXS_DCP_H */

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0003-KEYS-trusted-Introduce-NXP-DCP-backed-trusted-keys.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0003-KEYS-trusted-Introduce-NXP-DCP-backed-trusted-keys.patch
@@ -1,0 +1,457 @@
+From 2e8a0f40a39cc253002f21c54e1b5b995e5ec510 Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Wed, 3 Apr 2024 09:21:19 +0200
+Subject: [PATCH] KEYS: trusted: Introduce NXP DCP-backed trusted keys
+
+DCP (Data Co-Processor) is the little brother of NXP's CAAM IP.
+Beside of accelerated crypto operations, it also offers support for
+hardware-bound keys. Using this feature it is possible to implement a blob
+mechanism similar to what CAAM offers. Unlike on CAAM, constructing and
+parsing the blob has to happen in software (i.e. the kernel).
+
+The software-based blob format used by DCP trusted keys encrypts
+the payload using AES-128-GCM with a freshly generated random key and nonce.
+The random key itself is AES-128-ECB encrypted using the DCP unique
+or OTP key.
+
+The DCP trusted key blob format is:
+/*
+ * struct dcp_blob_fmt - DCP BLOB format.
+ *
+ * @fmt_version: Format version, currently being %1
+ * @blob_key: Random AES 128 key which is used to encrypt @payload,
+ *            @blob_key itself is encrypted with OTP or UNIQUE device key in
+ *            AES-128-ECB mode by DCP.
+ * @nonce: Random nonce used for @payload encryption.
+ * @payload_len: Length of the plain text @payload.
+ * @payload: The payload itself, encrypted using AES-128-GCM and @blob_key,
+ *           GCM auth tag of size AES_BLOCK_SIZE is attached at the end of it.
+ *
+ * The total size of a DCP BLOB is sizeof(struct dcp_blob_fmt) + @payload_len +
+ * AES_BLOCK_SIZE.
+ */
+struct dcp_blob_fmt {
+	__u8 fmt_version;
+	__u8 blob_key[AES_KEYSIZE_128];
+	__u8 nonce[AES_KEYSIZE_128];
+	__le32 payload_len;
+	__u8 payload[];
+} __packed;
+
+By default the unique key is used. It is also possible to use the
+OTP key. While the unique key should be unique it is not documented how
+this key is derived. Therefore selection the OTP key is supported as
+well via the use_otp_key module parameter.
+
+Co-developed-by: Richard Weinberger <richard@nod.at>
+Signed-off-by: Richard Weinberger <richard@nod.at>
+Co-developed-by: David Oberhollenzer <david.oberhollenzer@sigma-star.at>
+Signed-off-by: David Oberhollenzer <david.oberhollenzer@sigma-star.at>
+Signed-off-by: David Gstir <david@sigma-star.at>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ include/keys/trusted_dcp.h                |  11 +
+ security/keys/trusted-keys/Kconfig        |   8 +
+ security/keys/trusted-keys/Makefile       |   2 +
+ security/keys/trusted-keys/trusted_core.c |   6 +-
+ security/keys/trusted-keys/trusted_dcp.c  | 313 ++++++++++++++++++++++
+ 5 files changed, 339 insertions(+), 1 deletion(-)
+ create mode 100644 include/keys/trusted_dcp.h
+ create mode 100644 security/keys/trusted-keys/trusted_dcp.c
+
+diff --git a/include/keys/trusted_dcp.h b/include/keys/trusted_dcp.h
+new file mode 100644
+index 00000000000000..9aaa42075b40e1
+--- /dev/null
++++ b/include/keys/trusted_dcp.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Copyright (C) 2021 sigma star gmbh
++ */
++
++#ifndef TRUSTED_DCP_H
++#define TRUSTED_DCP_H
++
++extern struct trusted_key_ops dcp_trusted_key_ops;
++
++#endif
+diff --git a/security/keys/trusted-keys/Kconfig b/security/keys/trusted-keys/Kconfig
+--- a/security/keys/trusted-keys/Kconfig
++++ b/security/keys/trusted-keys/Kconfig
+@@ -33,6 +33,13 @@ config TRUSTED_KEYS_CAAM
+ 	  Enable use of NXP's Cryptographic Accelerator and Assurance Module
+ 	  (CAAM) as trusted key backend.
+ 
++config TRUSTED_KEYS_DCP
++	bool "DCP-based trusted keys"
++	depends on CRYPTO_DEV_MXS_DCP >= TRUSTED_KEYS
++	default y
++	help
++	  Enable use of NXP's DCP (Data Co-Processor) as trusted key backend.
++
+-if !TRUSTED_KEYS_TPM && !TRUSTED_KEYS_TEE && !TRUSTED_KEYS_CAAM
++if !TRUSTED_KEYS_TPM && !TRUSTED_KEYS_TEE && !TRUSTED_KEYS_CAAM && !TRUSTED_KEYS_DCP
+ comment "No trust source selected!"
+ endif
+diff --git a/security/keys/trusted-keys/Makefile b/security/keys/trusted-keys/Makefile
+index 735aa0bc08efc2..f0f3b27f688bc8 100644
+--- a/security/keys/trusted-keys/Makefile
++++ b/security/keys/trusted-keys/Makefile
+@@ -14,3 +14,5 @@ trusted-$(CONFIG_TRUSTED_KEYS_TPM) += tpm2key.asn1.o
+ trusted-$(CONFIG_TRUSTED_KEYS_TEE) += trusted_tee.o
+ 
+ trusted-$(CONFIG_TRUSTED_KEYS_CAAM) += trusted_caam.o
++
++trusted-$(CONFIG_TRUSTED_KEYS_DCP) += trusted_dcp.o
+diff --git a/security/keys/trusted-keys/trusted_core.c b/security/keys/trusted-keys/trusted_core.c
+index fee1ab2c734d32..5113aeae56283c 100644
+--- a/security/keys/trusted-keys/trusted_core.c
++++ b/security/keys/trusted-keys/trusted_core.c
+@@ -10,6 +10,7 @@
+ #include <keys/trusted-type.h>
+ #include <keys/trusted_tee.h>
+ #include <keys/trusted_caam.h>
++#include <keys/trusted_dcp.h>
+ #include <keys/trusted_tpm.h>
+ #include <linux/capability.h>
+ #include <linux/err.h>
+@@ -30,7 +31,7 @@ MODULE_PARM_DESC(rng, "Select trusted key RNG");
+ 
+ static char *trusted_key_source;
+ module_param_named(source, trusted_key_source, charp, 0);
+-MODULE_PARM_DESC(source, "Select trusted keys source (tpm, tee or caam)");
++MODULE_PARM_DESC(source, "Select trusted keys source (tpm, tee, caam or dcp)");
+ 
+ static const struct trusted_key_source trusted_key_sources[] = {
+ #if defined(CONFIG_TRUSTED_KEYS_TPM)
+@@ -42,6 +43,9 @@ static const struct trusted_key_source trusted_key_sources[] = {
+ #if defined(CONFIG_TRUSTED_KEYS_CAAM)
+ 	{ "caam", &trusted_key_caam_ops },
+ #endif
++#if defined(CONFIG_TRUSTED_KEYS_DCP)
++	{ "dcp", &dcp_trusted_key_ops },
++#endif
+ };
+ 
+ DEFINE_STATIC_CALL_NULL(trusted_key_seal, *trusted_key_sources[0].ops->seal);
+diff --git a/security/keys/trusted-keys/trusted_dcp.c b/security/keys/trusted-keys/trusted_dcp.c
+new file mode 100644
+index 00000000000000..16c44aafeab319
+--- /dev/null
++++ b/security/keys/trusted-keys/trusted_dcp.c
+@@ -0,0 +1,313 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (C) 2021 sigma star gmbh
++ */
++
++#include <crypto/aead.h>
++#include <crypto/aes.h>
++#include <crypto/algapi.h>
++#include <crypto/gcm.h>
++#include <crypto/skcipher.h>
++#include <keys/trusted-type.h>
++#include <linux/key-type.h>
++#include <linux/module.h>
++#include <linux/printk.h>
++#include <linux/random.h>
++#include <linux/scatterlist.h>
++#include <soc/fsl/dcp.h>
++
++#define DCP_BLOB_VERSION 1
++#define DCP_BLOB_AUTHLEN 16
++
++/**
++ * struct dcp_blob_fmt - DCP BLOB format.
++ *
++ * @fmt_version: Format version, currently being %1.
++ * @blob_key: Random AES 128 key which is used to encrypt @payload,
++ *            @blob_key itself is encrypted with OTP or UNIQUE device key in
++ *            AES-128-ECB mode by DCP.
++ * @nonce: Random nonce used for @payload encryption.
++ * @payload_len: Length of the plain text @payload.
++ * @payload: The payload itself, encrypted using AES-128-GCM and @blob_key,
++ *           GCM auth tag of size DCP_BLOB_AUTHLEN is attached at the end of it.
++ *
++ * The total size of a DCP BLOB is sizeof(struct dcp_blob_fmt) + @payload_len +
++ * DCP_BLOB_AUTHLEN.
++ */
++struct dcp_blob_fmt {
++	__u8 fmt_version;
++	__u8 blob_key[AES_KEYSIZE_128];
++	__u8 nonce[AES_KEYSIZE_128];
++	__le32 payload_len;
++	__u8 payload[];
++} __packed;
++
++static bool use_otp_key;
++module_param_named(dcp_use_otp_key, use_otp_key, bool, 0);
++MODULE_PARM_DESC(dcp_use_otp_key, "Use OTP instead of UNIQUE key for sealing");
++
++static bool skip_zk_test;
++module_param_named(dcp_skip_zk_test, skip_zk_test, bool, 0);
++MODULE_PARM_DESC(dcp_skip_zk_test, "Don't test whether device keys are zero'ed");
++
++static unsigned int calc_blob_len(unsigned int payload_len)
++{
++	return sizeof(struct dcp_blob_fmt) + payload_len + DCP_BLOB_AUTHLEN;
++}
++
++static int do_dcp_crypto(u8 *in, u8 *out, bool do_encrypt)
++{
++	struct skcipher_request *req = NULL;
++	struct scatterlist src_sg, dst_sg;
++	struct crypto_skcipher *tfm;
++	u8 paes_key[DCP_PAES_KEYSIZE];
++	DECLARE_CRYPTO_WAIT(wait);
++	int res = 0;
++
++	if (use_otp_key)
++		paes_key[0] = DCP_PAES_KEY_OTP;
++	else
++		paes_key[0] = DCP_PAES_KEY_UNIQUE;
++
++	tfm = crypto_alloc_skcipher("ecb-paes-dcp", CRYPTO_ALG_INTERNAL,
++				    CRYPTO_ALG_INTERNAL);
++	if (IS_ERR(tfm)) {
++		res = PTR_ERR(tfm);
++		tfm = NULL;
++		goto out;
++	}
++
++	req = skcipher_request_alloc(tfm, GFP_NOFS);
++	if (!req) {
++		res = -ENOMEM;
++		goto out;
++	}
++
++	skcipher_request_set_callback(req, CRYPTO_TFM_REQ_MAY_BACKLOG |
++				      CRYPTO_TFM_REQ_MAY_SLEEP,
++				      crypto_req_done, &wait);
++	res = crypto_skcipher_setkey(tfm, paes_key, sizeof(paes_key));
++	if (res < 0)
++		goto out;
++
++	sg_init_one(&src_sg, in, AES_KEYSIZE_128);
++	sg_init_one(&dst_sg, out, AES_KEYSIZE_128);
++	skcipher_request_set_crypt(req, &src_sg, &dst_sg, AES_KEYSIZE_128,
++				   NULL);
++
++	if (do_encrypt)
++		res = crypto_wait_req(crypto_skcipher_encrypt(req), &wait);
++	else
++		res = crypto_wait_req(crypto_skcipher_decrypt(req), &wait);
++
++out:
++	skcipher_request_free(req);
++	crypto_free_skcipher(tfm);
++
++	return res;
++}
++
++static int do_aead_crypto(u8 *in, u8 *out, size_t len, u8 *key, u8 *nonce,
++			  bool do_encrypt)
++{
++	struct aead_request *aead_req = NULL;
++	struct scatterlist src_sg, dst_sg;
++	struct crypto_aead *aead;
++	int ret;
++
++	aead = crypto_alloc_aead("gcm(aes)", 0, CRYPTO_ALG_ASYNC);
++	if (IS_ERR(aead)) {
++		ret = PTR_ERR(aead);
++		goto out;
++	}
++
++	ret = crypto_aead_setauthsize(aead, DCP_BLOB_AUTHLEN);
++	if (ret < 0) {
++		pr_err("Can't set crypto auth tag len: %d\n", ret);
++		goto free_aead;
++	}
++
++	aead_req = aead_request_alloc(aead, GFP_KERNEL);
++	if (!aead_req) {
++		ret = -ENOMEM;
++		goto free_aead;
++	}
++
++	sg_init_one(&src_sg, in, len);
++	if (do_encrypt) {
++		/*
++		 * If we encrypt our buffer has extra space for the auth tag.
++		 */
++		sg_init_one(&dst_sg, out, len + DCP_BLOB_AUTHLEN);
++	} else {
++		sg_init_one(&dst_sg, out, len);
++	}
++
++	aead_request_set_crypt(aead_req, &src_sg, &dst_sg, len, nonce);
++	aead_request_set_callback(aead_req, CRYPTO_TFM_REQ_MAY_SLEEP, NULL,
++				  NULL);
++	aead_request_set_ad(aead_req, 0);
++
++	if (crypto_aead_setkey(aead, key, AES_KEYSIZE_128)) {
++		pr_err("Can't set crypto AEAD key\n");
++		ret = -EINVAL;
++		goto free_req;
++	}
++
++	if (do_encrypt)
++		ret = crypto_aead_encrypt(aead_req);
++	else
++		ret = crypto_aead_decrypt(aead_req);
++
++free_req:
++	aead_request_free(aead_req);
++free_aead:
++	crypto_free_aead(aead);
++out:
++	return ret;
++}
++
++static int decrypt_blob_key(u8 *key)
++{
++	return do_dcp_crypto(key, key, false);
++}
++
++static int encrypt_blob_key(u8 *key)
++{
++	return do_dcp_crypto(key, key, true);
++}
++
++static int trusted_dcp_seal(struct trusted_key_payload *p, char *datablob)
++{
++	struct dcp_blob_fmt *b = (struct dcp_blob_fmt *)p->blob;
++	int blen, ret;
++
++	blen = calc_blob_len(p->key_len);
++	if (blen > MAX_BLOB_SIZE)
++		return -E2BIG;
++
++	b->fmt_version = DCP_BLOB_VERSION;
++	get_random_bytes(b->nonce, AES_KEYSIZE_128);
++	get_random_bytes(b->blob_key, AES_KEYSIZE_128);
++
++	ret = do_aead_crypto(p->key, b->payload, p->key_len, b->blob_key,
++			     b->nonce, true);
++	if (ret) {
++		pr_err("Unable to encrypt blob payload: %i\n", ret);
++		return ret;
++	}
++
++	ret = encrypt_blob_key(b->blob_key);
++	if (ret) {
++		pr_err("Unable to encrypt blob key: %i\n", ret);
++		return ret;
++	}
++
++	b->payload_len = get_unaligned_le32(&p->key_len);
++	p->blob_len = blen;
++	return 0;
++}
++
++static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
++{
++	struct dcp_blob_fmt *b = (struct dcp_blob_fmt *)p->blob;
++	int blen, ret;
++
++	if (b->fmt_version != DCP_BLOB_VERSION) {
++		pr_err("DCP blob has bad version: %i, expected %i\n",
++		       b->fmt_version, DCP_BLOB_VERSION);
++		ret = -EINVAL;
++		goto out;
++	}
++
++	p->key_len = le32_to_cpu(b->payload_len);
++	blen = calc_blob_len(p->key_len);
++	if (blen != p->blob_len) {
++		pr_err("DCP blob has bad length: %i != %i\n", blen,
++		       p->blob_len);
++		ret = -EINVAL;
++		goto out;
++	}
++
++	ret = decrypt_blob_key(b->blob_key);
++	if (ret) {
++		pr_err("Unable to decrypt blob key: %i\n", ret);
++		goto out;
++	}
++
++	ret = do_aead_crypto(b->payload, p->key, p->key_len + DCP_BLOB_AUTHLEN,
++			     b->blob_key, b->nonce, false);
++	if (ret) {
++		pr_err("Unwrap of DCP payload failed: %i\n", ret);
++		goto out;
++	}
++
++	ret = 0;
++out:
++	return ret;
++}
++
++static int test_for_zero_key(void)
++{
++	/*
++	 * Encrypting a plaintext of all 0x55 bytes will yield
++	 * this ciphertext in case the DCP test key is used.
++	 */
++	static const u8 bad[] = {0x9a, 0xda, 0xe0, 0x54, 0xf6, 0x3d, 0xfa, 0xff,
++				 0x5e, 0xa1, 0x8e, 0x45, 0xed, 0xf6, 0xea, 0x6f};
++	void *buf = NULL;
++	int ret = 0;
++
++	if (skip_zk_test)
++		goto out;
++
++	buf = kmalloc(AES_BLOCK_SIZE, GFP_KERNEL);
++	if (!buf) {
++		ret = -ENOMEM;
++		goto out;
++	}
++
++	memset(buf, 0x55, AES_BLOCK_SIZE);
++
++	ret = do_dcp_crypto(buf, buf, true);
++	if (ret)
++		goto out;
++
++	if (memcmp(buf, bad, AES_BLOCK_SIZE) == 0) {
++		pr_warn("Device neither in secure nor trusted mode!\n");
++		ret = -EINVAL;
++	}
++out:
++	kfree(buf);
++	return ret;
++}
++
++static int trusted_dcp_init(void)
++{
++	int ret;
++
++	if (use_otp_key)
++		pr_info("Using DCP OTP key\n");
++
++	ret = test_for_zero_key();
++	if (ret) {
++		pr_warn("Test for zero'ed keys failed: %i\n", ret);
++
++		return -EINVAL;
++	}
++
++	return register_key_type(&key_type_trusted);
++}
++
++static void trusted_dcp_exit(void)
++{
++	unregister_key_type(&key_type_trusted);
++}
++
++struct trusted_key_ops dcp_trusted_key_ops = {
++	.exit = trusted_dcp_exit,
++	.init = trusted_dcp_init,
++	.seal = trusted_dcp_seal,
++	.unseal = trusted_dcp_unseal,
++	.migratable = 0,
++};

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0004-crypto-mxs-dcp-Ensure-payload-is-zero-when-using-ke.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0004-crypto-mxs-dcp-Ensure-payload-is-zero-when-using-ke.patch
@@ -1,0 +1,36 @@
+From dd52b5eeb0f70893f762da7254e923fd23fd1379 Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Wed, 3 Jul 2024 14:49:58 +0200
+Subject: [PATCH] crypto: mxs-dcp - Ensure payload is zero when using key slot
+
+We could leak stack memory through the payload field when running
+AES with a key from one of the hardware's key slots. Fix this by
+ensuring the payload field is set to 0 in such cases.
+
+This does not affect the common use case when the key is supplied
+from main memory via the descriptor payload.
+
+Signed-off-by: David Gstir <david@sigma-star.at>
+Reported-by: kernel test robot <lkp@intel.com>
+Reported-by: Dan Carpenter <dan.carpenter@linaro.org>
+Closes: https://lore.kernel.org/r/202405270146.Y9tPoil8-lkp@intel.com/
+Fixes: 3d16af0b4cfa ("crypto: mxs-dcp: Add support for hardware-bound keys")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/mxs-dcp.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/crypto/mxs-dcp.c b/drivers/crypto/mxs-dcp.c
+index 057d73c370b735..c82775dbb557a7 100644
+--- a/drivers/crypto/mxs-dcp.c
++++ b/drivers/crypto/mxs-dcp.c
+@@ -225,7 +225,8 @@ static int mxs_dcp_start_dma(struct dcp_async_ctx *actx)
+ static int mxs_dcp_run_aes(struct dcp_async_ctx *actx,
+ 			   struct skcipher_request *req, int init)
+ {
+-	dma_addr_t key_phys, src_phys, dst_phys;
++	dma_addr_t key_phys = 0;
++	dma_addr_t src_phys, dst_phys;
+ 	struct dcp *sdcp = global_sdcp;
+ 	struct dcp_dma_desc *desc = &sdcp->coh->desc[actx->chan];
+ 	struct dcp_aes_req_ctx *rctx = skcipher_request_ctx(req);

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0005-KEYS-trusted-fix-DCP-blob-payload-length-assignment.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0005-KEYS-trusted-fix-DCP-blob-payload-length-assignment.patch
@@ -1,0 +1,36 @@
+From 6486cad00a8b7f8585983408c152bbe33dda529b Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Wed, 17 Jul 2024 13:28:44 +0200
+Subject: [PATCH] KEYS: trusted: fix DCP blob payload length assignment
+
+The DCP trusted key type uses the wrong helper function to store
+the blob's payload length which can lead to the wrong byte order
+being used in case this would ever run on big endian architectures.
+
+Fix by using correct helper function.
+
+Cc: stable@vger.kernel.org # v6.10+
+Fixes: 2e8a0f40a39c ("KEYS: trusted: Introduce NXP DCP-backed trusted keys")
+Suggested-by: Richard Weinberger <richard@nod.at>
+Reported-by: kernel test robot <lkp@intel.com>
+Closes: https://lore.kernel.org/oe-kbuild-all/202405240610.fj53EK0q-lkp@intel.com/
+Signed-off-by: David Gstir <david@sigma-star.at>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ security/keys/trusted-keys/trusted_dcp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/security/keys/trusted-keys/trusted_dcp.c b/security/keys/trusted-keys/trusted_dcp.c
+index b5f81a05be3676..b0947f072a98c8 100644
+--- a/security/keys/trusted-keys/trusted_dcp.c
++++ b/security/keys/trusted-keys/trusted_dcp.c
+@@ -222,7 +222,7 @@ static int trusted_dcp_seal(struct trusted_key_payload *p, char *datablob)
+ 		return ret;
+ 	}
+ 
+-	b->payload_len = get_unaligned_le32(&p->key_len);
++	put_unaligned_le32(p->key_len, &b->payload_len);
+ 	p->blob_len = blen;
+ 	return 0;
+ }

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0006-KEYS-trusted-dcp-fix-leak-of-blob-encryption-key.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0006-KEYS-trusted-dcp-fix-leak-of-blob-encryption-key.patch
@@ -1,0 +1,133 @@
+From 0e28bf61a5f9ab30be3f3b4eafb8d097e39446bb Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Wed, 17 Jul 2024 13:28:45 +0200
+Subject: [PATCH] KEYS: trusted: dcp: fix leak of blob encryption key
+
+Trusted keys unseal the key blob on load, but keep the sealed payload in
+the blob field so that every subsequent read (export) will simply
+convert this field to hex and send it to userspace.
+
+With DCP-based trusted keys, we decrypt the blob encryption key (BEK)
+in the Kernel due hardware limitations and then decrypt the blob payload.
+BEK decryption is done in-place which means that the trusted key blob
+field is modified and it consequently holds the BEK in plain text.
+Every subsequent read of that key thus send the plain text BEK instead
+of the encrypted BEK to userspace.
+
+This issue only occurs when importing a trusted DCP-based key and
+then exporting it again. This should rarely happen as the common use cases
+are to either create a new trusted key and export it, or import a key
+blob and then just use it without exporting it again.
+
+Fix this by performing BEK decryption and encryption in a dedicated
+buffer. Further always wipe the plain text BEK buffer to prevent leaking
+the key via uninitialized memory.
+
+Cc: stable@vger.kernel.org # v6.10+
+Fixes: 2e8a0f40a39c ("KEYS: trusted: Introduce NXP DCP-backed trusted keys")
+Signed-off-by: David Gstir <david@sigma-star.at>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ security/keys/trusted-keys/trusted_dcp.c | 33 +++++++++++++++---------
+ 1 file changed, 21 insertions(+), 12 deletions(-)
+
+diff --git a/security/keys/trusted-keys/trusted_dcp.c b/security/keys/trusted-keys/trusted_dcp.c
+index b0947f072a98c8..4edc5bbbcda3c9 100644
+--- a/security/keys/trusted-keys/trusted_dcp.c
++++ b/security/keys/trusted-keys/trusted_dcp.c
+@@ -186,20 +186,21 @@ static int do_aead_crypto(u8 *in, u8 *out, size_t len, u8 *key, u8 *nonce,
+ 	return ret;
+ }
+ 
+-static int decrypt_blob_key(u8 *key)
++static int decrypt_blob_key(u8 *encrypted_key, u8 *plain_key)
+ {
+-	return do_dcp_crypto(key, key, false);
++	return do_dcp_crypto(encrypted_key, plain_key, false);
+ }
+ 
+-static int encrypt_blob_key(u8 *key)
++static int encrypt_blob_key(u8 *plain_key, u8 *encrypted_key)
+ {
+-	return do_dcp_crypto(key, key, true);
++	return do_dcp_crypto(plain_key, encrypted_key, true);
+ }
+ 
+ static int trusted_dcp_seal(struct trusted_key_payload *p, char *datablob)
+ {
+ 	struct dcp_blob_fmt *b = (struct dcp_blob_fmt *)p->blob;
+ 	int blen, ret;
++	u8 plain_blob_key[AES_KEYSIZE_128];
+ 
+ 	blen = calc_blob_len(p->key_len);
+ 	if (blen > MAX_BLOB_SIZE)
+@@ -207,30 +208,36 @@ static int trusted_dcp_seal(struct trusted_key_payload *p, char *datablob)
+ 
+ 	b->fmt_version = DCP_BLOB_VERSION;
+ 	get_random_bytes(b->nonce, AES_KEYSIZE_128);
+-	get_random_bytes(b->blob_key, AES_KEYSIZE_128);
++	get_random_bytes(plain_blob_key, AES_KEYSIZE_128);
+ 
+-	ret = do_aead_crypto(p->key, b->payload, p->key_len, b->blob_key,
++	ret = do_aead_crypto(p->key, b->payload, p->key_len, plain_blob_key,
+ 			     b->nonce, true);
+ 	if (ret) {
+ 		pr_err("Unable to encrypt blob payload: %i\n", ret);
+-		return ret;
++		goto out;
+ 	}
+ 
+-	ret = encrypt_blob_key(b->blob_key);
++	ret = encrypt_blob_key(plain_blob_key, b->blob_key);
+ 	if (ret) {
+ 		pr_err("Unable to encrypt blob key: %i\n", ret);
+-		return ret;
++		goto out;
+ 	}
+ 
+ 	put_unaligned_le32(p->key_len, &b->payload_len);
+ 	p->blob_len = blen;
+-	return 0;
++	ret = 0;
++
++out:
++	memzero_explicit(plain_blob_key, sizeof(plain_blob_key));
++
++	return ret;
+ }
+ 
+ static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
+ {
+ 	struct dcp_blob_fmt *b = (struct dcp_blob_fmt *)p->blob;
+ 	int blen, ret;
++	u8 plain_blob_key[AES_KEYSIZE_128];
+ 
+ 	if (b->fmt_version != DCP_BLOB_VERSION) {
+ 		pr_err("DCP blob has bad version: %i, expected %i\n",
+@@ -248,14 +255,14 @@ static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
+ 		goto out;
+ 	}
+ 
+-	ret = decrypt_blob_key(b->blob_key);
++	ret = decrypt_blob_key(b->blob_key, plain_blob_key);
+ 	if (ret) {
+ 		pr_err("Unable to decrypt blob key: %i\n", ret);
+ 		goto out;
+ 	}
+ 
+ 	ret = do_aead_crypto(b->payload, p->key, p->key_len + DCP_BLOB_AUTHLEN,
+-			     b->blob_key, b->nonce, false);
++			     plain_blob_key, b->nonce, false);
+ 	if (ret) {
+ 		pr_err("Unwrap of DCP payload failed: %i\n", ret);
+ 		goto out;
+@@ -263,6 +270,8 @@ static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
+ 
+ 	ret = 0;
+ out:
++	memzero_explicit(plain_blob_key, sizeof(plain_blob_key));
++
+ 	return ret;
+ }
+ 

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0007-KEYS-trusted-dcp-fix-NULL-dereference-in-AEAD-crypt.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0007-KEYS-trusted-dcp-fix-NULL-dereference-in-AEAD-crypt.patch
@@ -1,0 +1,62 @@
+From 04de7589e0a95167d803ecadd115235ba2c14997 Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Tue, 29 Oct 2024 12:34:01 +0100
+Subject: [PATCH] KEYS: trusted: dcp: fix NULL dereference in AEAD crypto
+ operation
+
+When sealing or unsealing a key blob we currently do not wait for
+the AEAD cipher operation to finish and simply return after submitting
+the request. If there is some load on the system we can exit before
+the cipher operation is done and the buffer we read from/write to
+is already removed from the stack. This will e.g. result in NULL
+pointer dereference errors in the DCP driver during blob creation.
+
+Fix this by waiting for the AEAD cipher operation to finish before
+resuming the seal and unseal calls.
+
+Cc: stable@vger.kernel.org # v6.10+
+Fixes: 0e28bf61a5f9 ("KEYS: trusted: dcp: fix leak of blob encryption key")
+Reported-by: Parthiban N <parthiban@linumiz.com>
+Closes: https://lore.kernel.org/keyrings/254d3bb1-6dbc-48b4-9c08-77df04baee2f@linumiz.com/
+Signed-off-by: David Gstir <david@sigma-star.at>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ security/keys/trusted-keys/trusted_dcp.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/security/keys/trusted-keys/trusted_dcp.c b/security/keys/trusted-keys/trusted_dcp.c
+index 4edc5bbbcda3c9..e908c53a803c4b 100644
+--- a/security/keys/trusted-keys/trusted_dcp.c
++++ b/security/keys/trusted-keys/trusted_dcp.c
+@@ -133,6 +133,7 @@ static int do_aead_crypto(u8 *in, u8 *out, size_t len, u8 *key, u8 *nonce,
+ 	struct scatterlist src_sg, dst_sg;
+ 	struct crypto_aead *aead;
+ 	int ret;
++	DECLARE_CRYPTO_WAIT(wait);
+ 
+ 	aead = crypto_alloc_aead("gcm(aes)", 0, CRYPTO_ALG_ASYNC);
+ 	if (IS_ERR(aead)) {
+@@ -163,8 +164,8 @@ static int do_aead_crypto(u8 *in, u8 *out, size_t len, u8 *key, u8 *nonce,
+ 	}
+ 
+ 	aead_request_set_crypt(aead_req, &src_sg, &dst_sg, len, nonce);
+-	aead_request_set_callback(aead_req, CRYPTO_TFM_REQ_MAY_SLEEP, NULL,
+-				  NULL);
++	aead_request_set_callback(aead_req, CRYPTO_TFM_REQ_MAY_SLEEP,
++				  crypto_req_done, &wait);
+ 	aead_request_set_ad(aead_req, 0);
+ 
+ 	if (crypto_aead_setkey(aead, key, AES_KEYSIZE_128)) {
+@@ -174,9 +175,9 @@ static int do_aead_crypto(u8 *in, u8 *out, size_t len, u8 *key, u8 *nonce,
+ 	}
+ 
+ 	if (do_encrypt)
+-		ret = crypto_aead_encrypt(aead_req);
++		ret = crypto_wait_req(crypto_aead_encrypt(aead_req), &wait);
+ 	else
+-		ret = crypto_aead_decrypt(aead_req);
++		ret = crypto_wait_req(crypto_aead_decrypt(aead_req), &wait);
+ 
+ free_req:
+ 	aead_request_free(aead_req);

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0008-KEYS-trusted-dcp-fix-improper-sg-use-with-CONFIG_VM.patch
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/files/0008-KEYS-trusted-dcp-fix-improper-sg-use-with-CONFIG_VM.patch
@@ -1,0 +1,89 @@
+From e8d9fab39d1f87b52932646b2f1e7877aa3fc0f4 Mon Sep 17 00:00:00 2001
+From: David Gstir <david@sigma-star.at>
+Date: Wed, 13 Nov 2024 22:27:54 +0100
+Subject: [PATCH] KEYS: trusted: dcp: fix improper sg use with
+ CONFIG_VMAP_STACK=y
+
+With vmalloc stack addresses enabled (CONFIG_VMAP_STACK=y) DCP trusted
+keys can crash during en- and decryption of the blob encryption key via
+the DCP crypto driver. This is caused by improperly using sg_init_one()
+with vmalloc'd stack buffers (plain_key_blob).
+
+Fix this by always using kmalloc() for buffers we give to the DCP crypto
+driver.
+
+Cc: stable@vger.kernel.org # v6.10+
+Fixes: 0e28bf61a5f9 ("KEYS: trusted: dcp: fix leak of blob encryption key")
+Signed-off-by: David Gstir <david@sigma-star.at>
+Reviewed-by: Jarkko Sakkinen <jarkko@kernel.org>
+Signed-off-by: Jarkko Sakkinen <jarkko@kernel.org>
+---
+ security/keys/trusted-keys/trusted_dcp.c | 22 ++++++++++++++++++----
+ 1 file changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/security/keys/trusted-keys/trusted_dcp.c b/security/keys/trusted-keys/trusted_dcp.c
+index e908c53a803c4b..7b6eb655df0cbf 100644
+--- a/security/keys/trusted-keys/trusted_dcp.c
++++ b/security/keys/trusted-keys/trusted_dcp.c
+@@ -201,12 +201,16 @@ static int trusted_dcp_seal(struct trusted_key_payload *p, char *datablob)
+ {
+ 	struct dcp_blob_fmt *b = (struct dcp_blob_fmt *)p->blob;
+ 	int blen, ret;
+-	u8 plain_blob_key[AES_KEYSIZE_128];
++	u8 *plain_blob_key;
+ 
+ 	blen = calc_blob_len(p->key_len);
+ 	if (blen > MAX_BLOB_SIZE)
+ 		return -E2BIG;
+ 
++	plain_blob_key = kmalloc(AES_KEYSIZE_128, GFP_KERNEL);
++	if (!plain_blob_key)
++		return -ENOMEM;
++
+ 	b->fmt_version = DCP_BLOB_VERSION;
+ 	get_random_bytes(b->nonce, AES_KEYSIZE_128);
+ 	get_random_bytes(plain_blob_key, AES_KEYSIZE_128);
+@@ -229,7 +233,8 @@ static int trusted_dcp_seal(struct trusted_key_payload *p, char *datablob)
+ 	ret = 0;
+ 
+ out:
+-	memzero_explicit(plain_blob_key, sizeof(plain_blob_key));
++	memzero_explicit(plain_blob_key, AES_KEYSIZE_128);
++	kfree(plain_blob_key);
+ 
+ 	return ret;
+ }
+@@ -238,7 +243,7 @@ static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
+ {
+ 	struct dcp_blob_fmt *b = (struct dcp_blob_fmt *)p->blob;
+ 	int blen, ret;
+-	u8 plain_blob_key[AES_KEYSIZE_128];
++	u8 *plain_blob_key = NULL;
+ 
+ 	if (b->fmt_version != DCP_BLOB_VERSION) {
+ 		pr_err("DCP blob has bad version: %i, expected %i\n",
+@@ -256,6 +261,12 @@ static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
+ 		goto out;
+ 	}
+ 
++	plain_blob_key = kmalloc(AES_KEYSIZE_128, GFP_KERNEL);
++	if (!plain_blob_key) {
++		ret = -ENOMEM;
++		goto out;
++	}
++
+ 	ret = decrypt_blob_key(b->blob_key, plain_blob_key);
+ 	if (ret) {
+ 		pr_err("Unable to decrypt blob key: %i\n", ret);
+@@ -271,7 +282,10 @@ static int trusted_dcp_unseal(struct trusted_key_payload *p, char *datablob)
+ 
+ 	ret = 0;
+ out:
+-	memzero_explicit(plain_blob_key, sizeof(plain_blob_key));
++	if (plain_blob_key) {
++		memzero_explicit(plain_blob_key, AES_KEYSIZE_128);
++		kfree(plain_blob_key);
++	}
+ 
+ 	return ret;
+ }

--- a/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/linux-%.bbappend
+++ b/dynamic-layers/meta-toradex-bsp-common/recipes-kernel/linux/linux-%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:colibri-imx6ull = " \
+	${@bb.utils.contains('PANTAVISOR_FEATURES', 'dcp', 'file://0001-ARM-dts-imx6ull-colibri-enable-dcp.patch file://0002-crypto-mxs-dcp-Add-support-for-hardware-bound-keys.patch file://0003-KEYS-trusted-Introduce-NXP-DCP-backed-trusted-keys.patch file://0004-crypto-mxs-dcp-Ensure-payload-is-zero-when-using-ke.patch file://0005-KEYS-trusted-fix-DCP-blob-payload-length-assignment.patch file://0006-KEYS-trusted-dcp-fix-leak-of-blob-encryption-key.patch file://0007-KEYS-trusted-dcp-fix-NULL-dereference-in-AEAD-crypt.patch file://0008-KEYS-trusted-dcp-fix-improper-sg-use-with-CONFIG_VM.patch', '', d) if bb.utils.contains('PROVIDES', 'virtual/kernel', True, False, d) else ''} \
+"

--- a/kas/build-configs/release/colibri-imx6ull-scarthgap.yaml
+++ b/kas/build-configs/release/colibri-imx6ull-scarthgap.yaml
@@ -87,6 +87,27 @@ local_conf_header:
         IMAGE_FSTYPES:remove = "teziimg"
         IMAGE_FSTYPES:pn-pantavisor-starter:append = " ubifs"
         MKUBIFS_ARGS = "-m 2048 -e 126976 -c 4096"
+        PV_BOOT_OEMARGS = "mtdparts=gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,512k(u-boot-env),-(ubi) ubi.mtd=ubi pv_storage.device=ubi0:boot pv_storage.fstype=ubifs"
+        # WiFi/BT (Colibri iMX6ULL WB): the default KERNEL_DEVICETREE order makes
+        # PV_UBOOT_AUTOFDT pick the non-WiFi imx6ull-colibri-aster.dtb, which never
+        # enables usdhc2, so the Marvell SD8997 SDIO chip is not probed (mwifiex_sdio
+        # loads but binds nothing, no wlan0). Pin the WiFi device tree for the Aster
+        # carrier and disable autofdt so it isn't overridden by the first DTB.
+        # Other carriers: imx6ull-colibri-wifi-{eval-v3,iris,iris-v2}.dtb
+        # NB: use a :colibri-imx6ull override to disable autofdt — a plain
+        # PV_UBOOT_AUTOFDT = "" loses to the platform-toradex "1" emitted later
+        # in local.conf; the machine override is applied at finalize and wins.
+        PV_INITIAL_DTB = "imx6ull-colibri-wifi-aster.dtb"
+        PV_UBOOT_AUTOFDT:colibri-imx6ull = ""
+        MACHINE_FEATURES:append = " wifi"
+        # 'dm-internal-secrets' uses the software 'dm-crypt-versatile' key type
+        # (pantavisor-default-skel device-disks.json) so it works on OPEN devices.
+        # Hardware-bound DCP needs a HAB-closed part: the mainline DCP trusted-key
+        # backend rejects the zeroed OTP key on open devices. To enable it on a
+        # secured device, set PANTAVISOR_FEATURES "dcp" (wires the DCP kernel
+        # backport patches + dcp.cfg + keyutils) and 'trusted.source=dcp' here,
+        # and switch the device-disks.json disk back to type dm-crypt-dcp.
+        PV_MACHINE_UBOOT_CONFIGS:colibri-imx6ull = "file://pv.colibri-imx6ull.cfg"
         UBOOT_CONFIG_BASENAME:colibri-imx6ull = "colibri-imx6ull"
         PANTAVISOR_MACHINE_FIRMWARE:pn-empty-image = "${MACHINE_FIRMWARE}"
         PV_FLASH_RECOVERY_MC = "tezi-recovery"

--- a/kas/machines/colibri-imx6ull.yaml
+++ b/kas/machines/colibri-imx6ull.yaml
@@ -14,6 +14,29 @@ local_conf_header:
         IMAGE_FSTYPES:remove = "teziimg"
         IMAGE_FSTYPES:pn-pantavisor-starter:append = " ubifs"
         MKUBIFS_ARGS = "-m 2048 -e 126976 -c 4096"
+        PV_BOOT_OEMARGS = "mtdparts=gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,512k(u-boot-env),-(ubi) ubi.mtd=ubi pv_storage.device=ubi0:boot pv_storage.fstype=ubifs"
+
+        # WiFi/BT (Colibri iMX6ULL WB): the default KERNEL_DEVICETREE order makes
+        # PV_UBOOT_AUTOFDT pick the non-WiFi imx6ull-colibri-aster.dtb, which never
+        # enables usdhc2, so the Marvell SD8997 SDIO chip is not probed (mwifiex_sdio
+        # loads but binds nothing, no wlan0). Pin the WiFi device tree for the Aster
+        # carrier and disable autofdt so it isn't overridden by the first DTB.
+        # Other carriers: imx6ull-colibri-wifi-{eval-v3,iris,iris-v2}.dtb
+        # NB: use a :colibri-imx6ull override to disable autofdt — a plain
+        # PV_UBOOT_AUTOFDT = "" loses to the platform-toradex "1" emitted later
+        # in local.conf; the machine override is applied at finalize and wins.
+        PV_INITIAL_DTB = "imx6ull-colibri-wifi-aster.dtb"
+        PV_UBOOT_AUTOFDT:colibri-imx6ull = ""
+        MACHINE_FEATURES:append = " wifi"
+
+        # 'dm-internal-secrets' uses the software 'dm-crypt-versatile' key type
+        # (pantavisor-default-skel device-disks.json) so it works on OPEN devices.
+        # Hardware-bound DCP needs a HAB-closed part: the mainline DCP trusted-key
+        # backend rejects the zeroed OTP key on open devices. To enable it on a
+        # secured device, set PANTAVISOR_FEATURES "dcp" (wires the DCP kernel
+        # backport patches + dcp.cfg + keyutils) and 'trusted.source=dcp' here,
+        # and switch the device-disks.json disk back to type dm-crypt-dcp.
+        PV_MACHINE_UBOOT_CONFIGS:colibri-imx6ull = "file://pv.colibri-imx6ull.cfg"
         UBOOT_CONFIG_BASENAME:colibri-imx6ull = "colibri-imx6ull"
         PANTAVISOR_MACHINE_FIRMWARE:pn-empty-image = "${MACHINE_FIRMWARE}"
         PV_FLASH_RECOVERY_MC = "tezi-recovery"

--- a/recipes-bsp/pv-flash/files/colibri-imx6ull/uuu.auto.in
+++ b/recipes-bsp/pv-flash/files/colibri-imx6ull/uuu.auto.in
@@ -15,6 +15,11 @@ FB: ucmd nand erase 0x80000 0x180000
 FB: ucmd nand write.trimffs 0x81100000 0x80000 ${filesize}
 FB: ucmd nand erase 0x200000 0x180000
 FB: ucmd nand write.trimffs 0x81100000 0x200000 ${filesize}
+# Erase the u-boot-env partition (0x380000, 512KB) so U-Boot falls back to
+# its built-in default environment. The CONFIG_BOOTCOMMAND baked in by
+# pv.colibri-imx6ull.cfg mounts ubi0:boot and sources /boot/boot.scr; a
+# leftover env from a prior image would otherwise run a stale bootcmd.
+FB: ucmd nand erase 0x380000 0x80000
 # Write UBIFS rootfs to the ubi MTD partition
 FB: download -f @UBIFS@
 FB[-t 120000]: ucmd nand erase.part ubi

--- a/recipes-bsp/u-boot/files/boot.cmd.pvgeneric
+++ b/recipes-bsp/u-boot/files/boot.cmd.pvgeneric
@@ -9,6 +9,23 @@ if test -z "${devtype}"; then
 	setenv devtype mmc
 fi
 setenv envloadaddr ${loadaddr}
+
+# UBI/UBIFS (NAND) support: the sourcing bootcmd has run `ubi part /
+# ubifsmount ubi0:<vol>` and set devtype=ubi. A single UBIFS volume holds
+# the whole pantavisor rootfs, so the per-partition mmc load prefixes
+# collapse to ubifsload and the MBR-based OEM-config probe below is
+# skipped. ubifs paths are absolute, so files that live at the boot
+# partition root on mmc (oemEnv.txt, pv.env) need a leading slash; pv_root
+# supplies it for ubi and stays empty for mmc.
+setenv pv_is_ubi
+setenv pv_root
+if test "${devtype}" = "ubi"; then
+	setenv pv_is_ubi 1
+	setenv pv_root /
+	setenv pv_load_boot ubifsload
+	setenv pv_load_data ubifsload
+fi
+
 i
 pv_mmcdev=${devnum}
 if test -z "${pv_mmcdev}"; then
@@ -33,6 +50,10 @@ if test -z "${pv_bootpart}"; then
 	pv_bootpart=1
 fi
 
+if test "${pv_is_ubi}" != "1"; then
+	setenv pv_load_boot "load ${devtype} ${pv_mmcdev}:${pv_bootpart}"
+fi
+
 if test -z "${ramdisk_addr_r}"; then
 	ramdisk_addr_r=${initrd_addr}
 fi
@@ -50,39 +71,44 @@ if test -z "${fdt_addr_r}"; then
 fi
 
 echo Trying to load oemEnv.txt
-if load ${devtype} ${pv_mmcdev}:${pv_bootpart} ${envloadaddr} oemEnv.txt; then
+if ${pv_load_boot} ${envloadaddr} ${pv_root}oemEnv.txt; then
 	echo Importing oemEnv.txt ...
 	env import ${envloadaddr} ${filesize}
 fi
 
-echo part size ${devtype} ${pv_mmcdev} ${pv_ctrl} pv_config_size
-part size ${devtype} ${pv_mmcdev} ${pv_ctrl} pv_config_size
-if test "${pv_config_size}" = "800"; then
-	echo Found PV OEM Config at ${devtype} ${pv_mmcdev}:2
-	part start ${devtype} ${pv_mmcdev} ${pv_ctrl} pv_config_start
-	${devtype} read ${envloadaddr} ${pv_config_start} ${pv_config_size}
-	env import ${envloadaddr} 0x1000
-	setexpr pv_mmcdata ${pv_ctrl} + 1
+if test "${pv_is_ubi}" = "1"; then
+	echo UBI: single ubifs volume, skipping MBR OEM-config probe
 else
-	setexpr pv_mmcdata ${pv_bootpart} + 1
-	if part size ${devtype} ${pv_mmcdev} ${pv_mmcdata}; then
-		echo pv_mmcdata: ${pv_mmcdata}
+	echo part size ${devtype} ${pv_mmcdev} ${pv_ctrl} pv_config_size
+	part size ${devtype} ${pv_mmcdev} ${pv_ctrl} pv_config_size
+	if test "${pv_config_size}" = "800"; then
+		echo Found PV OEM Config at ${devtype} ${pv_mmcdev}:2
+		part start ${devtype} ${pv_mmcdev} ${pv_ctrl} pv_config_start
+		${devtype} read ${envloadaddr} ${pv_config_start} ${pv_config_size}
+		env import ${envloadaddr} 0x1000
+		setexpr pv_mmcdata ${pv_ctrl} + 1
 	else
-		echo pv_mmcdata: ${pv_bootpart}
-		setenv pv_mmcdata ${pv_bootpart}
+		setexpr pv_mmcdata ${pv_bootpart} + 1
+		if part size ${devtype} ${pv_mmcdev} ${pv_mmcdata}; then
+			echo pv_mmcdata: ${pv_mmcdata}
+		else
+			echo pv_mmcdata: ${pv_bootpart}
+			setenv pv_mmcdata ${pv_bootpart}
+		fi
 	fi
+	setenv pv_load_data "load ${devtype} ${pv_mmcdev}:${pv_mmcdata}"
 fi
 
 echo "${devtype} root selected = ${pv_mmcdev}:${pv_mmcdata}"
 
 echo Loading uboot.txt
-echo load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${envloadaddr} /boot/uboot.txt; setenv uboot_txt_size ${filesize}
-load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${envloadaddr} /boot/uboot.txt; setenv uboot_txt_size ${filesize}
+echo ${pv_load_data} ${envloadaddr} /boot/uboot.txt; setenv uboot_txt_size ${filesize}
+${pv_load_data} ${envloadaddr} /boot/uboot.txt; setenv uboot_txt_size ${filesize}
 
 echo Loading pantavisor uboot.txt
 setenv pv_try; env import ${envloadaddr} ${uboot_txt_size}
 
-load ${devtype} ${pv_mmcdev}:${pv_bootpart} ${envloadaddr} pv.env; setenv pv_env_size ${filesize}
+${pv_load_boot} ${envloadaddr} ${pv_root}pv.env; setenv pv_env_size ${filesize}
 echo Loading pv.env
 setenv pv_trying; env import ${envloadaddr} ${pv_env_size}
 
@@ -92,13 +118,13 @@ if env exists pv_try; then
 		echo Pantavisor boots checkpoint revision ${pv_rev} after failed try-boot of revision: ${pv_try}
 		setenv pv_trying
 		env export ${envloadaddr} pv_trying; setenv pv_env_size ${filesize};
-		save ${devtype} ${pv_mmcdev}:${pv_bootpart} ${envloadaddr} pv.env ${pv_env_size}
+		if test "${pv_is_ubi}" != "1"; then save ${devtype} ${pv_mmcdev}:${pv_bootpart} ${envloadaddr} pv.env ${pv_env_size}; fi
 		setenv boot_rev ${pv_rev}
 	else
 		echo Pantavisor boots try-boot revision: ${pv_try}
 		setenv pv_trying ${pv_try}
 		env export ${envloadaddr} pv_trying; setenv pv_env_size ${filesize};
-		save ${devtype} ${pv_mmcdev}:${pv_bootpart} ${envloadaddr} pv.env ${pv_env_size}
+		if test "${pv_is_ubi}" != "1"; then save ${devtype} ${pv_mmcdev}:${pv_bootpart} ${envloadaddr} pv.env ${pv_env_size}; fi
 		setenv boot_rev ${pv_trying}
 	fi
 else
@@ -106,13 +132,13 @@ else
 	setenv boot_rev ${pv_rev}
 fi
 
-echo "Trying to load fit: load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${addr_fit} /trails/${boot_rev}/bsp/pantavisor.fit"
+echo "Trying to load fit: ${pv_load_data} ${addr_fit} /trails/${boot_rev}/bsp/pantavisor.fit"
 
 if test -z "${fdtfile}"; then
 	setenv fdtfile ${fdt_file}
 fi
 
-if test -n "${addr_fit}" && load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${addr_fit} /trails/${boot_rev}/bsp/pantavisor.fit; then
+if test -n "${addr_fit}" && ${pv_load_data} ${addr_fit} /trails/${boot_rev}/bsp/pantavisor.fit; then
 	echo Successfully loaded pantavisor.fit. booting...
 	iminfo ${addr_fit}
 	# first allow platforms to do their job to set name_fit_config
@@ -151,8 +177,8 @@ if test -z "${kernel_addr_r}"; then
 	kernel_addr_r=${loadaddr}
 fi
 
-echo Pantavisor kernel load: load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${kernel_addr_r} /trails/${boot_rev}/.pv/pv-kernel.img
-load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${kernel_addr_r} /trails/${boot_rev}/.pv/pv-kernel.img
+echo Pantavisor kernel load: ${pv_load_data} ${kernel_addr_r} /trails/${boot_rev}/.pv/pv-kernel.img
+${pv_load_data} ${kernel_addr_r} /trails/${boot_rev}/.pv/pv-kernel.img
 
 if test -z "${ramdisk_addr_r}"; then
         setexpr fsmod ${filesize} % 512
@@ -163,8 +189,8 @@ if test -z "${ramdisk_addr_r}"; then
 	echo "cannot find place to load ramdisk in ramdisk_addr_r ... auto calculated ${ramdisk_addr_r}"
 fi
 
-echo Pantavisor initrd load: load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${ramdisk_addr_r} /trails/${boot_rev}/.pv/pv-initrd.img
-load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${ramdisk_addr_r} /trails/${boot_rev}/.pv/pv-initrd.img
+echo Pantavisor initrd load: ${pv_load_data} ${ramdisk_addr_r} /trails/${boot_rev}/.pv/pv-initrd.img
+${pv_load_data} ${ramdisk_addr_r} /trails/${boot_rev}/.pv/pv-initrd.img
 
 setenv rd_size ${filesize}
 setexpr rd_offset ${ramdisk_addr_r} + ${rd_size}
@@ -184,11 +210,11 @@ echo "moving fdt to ${fdt_addr_r}"
 fdt move $fdtcontroladdr $fdt_addr_r $tsize
 
 echo "Pantavisor loading FDT at ${fdt_addr_r}"
-echo "load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${fdt_addr_r} /trails/${boot_rev}/.pv/pv-fdt.dtb"
-if load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${fdt_addr_r} /trails/${boot_rev}/.pv/pv-fdt.dtb; then
+echo "${pv_load_data} ${fdt_addr_r} /trails/${boot_rev}/.pv/pv-fdt.dtb"
+if ${pv_load_data} ${fdt_addr_r} /trails/${boot_rev}/.pv/pv-fdt.dtb; then
 	echo "Successfully loaded pv-fdt.dtb"
 else
-	if load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${fdt_addr_r} /trails/${boot_rev}/bsp/${fdtfile}; then
+	if ${pv_load_data} ${fdt_addr_r} /trails/${boot_rev}/bsp/${fdtfile}; then
 		echo "successfully loaded fdt directly"
 	else
 		echo "failed to load fdt trying to copy fdt_addr_r for booting ..."
@@ -203,8 +229,8 @@ if test -n "${fdt_addr_r}"; then
 fi
 
 setenv i 0
-while load ${devtype} ${pv_mmcdev}:${pv_mmcdata} ${rd_offset} /trails/${boot_rev}/.pv/pv-initrd.img.${i}; do
-	echo Pantavisor initrd addon loaded: load ${devtype} ${mmcdev}:${mmcdata} ${rd_offset} /trails/${boot_rev}/.pv/pv-initrd.img.${i}
+while ${pv_load_data} ${rd_offset} /trails/${boot_rev}/.pv/pv-initrd.img.${i}; do
+	echo Pantavisor initrd addon loaded: ${pv_load_data} ${rd_offset} /trails/${boot_rev}/.pv/pv-initrd.img.${i}
 	setexpr i ${i} + 1
 	setexpr rd_size ${rd_size} + ${filesize}
 	setexpr rd_offset ${rd_offset} + ${filesize}

--- a/recipes-bsp/u-boot/files/pv.colibri-imx6ull.cfg
+++ b/recipes-bsp/u-boot/files/pv.colibri-imx6ull.cfg
@@ -1,0 +1,19 @@
+# NAND/UBI boot for Pantavisor on Colibri iMX6ULL.
+#
+# Toradex's stock environment boots NAND via `ubiboot`, which expects raw
+# UBI volumes named `kernel`, `dtb` and a `rootfs` UBIFS volume. Pantavisor
+# instead keeps a single UBIFS `boot` volume that holds the full pantavisor
+# rootfs (trails, bsp FIT, boot.scr). Override the default bootcmd to mount
+# that volume and source the generic pantavisor boot script from it.
+#
+# This also overrides pv.distroboot.cfg's CONFIG_BOOTCOMMAND="run
+# distro_bootcmd" — on this board distro_bootcmd only scans MMC/USB/DHCP
+# (no UBI boot target), so it can never reach the NAND rootfs.
+#
+# merge_config.sh -m applies fragments in SRC_URI order; this machine
+# fragment is appended last (via PV_MACHINE_UBOOT_CONFIGS) so it wins.
+CONFIG_CMD_UBI=y
+CONFIG_CMD_UBIFS=y
+CONFIG_CMD_BOOTZ=y
+CONFIG_USE_BOOTCOMMAND=y
+CONFIG_BOOTCOMMAND="ubi part ubi && ubifsmount ubi0:boot && setenv devtype ubi && ubifsload ${scriptaddr} /boot/boot.scr && source ${scriptaddr}"

--- a/recipes-bsp/u-boot/u-boot%.bbappend
+++ b/recipes-bsp/u-boot/u-boot%.bbappend
@@ -5,6 +5,13 @@ OVERRIDES =. "mc-${BB_CURRENT_MC}:"
 PV_MACHINE_UBOOT_CONFIGS ?= ""
 PV_MACHINE_UBOOT_CONFIGS:qemumips ?= "file://pv.qemumips.cfg"
 
+# colibri-imx6ull is a NAND-only module in this layer; drop the unused "emmc"
+# UBOOT_CONFIG variant that tezi.conf adds ("rawnand emmc recoverytezi"). Its
+# colibri-imx6ull-emmc_defconfig has no MTD/UBI, so the CMD_UBIFS enabled by
+# pv.colibri-imx6ull.cfg fails to compile there. Scoped to the tezi-recovery
+# multiconfig (where tezi.conf sets UBOOT_CONFIG) via the mc override above.
+UBOOT_CONFIG:mc-tezi-recovery:colibri-imx6ull = "rawnand recoverytezi"
+
 PV_BOOT_OEMARGS ?= ""
 
 SRC_URI += " \

--- a/recipes-kernel/linux/files/dcp.cfg
+++ b/recipes-kernel/linux/files/dcp.cfg
@@ -1,0 +1,13 @@
+# i.MX6UL/6ULL/7 DCP (Data Co-Processor) crypto engine + mainline
+# DCP-backed trusted-key subsystem.
+#
+# Built-in (not modules) so the DCP engine and its trusted-key backend
+# are available at init time, before pantavisor mounts the dm-crypt
+# 'dm-internal-secrets' volume in mainline mode.
+#
+# DM_CRYPT, TRUSTED_KEYS, ENCRYPTED_KEYS and the AES/CBC/SHA algorithms
+# come from dm.cfg; TRUSTED_KEYS_DCP is added by the DCP backport patches
+# in dynamic-layers/meta-toradex-bsp-common (gated on the same 'dcp'
+# feature), so this fragment only needs to switch the two DCP symbols on.
+CONFIG_CRYPTO_DEV_MXS_DCP=y
+CONFIG_TRUSTED_KEYS_DCP=y

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -39,6 +39,7 @@ PANTAVISOR_SRC_URI = " \
 	${TAILSCALE_KERNEL_SRC_URI} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', 'file://pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', 'file://caam-nxp.cfg', '', d)} \
+	${@bb.utils.contains('PANTAVISOR_FEATURES', 'dcp', 'file://dcp.cfg', '', d)} \
 "
 
 
@@ -50,6 +51,7 @@ PANTAVISOR_KERNEL_FRAGMENTS = " \
 	${TAILSCALE_KERNEL_FRAGMENT} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', '${WORKDIR}/pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', '${WORKDIR}/caam-nxp.cfg', '', d)} \
+	${@bb.utils.contains('PANTAVISOR_FEATURES', 'dcp', '${WORKDIR}/dcp.cfg', '', d)} \
 "
 
 SRC_URI:append = " \

--- a/recipes-pv/images/pantavisor-initramfs.bb
+++ b/recipes-pv/images/pantavisor-initramfs.bb
@@ -39,6 +39,9 @@ PACKAGE_INSTALL = "pantavisor \
 	${ROOTFS_BOOTSTRAP_INSTALL}"
 
 PACKAGE_INSTALL:append = " ${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', 'keyctl-caam keyutils', '', d)}"
+# DCP mainline dm-crypt uses keyctl trusted keys (no caam-keygen); keyutils
+# provides keyctl, run by scripts/volmount/crypt/crypt from the initramfs.
+PACKAGE_INSTALL:append = " ${@bb.utils.contains('PANTAVISOR_FEATURES', 'dcp', 'keyutils', '', d)}"
 
 IMAGE_TYPES_MASKED += " pvbspit pvrexportit"
 

--- a/recipes-pv/images/pantavisor-starter.bb
+++ b/recipes-pv/images/pantavisor-starter.bb
@@ -17,6 +17,12 @@ do_rootfs_boot_scr(){
 		mkdir -p ${IMAGE_ROOTFS}/boot
 		cp -f ${DEPLOY_DIR_IMAGE}/boot.scr ${IMAGE_ROOTFS}/boot/
 	fi
+	# boot.scr loads oemEnv.txt from the boot volume root; on UBIFS
+	# machines the image rootfs is that volume, so wic IMAGE_BOOT_FILES
+	# (pvroot-image.bbclass) never places it there
+	if [ -f "${DEPLOY_DIR_IMAGE}/oemEnv.txt" ]; then
+		cp -f ${DEPLOY_DIR_IMAGE}/oemEnv.txt ${IMAGE_ROOTFS}/
+	fi
 }
 
 

--- a/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/bsp/drivers.json
+++ b/recipes-pv/pantavisor/files/colibri-imx6ull/pantavisor-default-skel/bsp/drivers.json
@@ -7,15 +7,15 @@
             "bluetooth"
         ],
         "wifi": [
-            "mlan",
+            "mwifiex_sdio",
             "cfg80211"
         ],
         "wireguard": [
             "wireguard"
         ],
-		"rng": [
-			"imx-rng"
-		]
+        "rng": [
+            "imx-rng"
+        ]
     },
     "dtb:all": {}
 }

--- a/recipes-pv/pantavisor/files/pv-imx-dcp/device-disks.json
+++ b/recipes-pv/pantavisor/files/pv-imx-dcp/device-disks.json
@@ -2,10 +2,8 @@
     "disks": [
         {
             "name": "dm-internal-secrets",
-            "path": "/storage/dm-crypt-files/dm-internal-secrets-nxp/dcp.img,2,dcp_key-internal_secrets",
-            "migrate_keyblob": "no",
-            "mode": "nxp",
-            "type": "dm-crypt-dcp",
+            "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
+            "type": "dm-crypt-versatile",
             "aliases": ["dm-versatile"]
         }
     ]


### PR DESCRIPTION
## Summary

Pantavisor rebooted during init on colibri-imx6ull NAND boots:

```
[   11.053850] [pantavisor] 11 FATAL -- [mount-init]: (pv_mount_init:153) could not mount '(null)': I/O error
[   11.063973] [pantavisor] 11 FATAL -- [log]: (exit_error:123) rebooting system in 20 seconds
```

**Root cause:** the initramfs `pantavisor.config` carries the generic embedded defaults (`PV_STORAGE_DEVICE=LABEL=root`, `PV_STORAGE_FSTYPE=ext4`). On the NAND module there is no labeled block device — `get_blkid()` probes the only entry in `/proc/partitions` (`mtdblock0`, raw NAND, EIO on read — the repeated `I/O error, dev mtdblock0` bursts) until `PV_STORAGE_WAIT` expires and `pv_mount_init` fails fatally. Nothing in the boot chain attached UBI either: boot.scr's bootargs contain no `ubi.mtd=`, and pantavisor has no ubiattach support.

**Fix:** pass the storage config through the existing `PV_BOOT_OEMARGS` → `oemEnv.txt` → `${oemargs}` bootargs hook:

- `kas/machines/colibri-imx6ull.yaml` + the release build-config (which inlines its own copy of the platform block): set `PV_BOOT_OEMARGS = "ubi.mtd=ubi pv_storage.device=ubi0:boot pv_storage.fstype=ubifs"`. The kernel attaches the `ubi` MTD partition at boot (`CONFIG_MTD_UBI=y`), and pantavisor's `pv_` cmdline overrides take precedence over the baked-in config, resolving `ubi0:boot` to `/dev/ubi0_0` via `/sys/class/ubi`.
- `pantavisor-starter.bb`: copy the deployed `oemEnv.txt` into the image rootfs root. `pvroot-image.bbclass` only ships it via `IMAGE_BOOT_FILES` (wic boot partitions); on UBIFS machines the image rootfs *is* the boot volume boot.scr loads `oemEnv.txt` from.

**Known follow-up (separate issue):** boot.scr's `save ... pv.env` won't work on UBIFS (U-Boot's driver is read-only), so try-boot revision state needs its own solution on NAND (e.g. the `u-boot-env` MTD partition).

## Test plan

- [x] Full `pantavisor-starter` kas build for colibri-imx6ull passes (exit 0)
- [x] Deployed `oemEnv.txt` contains `oemargs=ubi.mtd=ubi pv_storage.device=ubi0:boot pv_storage.fstype=ubifs`
- [x] Starter UBIFS image contains `oemEnv.txt` at the volume root (verified in image binary)
- [ ] On-device boot test after UUU reflash of the `boot` volume