### PR TITLE
fix(pvrexport): gate developer CA vendor keys behind PVREXPORT_VENDOR_NAME

### DIFF
--- a/classes/pvrexport.bbclass
+++ b/classes/pvrexport.bbclass
@@ -20,6 +20,10 @@ PVR_SRC_URI ?= ""
 PVR_DOCKER_REF ?= ""
 PVR_APP_ADD_EXTRA_ARGS ?= ""
 
+# vendor whose developer CA keys are unpacked before signing; distros
+# opt in to per-vendor keys with PVREXPORT_VENDOR_NAME = "${PVS_VENDOR_NAME}"
+PVREXPORT_VENDOR_NAME ??= "generic"
+
 do_fetch_pvr[dirs] += "${PVR_HOME_DIR}"
 do_fetch_pvr[cleandirs] += "${PVR_CONFIG_DIR} ${PVR_SRC_DIR} ${PVR_TMPDIR}"
 do_fetch_pvr[depends] += "pvr-native:do_populate_sysroot squashfs-tools-native:do_populate_sysroot virtual/fakeroot-native:do_populate_sysroot"
@@ -54,8 +58,8 @@ do_unpack[postfuncs] += "do_unpack_pvr"
 do_unpack_pvr() {
 	export PVR_DISABLE_SELF_UPGRADE=true
 	export PVR_CONFIG_DIR="${PVR_CONFIG_DIR}"
-	if [ -d ${WORKDIR}/pv-developer-ca_generic ]; then
-		tar -C ${PVR_CONFIG_DIR}/ -xf ${WORKDIR}/pv-developer-ca_generic/pvs/pvs.defaultkeys.tar.gz
+	if [ -d ${WORKDIR}/pv-developer-ca_${PVREXPORT_VENDOR_NAME} ]; then
+		tar -C ${PVR_CONFIG_DIR}/ -xf ${WORKDIR}/pv-developer-ca_${PVREXPORT_VENDOR_NAME}/pvs/pvs.defaultkeys.tar.gz
 	fi
 	echo "do_unpack_pvr: $PWD ${B}/pvrrepo"
 	mkdir -p ${B}/pvrrepo

--- a/conf/distro/panta-appengine.inc
+++ b/conf/distro/panta-appengine.inc
@@ -10,4 +10,7 @@ PREFERRED_VERSION_mbedtls = "2.28.%"
 PANTAVISOR_MACHINE_FIRMWARE ?= ""
 PANTAVISOR_MACHINE_KERNEL_MODULES ?= ""
 
+# appengine builds sign pvrexport parts with the vendor developer CA
+PVREXPORT_VENDOR_NAME ?= "${PVS_VENDOR_NAME}"
+
 


### PR DESCRIPTION
## Summary
- `do_unpack_pvr` in `classes/pvrexport.bbclass` always extracted developer CA keys from the hardcoded `pv-developer-ca_generic` directory, ignoring `PVS_VENDOR_NAME`. Non-generic vendors never got their developer CA keys unpacked before signing.
- Switching unconditionally to `PVS_VENDOR_NAME` would change signing behavior for every recipe inheriting `pvrexport` in any distro of a non-generic vendor, including production BSP distros.

## Changes
- `classes/pvrexport.bbclass`: introduce `PVREXPORT_VENDOR_NAME ??= "generic"` and use `pv-developer-ca_${PVREXPORT_VENDOR_NAME}` for key extraction — default behavior is unchanged everywhere.
- `conf/distro/panta-appengine.inc`: opt appengine distros into per-vendor keys with `PVREXPORT_VENDOR_NAME ?= "${PVS_VENDOR_NAME}"`.
- Downstream distros that need vendor keys outside appengine (e.g. vendor pvtest distros) opt in with `PVREXPORT_VENDOR_NAME = "${PVS_VENDOR_NAME}"`.

https://claude.ai/code/session_011vgM37eUL4SwQBRBSZJXtL
