### PR TITLE
fix(pvtest): local/runtime/status-goal-success-failure downloading test container from hub

### DIFF
--- a/recipes-containers/pv-examples/files/pv-example-ready-timeout.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-ready-timeout.args.json
@@ -1,0 +1,4 @@
+{
+    "PV_RESTART_POLICY": "container",
+    "PV_STATUS_GOAL": "READY"
+}

--- a/recipes-containers/pv-examples/files/pv-example-ready.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-ready.args.json
@@ -1,0 +1,4 @@
+{
+    "PV_STATUS_GOAL": "READY",
+    "PV_LXC_EXTRA_CONF": "lxc.mount.entry = tmpfs tmp tmpfs rw,nodev,relatime,create=dir,mode=1777 0 0"
+}

--- a/recipes-containers/pv-examples/files/pv-ready-timeout.sh
+++ b/recipes-containers/pv-examples/files/pv-ready-timeout.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+trap 'echo "Received shutdown signal, exiting..."; exit 0' TERM PWR INT
+
+echo "pv-example-ready-timeout starting (PID $$)..."
+
+# Never send the READY signal: with status_goal READY this deterministically
+# times out the update goals and triggers a rollback. Counterpart of
+# pv-example-ready, which signals as soon as it is up.
+while true; do
+    sleep 1
+done

--- a/recipes-containers/pv-examples/files/pv-ready.sh
+++ b/recipes-containers/pv-examples/files/pv-ready.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+trap 'echo "Received shutdown signal, exiting..."; exit 0' TERM PWR INT
+
+echo "pv-example-ready starting (PID $$)..."
+
+# Signal READY as soon as the pv-ctrl socket answers; with status_goal READY
+# this lets the update meet its goals. Counterpart of pv-example-ready-timeout,
+# which never signals.
+until pvcontrol signal ready > /dev/null 2>&1; do
+    sleep 1
+done
+echo "pv-example-ready: READY signal sent"
+
+while true; do
+    sleep 1
+done

--- a/recipes-containers/pv-examples/pv-example-ready-timeout.bb
+++ b/recipes-containers/pv-examples/pv-example-ready-timeout.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Pantavisor Example Ready-Timeout Container"
+DESCRIPTION = "Example container with status_goal READY that never sends the \
+READY signal, so any update that includes it deterministically times out its \
+goals and rolls back. Used by tests that need a controlled status-goal failure \
+(e.g. local/runtime/status-goal-success-failure). Counterpart of \
+pv-example-ready, which signals as soon as it is up."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-ready-timeout"
+
+IMAGE_INSTALL = "busybox"
+IMAGE_FEATURES = ""
+IMAGE_LINGUAS = ""
+NO_RECOMMENDATIONS = "1"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+SRC_URI += "file://pv-ready-timeout.sh file://pv-example-ready-timeout.args.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-ready-timeout.sh ${IMAGE_ROOTFS}${bindir}/pv-ready-timeout
+    install -d -m 1777 ${IMAGE_ROOTFS}/tmp
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-ready-timeout"
+PVR_APP_ADD_ROLES = "nobody"

--- a/recipes-containers/pv-examples/pv-example-ready.bb
+++ b/recipes-containers/pv-examples/pv-example-ready.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Pantavisor Example Ready-Signaling Container"
+DESCRIPTION = "Example container with status_goal READY that signals READY as \
+soon as it starts. Used by tests that need an update to succeed through the \
+status-goal mechanism (e.g. local/runtime/status-goal-success-failure). \
+Counterpart of pv-example-ready-timeout, which never signals."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-ready"
+
+IMAGE_INSTALL = "busybox coreutils curl"
+IMAGE_FEATURES = ""
+IMAGE_LINGUAS = ""
+NO_RECOMMENDATIONS = "1"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+SRC_URI += "file://pv-ready.sh file://pv-example-ready.args.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-ready.sh ${IMAGE_ROOTFS}${bindir}/pv-ready
+    install -d -m 1777 ${IMAGE_ROOTFS}/tmp
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-ready"
+PVR_APP_ADD_ROLES = "nobody"

--- a/recipes-pv/pantavisor-pvtests/files/local/runtime/status-goal-success-failure/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/runtime/status-goal-success-failure/output
@@ -19,7 +19,7 @@ locals/success
 + wait_for_revision_state pvr-sdk locals/failure DONE
 + pventer -c pvr-sdk pvcontrol steps show-progress locals/failure
 + sed 's/\\\"tsec\\\":[0-9]\+/\\\"tsec\\\":0/g; s/\\\"tnano\\\":[0-9]\+/\\\"tnano\\\":0/g; s/\\\"msg\\\":\\\"([a-zA-Z_][a-zA-Z0-9_]*:[0-9]\+) /\\\"msg\\\":\\\"/g'
-{"status":"ERROR","status-msg":"Status goal not reached","progress":100,"retries":0,"logs":"{\"tsec\":0,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"platforms\",\"msg\":\"platform 'pvr-sdk_ready' status goal timed out after waiting for more than 30 secs\"}\n{\"tsec\":0,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"controller\",\"msg\":\"timed out before all goals were met. Rolling back...\"}\n"}
+{"status":"ERROR","status-msg":"Status goal not reached","progress":100,"retries":0,"logs":"{\"tsec\":0,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"platforms\",\"msg\":\"platform 'pv-example-ready-timeout' status goal timed out after waiting for more than 30 secs\"}\n{\"tsec\":0,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"controller\",\"msg\":\"timed out before all goals were met. Rolling back...\"}\n"}
 + pventer -c pvr-sdk pvcontrol devmeta ls
 + jq -M -r '.["pantavisor.revision"]'
 locals/success

--- a/recipes-pv/pantavisor-pvtests/files/local/runtime/status-goal-success-failure/resources/test
+++ b/recipes-pv/pantavisor-pvtests/files/local/runtime/status-goal-success-failure/resources/test
@@ -8,7 +8,7 @@ pvr clone http://localhost:12368/cgi-bin/pvr /home/checkout > /dev/null 2>&1
 cd /home/checkout
 
 # post a new container that expects and sends READY
-pvr get https://pvr.pantahub.com/pantahub-ci/pv_tests_assets/3#container-ready-demo/ > /dev/null 2>&1
+pvr get /work/local/common/tarballs/pv-example-ready.tgz > /dev/null 2>&1
 pvr checkout
 pvr post --rev "locals/success" > /dev/null 2>&1
 
@@ -19,11 +19,11 @@ pvcontrol steps show-progress locals/success
 pvcontrol devmeta ls | jq -M -r '.["pantavisor.revision"]'
 
 # post a new container that expects but does not send READY
-pvr get https://pvr.pantahub.com/pantahub-ci/pv_tests_assets/5#pvr-sdk_ready/ > /dev/null 2>&1
+pvr get /work/local/common/tarballs/pv-example-ready-timeout.tgz > /dev/null 2>&1
 pvr checkout
 pvr post --rev "locals/failure" > /dev/null 2>&1
 
-# after posting evaluation — locals/failure triggers a rollback (pvr-sdk_ready never signals READY)
+# after posting evaluation — locals/failure triggers a rollback (pv-example-ready-timeout never signals READY)
 # wait for the step to reach ERROR (the goals timeout), then for status to be READY again after rollback
 wait_for_value "pvcontrol steps show-progress locals/failure | jq -r '.status'" "ERROR" 90 > /dev/null 2>&1 \
     || { echo "ERROR: timeout waiting for locals/failure to reach ERROR" >&2; exit 1; }

--- a/recipes-pv/pantavisor-pvtests/files/local/runtime/status-goal-success-failure/test.json
+++ b/recipes-pv/pantavisor-pvtests/files/local/runtime/status-goal-success-failure/test.json
@@ -12,10 +12,7 @@
 				"../../common/tarballs/bsp.tgz",
 				"../../common/tarballs/pvr-sdk.tgz"
 			],
-			"urls": [
-				"https://pvr.pantahub.com/pantahub-ci/pv_tests_assets/6#bsp/,device.json",
-				"https://pvr.pantahub.com/pantahub-ci/pv_tests_assets/6#pvr-sdk/"
-			]
+			"urls": []
 		},
 		"ready-script": ""
 	},

--- a/recipes-pv/pantavisor/pantavisor-appengine-distro.bb
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro.bb
@@ -16,6 +16,7 @@ PV_APPENGINE_CONTAINERS ?= "pantavisor-appengine pantavisor-appengine-netsim pan
 do_create_tarball[depends] = "${@' '.join(['%s:do_image_complete' % x for x in d.getVar('PV_APPENGINE_CONTAINERS').split()])}"
 do_create_tarball[depends] += "pantavisor-bsp:do_compile pv-pvr-sdk:do_deploy"
 do_create_tarball[depends] += "pv-example-app:do_image_complete pv-example-norole:do_image_complete"
+do_create_tarball[depends] += "pv-example-ready:do_image_complete pv-example-ready-timeout:do_image_complete"
 do_create_tarball[depends] += "pantavisor-pvtests-local:do_deploy pantavisor-pvtests-remote:do_deploy"
 
 # Define the files you want from DEPLOY_DIR_IMAGE (modify as needed)
@@ -108,6 +109,18 @@ do_create_tarball() {
     for f in ${DEPLOY_DIR_IMAGE}/pv-example-norole.pvrexport.tgz; do
         if [ -e "$f" ]; then
             cp -v "$f" "${STAGING_DIR}/local/common/tarballs/pv-example-norole.tgz"
+            break
+        fi
+    done
+    for f in ${DEPLOY_DIR_IMAGE}/pv-example-ready.pvrexport.tgz; do
+        if [ -e "$f" ]; then
+            cp -v "$f" "${STAGING_DIR}/local/common/tarballs/pv-example-ready.tgz"
+            break
+        fi
+    done
+    for f in ${DEPLOY_DIR_IMAGE}/pv-example-ready-timeout.pvrexport.tgz; do
+        if [ -e "$f" ]; then
+            cp -v "$f" "${STAGING_DIR}/local/common/tarballs/pv-example-ready-timeout.tgz"
             break
         fi
     done


### PR DESCRIPTION
With this fix, instead of getting test containers `container-ready-demo` and `pvr-sdk_ready`from Hub, which is flaky, we use equivalent build generated ones `pv-example-ready` and `pv-example-ready-timeout`.