### PR TITLE
docs(index): sort meta-pantavisor after pantavisor in reference sidebar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: "meta-pantavisor Documentation"
 description: "Build, install, and develop with Pantavisor on embedded Linux using the meta-pantavisor Yocto layer."
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # meta-pantavisor Documentation


### PR DESCRIPTION
## Summary

Both this repo's and pantavisor's `docs/index.md` carried `sidebar_position: 1`, so the generated reference sidebar on docs.pantavisor.io fell back to alphabetical order (meta-pantavisor listed before pantavisor). Bumps this repo's position to 2 so Pantavisor's own docs list first, matching the intended reading order.

Only takes effect once docs.pantavisor.io ingests a release built from this change — it won't reorder already-published reference versions, only future ones.

## Test plan

- [x] Verified locally against docs.pantavisor.io's generated reference sidebar that pantavisor now sorts before meta-pantavisor