### PR TITLE
ci: unify scheduled pvtest into single job

### DIFF
--- a/.github/workflows/schedule-pvtests.yaml
+++ b/.github/workflows/schedule-pvtests.yaml
@@ -16,16 +16,7 @@ jobs:
       sdk: 0
     secrets: inherit
 
-  local:
+  pvtests:
     needs: build-docker-x86_64-scarthgap
     uses: ./.github/workflows/call-pvtests.yaml
-    with:
-      test_path: local
-    secrets: inherit
-
-  remote:
-    needs: build-docker-x86_64-scarthgap
-    uses: ./.github/workflows/call-pvtests.yaml
-    with:
-      test_path: remote
     secrets: inherit


### PR DESCRIPTION
## Summary
- schedule-pvtests.yaml had two separate call-pvtests.yaml invocations (local/remote), wasting a second runner and applying inconsistent options (local got parallelism but no retry; remote got retry but no parallelism)
- Replacing with a single job that omits test_path, hitting call-pvtests.yaml's existing "run all" path which already applies both --retry 2 and -p 4

## Changes
- Remove `local` and `remote` jobs from schedule-pvtests.yaml
- Add single `pvtests` job with no test_path (runs all tests via call-pvtests.yaml)