### PR TITLE
fix(ci): stop duplicating release artifacts, drop redundant GH artifacts

### DIFF
--- a/.github/scripts/upload.sh
+++ b/.github/scripts/upload.sh
@@ -11,7 +11,7 @@ AWS_S3_URL="https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor"
 RELEASE_FILE="releases.json"
 
 TAR_IMAGES="$MACHINE_NAME-$TAG.tar.gz"
-TAR_PVEXPORTS="pvexports-$MACHINE_NAME-$TAG.tar.gz"
+ZIP_PVEXPORTS="pvexports-$MACHINE_NAME-$TAG.zip"
 
 aws configure set aws_access_key_id $AWS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_KEY
@@ -31,14 +31,36 @@ if [ -d "images" ]; then
 fi
 
 if [ -d "pvexports" ]; then
+    # Each container's pvrexport is deployed twice: a versioned real file and an
+    # unversioned "latest" symlink pointing at it (classes/pvrexport.bbclass
+    # do_deploy). cp dereferences the symlink, so both land here as separate
+    # regular files with identical content. Dedupe by checksum, keeping the
+    # longer (versioned) filename.
+    declare -A CSUM_TO_FILE
+    for f in pvexports/*pvrexport.tgz; do
+        [ -f "$f" ] || continue
+        csum=$(sha256sum "$f" | cut -d' ' -f1)
+        existing="${CSUM_TO_FILE[$csum]}"
+        if [ -z "$existing" ]; then
+            CSUM_TO_FILE[$csum]="$f"
+        elif [ ${#f} -gt ${#existing} ]; then
+            rm -f "$existing"
+            CSUM_TO_FILE[$csum]="$f"
+        else
+            rm -f "$f"
+        fi
+    done
+
     FILES_PVEXPORTS=( $(ls pvexports) )
-    
+
     if [ ${#FILES_PVEXPORTS[@]} -gt 0 ]; then
         echo "processing: ${FILES_PVEXPORTS[*]}"
-        tar -czf "$TAR_PVEXPORTS" -C pvexports "${FILES_PVEXPORTS[@]}"
-        
-        PVEXPORTS_CSUM=$(sha256sum "$TAR_PVEXPORTS" | cut -d' ' -f1)
-        aws s3 cp "$TAR_PVEXPORTS" "s3://$AWS_S3_BUCKET/$TAG/$MACHINE_NAME/$TAR_PVEXPORTS"
+        # zip is not installed in the kas container image; python3's zipfile
+        # module is, and its CLI stores members under their basename.
+        python3 -m zipfile -c "$ZIP_PVEXPORTS" "${FILES_PVEXPORTS[@]/#/pvexports/}"
+
+        PVEXPORTS_CSUM=$(sha256sum "$ZIP_PVEXPORTS" | cut -d' ' -f1)
+        aws s3 cp "$ZIP_PVEXPORTS" "s3://$AWS_S3_BUCKET/$TAG/$MACHINE_NAME/$ZIP_PVEXPORTS"
     else
         echo "warning: folder pvrexports is empty"
     fi
@@ -83,7 +105,7 @@ aws s3 cp s3://$AWS_S3_BUCKET/$RELEASE_FILE $RELEASE_FILE || echo "{}" > $RELEAS
 NEW_DEVICE=$(jq -n \
   --arg name "$MACHINE_NAME" \
   --arg url1 "$AWS_S3_URL/$TAG/$MACHINE_NAME/$TAR_IMAGES" \
-  --arg url2 "$AWS_S3_URL/$TAG/$MACHINE_NAME/$TAR_PVEXPORTS" \
+  --arg url2 "$AWS_S3_URL/$TAG/$MACHINE_NAME/$ZIP_PVEXPORTS" \
   --arg url3 "$AWS_S3_URL/$TAG/$MACHINE_NAME/$BSP_FILE" \
   --arg IMAGES_CSUM "$IMAGES_CSUM" \
   --arg PVEXPORTS_CSUM "$PVEXPORTS_CSUM" \

--- a/.github/workflows/buildkas-upload.yaml
+++ b/.github/workflows/buildkas-upload.yaml
@@ -93,45 +93,6 @@ jobs:
           path: pvtest-distro/
           if-no-files-found: ignore
 
-      - name: Archive wic artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ inputs.build_target || 'pantavisor-starter' }}-${{ inputs.machine_name }}
-          path: |
-             images/${{ inputs.output }}
-          if-no-files-found: ignore
-
-      - name: Archive all pvrexport artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: pvrexports-${{ inputs.machine_name }}
-          path: |
-            pvexports/*pvrexport.tgz
-          if-no-files-found: ignore
-
-      - name: Archive bsp pvrexport artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: pantavisor-bsp-${{ inputs.machine_name }}
-          path: |
-            pvexports/pantavisor-bsp*
-          if-no-files-found: ignore
-
-      - name: Archive pv-flash-bundle artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: pv-flash-bundle-${{ inputs.machine_name }}
-          path: |
-            images/pv-flash-bundle-*.tar.gz
-          if-no-files-found: ignore
-
-      - name: Archive sdk tar artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: sdk-artifact-${{ inputs.machine_name }}
-          path: sdk/panta*.sh
-          if-no-files-found: ignore
-
       - name: Upload to S3
         run: |
           .github/scripts/upload.sh \


### PR DESCRIPTION
## Summary
- Removed 5 redundant `upload-artifact` steps in `buildkas-upload.yaml` (wic images, pvrexports, bsp, pv-flash-bundle, sdk) — these files are already pushed to S3 by `upload.sh`, so archiving them a second time as GitHub Actions artifacts was unnecessary. `pvtest-distro` is kept since it's consumed by `call-pvtests`.
- `upload.sh` was bundling each container's pvrexport twice into `pvexports-$MACHINE-$TAG.tar.gz`: once under its versioned filename and once under the unversioned "latest" symlink name that `classes/pvrexport.bbclass` (`do_deploy`) creates alongside it — `cp` dereferences the symlink, producing two regular files with identical content. Now dedupes by checksum before packing, keeping the versioned filename.
- Switched the pvexports bundle from `.tar.gz` to `.zip` (`pvexports-$MACHINE-$TAG.zip`). Verified `zip` is not installed in `ghcr.io/pantacor/kas/kas:next-v7`, so used `python3 -m zipfile` instead (present in the image, and its CLI stores members under their basename with no extra path handling needed).

## Test plan
- `bash -n .github/scripts/upload.sh` — syntax check passes.
- Verified the dedupe logic and `python3 -m zipfile` packing end-to-end by running them inside the actual `ghcr.io/pantacor/kas/kas:next-v7` container (`docker run`), confirming the versioned pvrexport wins over the duplicate symlink copy and the resulting zip has flat, correctly named entries.
- Note: neither `onpush-scarthgap.yaml` nor `manual-scarthgap.yaml` exercise `buildkas-upload.yaml`/`upload.sh` — that path only runs via `release.yaml` on an actual version tag push (`tag-scarthgap.yaml`, tags matching `0*`/`*-rc*`). There's no dry-run trigger for it, so this couldn't be exercised through this repo's CI; the container-level checks above are the closest available verification short of a live tag/release run.