### PR TITLE
fix(ci): use PAT instead of GITHUB_TOKEN in scheduled update workflows

### DIFF
--- a/.github/scripts/make-onpush-matrix.py
+++ b/.github/scripts/make-onpush-matrix.py
@@ -48,7 +48,7 @@ if pvtest_machines:
 lines += [
     f"      - '.github/workflows/onpush-{branch}.yaml'",
     "  pull_request:",
-    "    types: [ready_for_review]",
+    "    types: [opened, ready_for_review]",
     "",
     "concurrency:",
     "  group: ${{ github.workflow }}-${{ github.ref }}",

--- a/.github/workflows/onpush-scarthgap.yaml
+++ b/.github/workflows/onpush-scarthgap.yaml
@@ -24,7 +24,7 @@ on:
       - '.github/workflows/call-pvtests.yaml'
       - '.github/workflows/onpush-scarthgap.yaml'
   pull_request:
-    types: [ready_for_review]
+    types: [opened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/schedule-updatemachines.yaml
+++ b/.github/workflows/schedule-updatemachines.yaml
@@ -23,6 +23,8 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PANTAVISOR_TAG_SYNC_TOKEN }}
       - name: Install latest GitHub CLI
         run: |
           curl -sSL https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_amd64.tar.gz | tar -xz -C /usr/bin --strip-components=2 gh_2.92.0_linux_amd64/bin/gh
@@ -45,4 +47,4 @@ jobs:
             --body "Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog." || \
           gh pr edit autopr/machine-update-$GITHUB_REF_NAME-next --title "AutoPR: update kas meta layers to latest branch commits"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PANTAVISOR_TAG_SYNC_TOKEN }}

--- a/.github/workflows/schedule-updates.yaml
+++ b/.github/workflows/schedule-updates.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.PANTAVISOR_TAG_SYNC_TOKEN }}
 
       - name: Run Update Script
         env:
@@ -24,7 +25,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PANTAVISOR_TAG_SYNC_TOKEN }}
           COMMIT_MSG_FILE: /tmp/updates-commit-msg
         run: |
           git config user.email "pantavisor-meta@ci.pantavisor.io"


### PR DESCRIPTION
## Summary
- `schedule-updates.yaml` and `schedule-updatemachines.yaml` pushed branches and opened PRs using the default `GITHUB_TOKEN`. GitHub Actions suppresses downstream workflow runs triggered by the default token (anti-recursion protection), so `onpush-scarthgap.yaml` never fired for these auto-generated PRs — confirmed empirically: PR #391 and #389 show zero workflow runs, not even `check-draft`.
- Switched both workflows to the existing `PANTAVISOR_TAG_SYNC_TOKEN` PAT (checkout `token:` input + `GH_TOKEN` env), matching the pattern already used by `sync-pantavisor.yaml` and `tag-changelogs.yaml`.
- Added `opened` to `onpush-scarthgap.yaml`'s `pull_request.types` (via `.github/scripts/make-onpush-matrix.py` + `makeworkflows`): `gh pr create` opens these PRs directly as non-draft, which emits an `opened` event, not `ready_for_review` (that only fires on the draft→ready transition) — so the trigger would have missed them even with a working token.

## Test plan
- [ ] Confirm `.github/scripts/makeworkflows` output matches committed `onpush-scarthgap.yaml` (done locally, no unexpected drift in other generated files)
- [ ] Trigger `schedule-updates.yaml` or `schedule-updatemachines.yaml` via `workflow_dispatch` and confirm the resulting PR shows `onpush-scarthgap` checks (check-draft, build-hw, build-docker)
- [ ] Confirm `PANTAVISOR_TAG_SYNC_TOKEN` has push/PR permissions in this repo (already used by other workflows)