### PR TITLE
fix(verdin-imx8mm): add missing pv--firmware and network to device.json

### DIFF
--- a/recipes-pv/pantavisor/files/verdin-imx8mm/pantavisor-default-skel/device.json
+++ b/recipes-pv/pantavisor/files/verdin-imx8mm/pantavisor-default-skel/device.json
@@ -56,6 +56,20 @@
 		"pv--phconfig": {
 			"disk": "dm-internal-secrets",
 			"persistence": "permanent"
+		},
+		"pv--firmware": {
+			"persistence": "boot"
+		}
+	},
+	"network": {
+		"pools": {
+			"pvcnet": {
+				"type": "bridge",
+				"bridge": "lxcbr0",
+				"subnet": "10.0.3.0/24",
+				"gateway": "10.0.3.1",
+				"nat": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a boot rollback on verdin-imx8mm caused by the missing pv--firmware volume. Also adds the standard network bridge configuration.

## Test Plan
- Build the verdin-imx8mm image.
- Boot the image and verify that pv--firmware mounts successfully without errors in the boot logs.
- Ensure the state machine proceeds to STATE_RUNNING without rolling back.