### PR TITLE
test(pvtests): fix basic-endpoints golden + status-goal timeout after hosted-bus srcrev bump

### DIFF
--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
@@ -592,5 +592,10 @@ object count: 6
     "key": "PV_WDT_TIMEOUT",
     "value": "15",
     "modified": "default"
+  },
+  {
+    "key": "PV_XCONNECT_DBUS_SYSTEMBUS_ENABLED",
+    "value": "1",
+    "modified": "default"
   }
 ]

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
@@ -584,5 +584,10 @@ object count: 6
     "key": "PV_WDT_TIMEOUT",
     "value": "15",
     "modified": "default"
+  },
+  {
+    "key": "PV_XCONNECT_DBUS_SYSTEMBUS_ENABLED",
+    "value": "1",
+    "modified": "default"
   }
 ]


### PR DESCRIPTION
## Problem

Master `pvtest-local` regressed after the hosted D-Bus system bus landed (pantavisor #733; srcrev bump `a4ab01fe → feb08e7f`, master commit `67aad5133b`). Two failures, both from that one srcrev-only bump:

### 1. `basic-endpoints` / `basic-endpoints-curl` — golden drift
The new `xconnect.dbus.systembus.enabled` config entry makes `/config` list `PV_XCONNECT_DBUS_SYSTEMBUS_ENABLED`, which the recorded golden output predates. Fix: append the key to both golden `output` files (CRLF preserved).

### 2. `status-goal-success-failure` — CI-load timeout
`wait_for_revision_state` gives `locals/success` three 30s windows to become current / READY / DONE. Under the CI runner’s parallel load, the heavier hosted-bus startup tips it past a 30s window and the wait times out. It **passes locally at 175s with the hosted bus fully active** (each window holds under single-test load), and was green before the marginally-heavier srcrev — so this is CI-load timing fragility, not a functional regression. Fix: raise the three per-step waits to 60s.

## Scope
Test-data + test-infra only; no product behavior change. Unblocks master (currently red) and, by extension, #367.