### PR TITLE
docs: document pvwificonnect container and pantavisor-starter image

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,16 +1,20 @@
 ---
 title: "Examples"
-description: "Example containers demonstrating xconnect service mesh patterns in meta-pantavisor."
+description: "Feature and example containers shipped by meta-pantavisor — xconnect service mesh patterns and the pvwificonnect provisioning container."
 sidebar_position: 4
 ---
 
 # Examples
 
-Working example containers in `recipes-containers/pv-examples/` that demonstrate pv-xconnect service mesh patterns. Use these as reference implementations for your own app containers.
+Feature and example containers shipped by meta-pantavisor. The `pv-examples`
+containers in `recipes-containers/pv-examples/` demonstrate pv-xconnect service
+mesh patterns; use them as reference implementations for your own app
+containers. `pvwificonnect` is a core container documented here as a feature.
 
 ## Topics
 
 1. [xconnect Examples](xconnect-examples.md) — Unix socket, REST, D-Bus, DRM, and Wayland proxy patterns with provider/consumer container pairs
+2. [pvwificonnect](pvwificonnect.md) — WiFi provisioning container: access point, captive portal, tethering, and connection watcher
 
 ## Related
 

--- a/docs/examples/pvwificonnect.md
+++ b/docs/examples/pvwificonnect.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 2
+---
+# pvwificonnect — WiFi Provisioning Container
+
+`pvwificonnect` ships as a **core container** in the starter image
+(`PVROOT_CONTAINERS_CORE` in `recipes-pv/images/pantavisor-starter.bb`). It is a
+Go network-provisioning service ([gitlab.com/pantacor/pvwificonnect](https://gitlab.com/pantacor/pvwificonnect))
+that lets a headless device be joined to a WiFi network without a console: it
+brings up an access point / captive portal, can tether AP clients to an existing
+uplink, and watches connectivity so it can re-provision after a drop.
+
+## What it brings to the system
+
+| Feature | Description |
+|---------|-------------|
+| **Access point** | Broadcasts a setup SSID (default `pvwificonnect` / `1234567890`) so a phone/laptop can connect to the device. |
+| **Captive portal** | Redirects connecting clients to a web setup page (opt-in via `captive_portal`). |
+| **Internet tethering** | Shares the device's uplink (`eth0`, `wwan0`, …) to AP clients (opt-in via `tethering`). |
+| **Auto mode** | Picks portal vs. tethering automatically based on connectivity (`auto_mode`, on by default). |
+| **Connection watcher** | Background loop that re-triggers AP/tethering setup when connectivity is lost (`watcher`). |
+| **Pluggable backend** | Talks to the network stack over D-Bus (`org.pantacor.PvWificonnect`); adapts to whichever backend container is present. |
+
+It is built three ways in this layer:
+
+| Recipe | Produces |
+|--------|----------|
+| `recipes-containers/pantavisor/pvwificonnect_v1.7.0.bb` | The pvrexport container (this doc). |
+| `recipes-containers/pantavisor/pvwificonnect-app_v1.7.0.bb` | The `pvwificonnect` + `pvwificonnect-cli` binaries built from source. |
+| `recipes-containers/pantavisor/pv-pvwificonnect_v1.7.0.bb` | The prebuilt Docker-image variant. |
+
+## Network backend dependency
+
+`pvwificonnect` does not manage WiFi hardware itself — it drives a backend over
+the **host D-Bus** (imported via `os:/pvrun/dbus:/var/run/dbus`, see
+`args.json`). The starter image pairs it with the ConnMan backend:
+
+```bitbake
+PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pvwificonnect pv-avahi"
+```
+
+| Backend container | Stack | AP gateway IP |
+|-------------------|-------|---------------|
+| `pv-alpine-connman` (default here) | ConnMan tethering API + dnsmasq | `192.168.0.1` |
+| Debian / NetworkManager | NM "shared" connection profiles | `10.42.0.1` |
+
+If neither backend is running, the service waits at startup up to
+`wait_time_in_sec` for D-Bus readiness. The board must also have working WiFi
+firmware and a `wlanN` interface — see the board flashing guides
+(e.g. [Verdin iMX8MM](../how-to-install/boards/verdin-imx8mm.md),
+[Colibri iMX6ULL](../how-to-install/boards/colibri-imx6ull.md)) for enabling the
+WiFi DTB and firmware.
+
+## Configuration
+
+Runtime settings live in `/var/pvwificonnect/config.json` inside the container.
+The layer ships this overlay
+(`recipes-containers/pantavisor/pvwificonnect/pvwificonnect-config/var/pvwificonnect/config.json`):
+
+```json
+{
+    "ap": {
+        "ssid": "pvwificonnect",
+        "password": "1234567890"
+    },
+    "auto_mode": true,
+    "wait_time_in_sec": 60,
+    "watcher": true,
+    "watcher_interval": "1m"
+}
+```
+
+### config.json keys
+
+| Key | Meaning | Default |
+|-----|---------|---------|
+| `ap.ssid` | SSID broadcast by the access point | `pvwificonnect` |
+| `ap.password` | AP password | `1234567890` |
+| `network.ssid` / `network.password` | Pre-seed credentials for an existing network to join | unset |
+| `captive_portal` | Redirect AP clients to a web setup page | `false` |
+| `tethering` | Share the device uplink to AP clients | `false` |
+| `auto_mode` | Auto-select portal vs. tethering from connectivity | `true` |
+| `uplink_interface` | Preferred uplink (`eth0`, `wwan0`, …) | auto-detected |
+| `wait_time_in_sec` | D-Bus readiness timeout at startup | `60` |
+| `watcher` | Background connectivity monitor | `false` |
+| `watcher_interval` | Watcher check frequency (Go duration) | `1m` |
+| `watcher_max_retries` | Failures before the watcher backs off | `3` |
+
+> Change the default AP SSID/password before shipping a product image — the
+> `1234567890` default is for bring-up only.
+
+### Environment variables
+
+Set in the container's Docker config (`recipes-containers/pantavisor/pvwificonnect/config.json`):
+
+| Variable | Meaning | Default |
+|----------|---------|---------|
+| `PV_WIFI_CONNECT_WATCHER` | Enable the connection watcher | `false` |
+| `PV_WIFI_CONNECT_INTERVAL` | Watcher interval (Go duration) | `1m` |
+| `PV_WIFI_CONNECT_MAX_RETRIES` | Max consecutive watcher failures | `3` |
+
+### Container runtime args
+
+`args.json` grants the container the capabilities and group it needs:
+
+```json
+{
+    "PV_GROUP": "platform",
+    "PV_LXC_CAP_KEEP": [
+        "block_suspend", "wake_alarm", "sys_time",
+        "net_admin net_raw net_bind_service"
+    ],
+    "PV_RESTART_POLICY": "system",
+    "PV_VOLUME_IMPORTS": ["os:/pvrun/dbus:/var/run/dbus"]
+}
+```
+
+## Using it
+
+1. **Boot a device** running the starter image with both `pvwificonnect` and a
+   network backend (`pv-alpine-connman`). The service starts in the `platform`
+   group.
+2. **Join the setup AP** — from a phone/laptop connect to the `ap.ssid`
+   (default `pvwificonnect`, password `1234567890`). The backend hands out an
+   address on its gateway subnet (`192.168.0.x` for ConnMan).
+3. **Provision** — with `captive_portal` enabled, opening a browser redirects to
+   the setup page where you select the home network and enter credentials.
+   Alternatively, pre-seed `network.ssid`/`network.password` in `config.json` so
+   the device joins on first boot with no interaction.
+4. **Stay connected** — with `watcher` on, the service re-runs AP/tethering
+   setup whenever connectivity drops.
+
+The `pvwificonnect-cli` binary (installed to `/usr/bin` by `pvwificonnect-app`)
+is available inside the container for inspecting and driving the service over its
+D-Bus interface.
+
+## Building
+
+```bash
+./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+    --target pvwificonnect
+```
+
+Output: `build/tmp-scarthgap/deploy/images/<machine>/pvwificonnect.pvrexport.tgz`.
+Because it is in `PVROOT_CONTAINERS_CORE`, a full `pantavisor-starter` build
+already includes it.
+
+## Related
+
+- [Container Development](../how-to-build/container-development.md) — authoring and packaging containers
+- [pvwificonnect upstream](https://gitlab.com/pantacor/pvwificonnect) — service source and backend details

--- a/docs/overview/boot-flow.md
+++ b/docs/overview/boot-flow.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 5
+---
 # U-Boot Boot Flow
 
 How Pantavisor boots from U-Boot via the generic boot script

--- a/docs/overview/ci.md
+++ b/docs/overview/ci.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 ---
 # CI/CD Overview
 

--- a/docs/overview/images.md
+++ b/docs/overview/images.md
@@ -1,0 +1,145 @@
+---
+sidebar_position: 4
+---
+# Pantavisor Starter Image
+
+`pantavisor-starter` (`recipes-pv/images/pantavisor-starter.bb`) is the layer's
+top-level **deployable image**: a complete, bootable rootfs whose initial
+Pantavisor trail (`/trails/0`) is pre-populated with a working set of containers
+and the board's BSP. It is what you flash to get a device that boots Pantavisor
+and brings up a usable system out of the box.
+
+```bitbake
+inherit image pvroot-image pantavisor-docs
+
+PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pvwificonnect pv-avahi"
+PVROOT_IMAGE_BSP       ?= "core-image-minimal"
+```
+
+## What "starter" means
+
+Unlike a plain Yocto image (a package set in a rootfs), a pvroot image is a
+**Pantavisor state**. The rootfs is the `pantavisor-pvroot` skeleton, and the
+real payload is an initial signed trail under `/trails/0` assembled by mixing in
+container `pvrexport` bundles plus the BSP. The "starter" image is the opinionated
+default mix — enough to boot, get on the network, and be claimed/managed — as
+opposed to the bare [`pantavisor-remix`](#related-image-recipes) which ships only
+the SDK container.
+
+## What it ships
+
+The default trail is built from two variables (see
+[`pvroot-image.bbclass`](meta-pantavisor.md)):
+
+| Variable | Role | Default |
+|----------|------|---------|
+| `PVROOT_CONTAINERS_CORE` | Containers baked **into the initial trail** (`pvr deploy` into `/trails/0`) | `pv-pvr-sdk pv-alpine-connman pvwificonnect pv-avahi` |
+| `PVROOT_CONTAINERS` | Containers staged as **factory packages** (`factory-pkgs.d/`), installed on first boot | *(none)* |
+| `PVROOT_IMAGE_BSP` | Proto rootfs the BSP's modules/firmware come from | `core-image-minimal` |
+
+The core containers in the starter mix:
+
+| Container | Purpose |
+|-----------|---------|
+| `pv-pvr-sdk` | PVR SDK / local management container |
+| `pv-alpine-connman` | ConnMan network backend (the WiFi/networking stack) |
+| `pvwificonnect` | WiFi provisioning — AP, captive portal, tethering (see [pvwificonnect](../examples/pvwificonnect.md)) |
+| `pv-avahi` | mDNS/zeroconf service discovery |
+
+The `pantavisor-bsp` pvrexport (kernel, initramfs, DTBs, modules, firmware) is
+**always** mixed in, regardless of the container list — that is what makes the
+trail bootable on the target machine.
+
+## How the image is assembled
+
+The work happens in `pvroot-image.bbclass`'s `do_rootfs_pvroot` task (runs after
+`do_rootfs`, before `do_image`):
+
+1. **Skeleton trail** — `pvr checkout -c` lays down the device skeleton in
+   `/trails/0`, then `pvr sig add` / `add` / `commit` create the initial signed
+   revision.
+2. **Mix in containers** — for each `PVROOT_CONTAINERS_CORE` entry the matching
+   `*.pvrexport.tgz` from `DEPLOY_DIR_IMAGE` is unpacked and `pvr deploy`-ed into
+   the trail. `PVROOT_CONTAINERS` entries are instead copied into
+   `factory-pkgs.d/` to be applied on first boot.
+3. **Mix in the BSP** — `pantavisor-bsp-${MACHINE}.pvrexport.tgz` is always
+   deployed into the trail.
+4. **Sign** — the trail is signed with the developer CA
+   (`pv-developer-ca_${PVS_VENDOR_NAME}`), so unsigned/tampered states are
+   rejected at boot.
+5. **Boot glue** (`do_rootfs_boot_scr`) — `boot.scr` is copied to `/boot`, and on
+   UBIFS machines `oemEnv.txt` is placed at the rootfs root (where `boot.scr`
+   expects it).
+
+Container builds depend on `do_deploy`; the BSP on `do_compile`/`do_image_complete`
+— these are wired automatically by the `__anonymous` hook in `pvroot-image.bbclass`.
+
+## Build artifacts
+
+After a build, in `build/tmp-${codename}/deploy/images/${machine}/`:
+
+| Artifact | Description |
+|----------|-------------|
+| `pantavisor-starter-${machine}.wic[.bz2]` | Flashable disk image (partition layout from the machine's WKS file) |
+| `pantavisor-starter-${machine}.rootfs.*` | Rootfs tarball with the populated `/trails/0` |
+| `pantavisor-README.md` | Concatenated flashing guide (see below) |
+| `pantavisor-starter-*.docs.tar.zst` / `pantavisor-reference-documentation*.html.tar.zst` | Bundled docs (from `pantavisor-docs`) |
+
+### Flashing README
+
+Via the `pantavisor-docs` inherit and `do_deploy_readme`, the image emits a
+`pantavisor-README.md` by concatenating, in order:
+
+```
+docs/pantavisor.md  +  PV_FLASH_README_DEPS (e.g. toradex.md, uuu.md)  +  PV_FLASH_README
+```
+
+`PV_FLASH_README` and `PV_FLASH_README_DEPS` are set per machine in
+`kas/machines/<machine>.yaml` (via `local_conf_header`), so each board ships the
+right [install guide](../how-to-install/index.md) next to its image.
+
+## Building
+
+```bash
+./kas-container build kas/build-configs/release/<machine>-scarthgap.yaml \
+    --target pantavisor-starter
+```
+
+Because the starter aggregates the BSP and every core container, a full build
+also builds `pantavisor-bsp`, `pantavisor-initramfs`, and the core container
+recipes. See [Get Started](../how-to-build/get-started.md) for prerequisites and
+the KAS workflow.
+
+## Customizing the mix
+
+Override the container set from a machine/distro include or `local.conf` — use
+assignment, since these are the image's content list:
+
+```bitbake
+# Swap the default mix for your product's containers
+PVROOT_CONTAINERS_CORE = "pv-pvr-sdk pv-alpine-connman my-app-container"
+
+# Ship an extra container as a first-boot factory package instead of in-trail
+PVROOT_CONTAINERS = "my-optional-app"
+```
+
+Authoring a container to add here is covered in
+[Container Development](../how-to-build/container-development.md).
+
+## Related image recipes
+
+| Recipe | Description |
+|--------|-------------|
+| `pantavisor-starter.bb` | This image — BSP + core containers, ready to flash |
+| `pantavisor-remix.bb` | Minimal pvroot image: only `pv-pvr-sdk`, just enough to boot |
+| `pantavisor-bsp.bb` | BSP pvrexport (kernel + initramfs + modules + firmware); mixed into every pvroot image |
+| `pantavisor-initramfs.bb` | The Pantavisor-as-init initramfs the BSP wraps |
+| `empty-image.bb` | Empty proto rootfs used as a BSP modules/firmware source |
+| `pantavisor-appengine` | Docker-based image for local appengine testing (not a flashable device image) |
+
+## Related
+
+- [meta-pantavisor](meta-pantavisor.md) — layer layout and key recipes/classes
+- [Build System](build-system.md) — KAS hierarchy, multiconfig, and build targets
+- [Boot Flow](boot-flow.md) — how the BSP boots Pantavisor from U-Boot
+- [Install guides](../how-to-install/index.md) — flashing the starter image per board

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -13,5 +13,6 @@ Conceptual documentation for the Pantavisor runtime and the meta-pantavisor laye
 1. [Pantavisor](pantavisor.md) — what Pantavisor is: container model, atomic updates, cloud control, and the trail/revision system
 2. [meta-pantavisor](meta-pantavisor.md) — directory layout, key recipes, BitBake classes, KAS fragments, and layer conventions
 3. [Build System](build-system.md) — KAS configuration hierarchy, multiconfig architecture, and the relationship between build targets
-4. [Boot Flow](boot-flow.md) — how `boot.cmd.pvgeneric` boots Pantavisor: FIT/trail loading, try-boot, MMC vs NAND/UBIFS, and `PV_BOOT_OEMARGS`
-5. [CI](ci.md) — how CI machines, workflows, and build matrix relate to the layer structure
+4. [Starter Image](images.md) — what `pantavisor-starter` is, how the initial trail is composed from core containers + the BSP, and how to customize the mix
+5. [Boot Flow](boot-flow.md) — how `boot.cmd.pvgeneric` boots Pantavisor: FIT/trail loading, try-boot, MMC vs NAND/UBIFS, and `PV_BOOT_OEMARGS`
+6. [CI](ci.md) — how CI machines, workflows, and build matrix relate to the layer structure


### PR DESCRIPTION
## Summary

- Add `docs/examples/pvwificonnect.md` — full reference for the WiFi provisioning container that ships as a core container in the starter image: features (AP, captive portal, tethering, connection watcher), `config.json` keys, env vars, container runtime args (`args.json`), ConnMan backend dependency, and usage/build instructions.
- Add `docs/overview/images.md` — explains the `pantavisor-starter` image: what a pvroot image is vs. a plain Yocto image, how the initial trail is assembled from `PVROOT_CONTAINERS_CORE` + BSP via `pvroot-image.bbclass`, the signing flow, build artifacts (including the per-board flashing README), and how to customize the container mix.
- Update `docs/examples/index.md` and `docs/overview/index.md` to link the new pages and broaden section descriptions.
- Add missing `sidebar_position` to `boot-flow.md`; renumber `ci.md` to keep overview order consistent.

## Test plan

- [ ] Verify new pages render correctly in the docs site
- [ ] Check all internal cross-links resolve (pvwificonnect ↔ starter image, board install guides, container development)
- [ ] Confirm no existing page lost its sidebar position