### PR TITLE
pantavisor-starter: add pv-avahi container

### DIFF
--- a/recipes-pv/images/pantavisor-starter.bb
+++ b/recipes-pv/images/pantavisor-starter.bb
@@ -6,7 +6,7 @@ inherit image pvroot-image pantavisor-docs
 FILESPATH = "${@base_set_filespath(["${FILE_DIRNAME}/${BP}", \
         "${FILE_DIRNAME}/${BPN}", "${FILE_DIRNAME}/files"], d)}"
 
-PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pvwificonnect"
+PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pv-avahi pvwificonnect"
 
 PVROOT_IMAGE_BSP ?= "core-image-minimal"
 


### PR DESCRIPTION
## Summary

Adds the `pv-avahi` container to the starter image's core container set so mDNS/zeroconf (Avahi) service discovery is available out of the box.

The `PVROOT_CONTAINERS_CORE` list in `recipes-pv/images/pantavisor-starter.bb` now includes `pv-avahi` alongside the existing `pv-pvr-sdk`, `pv-alpine-connman`, and `pvwificonnect` containers.

```
-PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pvwificonnect"
+PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pv-avahi pvwificonnect"
```

## Test plan

- [ ] Build `pantavisor-starter` and confirm `pv-avahi` is included in the rootfs container set.
- [ ] Verify Avahi/mDNS service discovery works on a running starter image.