### PR TITLE
fix(manifest-audit): drop -DISTRO_CODENAME from reference name when unset

### DIFF
--- a/classes/pv-manifest-audit.bbclass
+++ b/classes/pv-manifest-audit.bbclass
@@ -48,7 +48,8 @@
 #       cd <layer>/files && patch < .../${IMAGE_NAME}.manifest.patch
 
 PV_MANIFEST_PREFIX ??= "${PN}"
-PV_MANIFEST_REFERENCE_NAME ??= "${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt"
+# DISTRO_CODENAME is optional — many distros leave it unset.
+PV_MANIFEST_REFERENCE_NAME ??= "${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}${@'-' + d.getVar('DISTRO_CODENAME') if d.getVar('DISTRO_CODENAME') else ''}.manifest.reference.txt"
 
 # Path prefixes (rootfs-relative, leading slash) whose entire subtree is
 # omitted from the manifest. Defaults cover package-manager state files

--- a/docs/how-to-build/manifest-audit.md
+++ b/docs/how-to-build/manifest-audit.md
@@ -172,7 +172,7 @@ trigger a `do_rootfs` rerun.
 | Variable                        | Default                                                                   | Purpose                                                                  |
 |---------------------------------|---------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | `PV_MANIFEST_PREFIX`            | `${PN}`                                                                   | Recipe-stable label embedded in the reference filename                   |
-| `PV_MANIFEST_REFERENCE_NAME`    | `${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt` | Basename of the reference fetched into `${WORKDIR}`         |
+| `PV_MANIFEST_REFERENCE_NAME`    | `${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}-${DISTRO_CODENAME}.manifest.reference.txt` (the `-${DISTRO_CODENAME}` segment is dropped when `DISTRO_CODENAME` is unset) | Basename of the reference fetched into `${WORKDIR}`         |
 | `PV_MANIFEST_EXCLUDES`          | (see above)                                                               | Rootfs-relative path prefixes to omit from the manifest                  |
 
 ## Inheriting the class


### PR DESCRIPTION
When `DISTRO_CODENAME` is unset (many distros leave it empty), the default `PV_MANIFEST_REFERENCE_NAME` produced a dangling separator:

```
…_distro-machine-.manifest.reference.txt
```

Append the `-${DISTRO_CODENAME}` segment only when the codename is set, so the basename becomes `…_distro-machine.manifest.reference.txt`. Behavior is unchanged when `DISTRO_CODENAME` is present.