### PR TITLE
test(xconnect): hosted-bus name-collision validation + rollback pvtest

### DIFF
--- a/docs/testing/automated-workflow.md
+++ b/docs/testing/automated-workflow.md
@@ -515,6 +515,7 @@ Local experience tests exercise Pantavisor features that operate without any clo
 | `local/xconnect/dbus` | D-Bus (Policy mediation) | |
 | `local/xconnect/dbus-systembus` | Hosted D-Bus system bus (owns/allow, generated default-deny policy): allowed role calls, non-allowed role denied, rogue name-ownership denied | ✓ |
 | `local/xconnect/avahi-systembus` | Hosted D-Bus system bus with a real daemon: avahi owns `org.freedesktop.Avahi`, monitor consumer roundtrips its API | ✓ |
+| `local/xconnect/dbus-collision` | Hosted D-Bus system bus name-collision validation: two apps owning the same well-known name on one bus fail `pv_dbus_daemon_validate` and the revision rolls back | ✓ |
 | `local/xconnect/drm` | DRM (Graphics node injection) | |
 | `local/xconnect/wayland` | Wayland (Isolated UI rendering) | |
 

--- a/recipes-containers/pv-examples/files/pv-example-dbus-host-server2.services.json
+++ b/recipes-containers/pv-examples/files/pv-example-dbus-host-server2.services.json
@@ -1,0 +1,12 @@
+{
+  "#spec": "service-manifest-xconnect@1",
+  "services": [
+    {
+      "type": "dbus",
+      "bus": "system-bus",
+      "owns": "org.pantavisor.Example",
+      "role": "example-service-2",
+      "allow": ["operator", "monitor"]
+    }
+  ]
+}

--- a/recipes-containers/pv-examples/pv-example-dbus-host-server2_1.0.bb
+++ b/recipes-containers/pv-examples/pv-example-dbus-host-server2_1.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Second owner of org.pantavisor.Example — provokes a hosted-bus name collision"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "pv-example-dbus-host-server2"
+
+PVRIMAGE_AUTO_MDEV = "0"
+
+# Deliberately minimal: this container never runs a real D-Bus server. It only
+# ships a services.json that declares ownership of org.pantavisor.Example on the
+# hosted system-bus with a DIFFERENT role than pv-example-dbus-host-server.
+# Placing both owners in one revision makes pv_dbus_daemon_validate() reject the
+# state ("owned by more than one app") before any container runs — the revision
+# errors and rolls back. A busybox sleep loop is all the payload we need.
+IMAGE_INSTALL = "busybox"
+IMAGE_FEATURES = ""
+IMAGE_LINGUAS = ""
+NO_RECOMMENDATIONS = "1"
+
+do_fetch[noexec] = "0"
+do_unpack[noexec] = "0"
+
+SRC_URI += "file://pv-app.sh \
+            file://${PN}.services.json"
+
+install_scripts() {
+    install -d ${IMAGE_ROOTFS}${bindir}
+    install -m 0755 ${WORKDIR}/pv-app.sh ${IMAGE_ROOTFS}${bindir}/pv-app
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_scripts; "
+
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/pv-app"

--- a/recipes-pv/pantavisor-pvtests/files/local/xconnect/dbus-collision/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/xconnect/dbus-collision/output
@@ -1,0 +1,18 @@
+[pvtest] 1783621275 DEBUG -- [test-script]: source /usr/share/pantavisor/pvtest/utils
+[pvtest] 1783621275 DEBUG -- [test-script]: pvcontrol devmeta ls
+[pvtest] 1783621275 DEBUG -- [test-script]: jq -M -r '.["pantavisor.revision"]'
+0
+[pvtest] 1783621275 DEBUG -- [test-script]: pvr clone http://localhost:12368/cgi-bin/pvr /home/checkout
+[pvtest] 1783621275 DEBUG -- [test-script]: cd /home/checkout
+[pvtest] 1783621275 DEBUG -- [test-script]: pvr get /work/local/common/tarballs/pv-example-dbus-host-server.tgz
+[pvtest] 1783621275 DEBUG -- [test-script]: pvr get /work/local/common/tarballs/pv-example-dbus-host-server2.tgz
+[pvtest] 1783621275 DEBUG -- [test-script]: pvr checkout
+[pvtest] 1783621276 DEBUG -- [test-script]: pvr post --rev locals/collision
+[pvtest] 1783621276 DEBUG -- [test-script]: wait_for_value 'pvcontrol steps show-progress locals/collision | jq -r '\''.status'\''' ERROR 90
+[pvtest] 1783621293 DEBUG -- [test-script]: wait_for_value 'pvcontrol devmeta ls | jq -r '\''."pantavisor.status"'\''' READY 30
+[pvtest] 1783621293 DEBUG -- [test-script]: pvcontrol steps show-progress locals/collision
+[pvtest] 1783621293 DEBUG -- [test-script]: sed 's/\\\"tsec\\\":[0-9]\+/\\\"tsec\\\":0/g; s/\\\"tnano\\\":[0-9]\+/\\\"tnano\\\":0/g; s/\\\"msg\\\":\\\"([a-zA-Z_][a-zA-Z0-9_]*:[0-9]\+) /\\\"msg\\\":\\\"/g'
+{"status":"ERROR","status-msg":"A container could not be started","progress":100,"retries":0,"logs":"{\"tsec\":0,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"dbus-daemon\",\"msg\":\"well-known name 'org.pantavisor.Example' on bus 'system-bus' is owned by more than one app\"}\n{\"tsec\":0,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"controller\",\"msg\":\"a platform did not work as expected. Tearing down...\"}\n"}
+[pvtest] 1783621293 DEBUG -- [test-script]: pvcontrol devmeta ls
+[pvtest] 1783621293 DEBUG -- [test-script]: jq -M -r '.["pantavisor.revision"]'
+0

--- a/recipes-pv/pantavisor-pvtests/files/local/xconnect/dbus-collision/resources/test
+++ b/recipes-pv/pantavisor-pvtests/files/local/xconnect/dbus-collision/resources/test
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Hosted D-Bus system bus: name-collision validation + rollback.
+#
+# Two containers each declare ownership of the SAME well-known name
+# (org.pantavisor.Example) on the SAME hosted bus (system-bus), with different
+# roles:
+#   pv-example-dbus-host-server   role "example-service"
+#   pv-example-dbus-host-server2  role "example-service-2"
+#
+# pv_dbus_daemon_validate() runs at the top of pv_state_run() and rejects a
+# state that has two owners of one name on one bus ("owned by more than one
+# app"), before any container starts. So a revision carrying both owners never
+# reaches DONE: pv_state_run returns -1, pantavisor tears the platforms down and
+# rolls back to the previous revision. The second owner never needs to run a
+# real D-Bus server; only its owns declaration is required.
+
+source /usr/share/pantavisor/pvtest/utils
+
+# initial setup — record the clean base revision we expect to roll back to
+pvcontrol devmeta ls | jq -M -r '.["pantavisor.revision"]'
+pvr clone http://localhost:12368/cgi-bin/pvr /home/checkout > /dev/null 2>&1
+cd /home/checkout
+
+# stage BOTH owners of org.pantavisor.Example into one checkout — the collision
+pvr get /work/local/common/tarballs/pv-example-dbus-host-server.tgz > /dev/null 2>&1
+pvr get /work/local/common/tarballs/pv-example-dbus-host-server2.tgz > /dev/null 2>&1
+pvr checkout
+pvr post --rev "locals/collision" > /dev/null 2>&1
+
+# after posting evaluation — locals/collision triggers a rollback (validation
+# rejects the duplicate owner). Wait for the step to reach ERROR, then for
+# status to be READY again after the rollback completes.
+wait_for_value "pvcontrol steps show-progress locals/collision | jq -r '.status'" "ERROR" 90 > /dev/null 2>&1 \
+    || { echo "ERROR: timeout waiting for locals/collision to reach ERROR" >&2; exit 1; }
+wait_for_value "pvcontrol devmeta ls | jq -r '.\"pantavisor.status\"'" "READY" 30 > /dev/null 2>&1 \
+    || { echo "ERROR: timeout waiting for pantavisor.status READY after rollback" >&2; exit 1; }
+pvcontrol steps show-progress locals/collision | sed 's/\\\"tsec\\\":[0-9]\+/\\\"tsec\\\":0/g; s/\\\"tnano\\\":[0-9]\+/\\\"tnano\\\":0/g; s/\\\"msg\\\":\\\"([a-zA-Z_][a-zA-Z0-9_]*:[0-9]\+) /\\\"msg\\\":\\\"/g'
+pvcontrol devmeta ls | jq -M -r '.["pantavisor.revision"]'

--- a/recipes-pv/pantavisor-pvtests/files/local/xconnect/dbus-collision/test.json
+++ b/recipes-pv/pantavisor-pvtests/files/local/xconnect/dbus-collision/test.json
@@ -1,0 +1,21 @@
+{
+	"#spec": "pv-test@1",
+	"description": "Hosted D-Bus system bus: two owners of one well-known name fail validation and roll back",
+	"setup": {
+		"cmdline": "",
+		"env": "PV_CONTROL_REMOTE=0 PV_LOG_CAPTURE_DMESG=0 PV_UPDATER_GOALS_TIMEOUT=10 PV_UPDATER_COMMIT_DELAY=5 PV_SECUREBOOT_MODE=disabled PV_WDT_MODE=disabled PV_DEBUG_SSH=0 PV_LOG_DIR_MAXSIZE=2147483647",
+		"pantavisor.config": "",
+		"pvs": "../../common/pvs/*.tar.gz",
+		"containers": {
+			"control": "pvr-sdk",
+			"tarballs": [
+				"../../common/tarballs/bsp.tgz",
+				"../../common/tarballs/pvr-sdk.tgz"
+			],
+			"urls": []
+		},
+		"ready-script": ""
+	},
+	"test-script": "resources/test",
+	"skip": "false"
+}

--- a/recipes-pv/pantavisor/pantavisor-appengine-distro.bb
+++ b/recipes-pv/pantavisor/pantavisor-appengine-distro.bb
@@ -17,7 +17,7 @@ do_create_tarball[depends] = "${@' '.join(['%s:do_image_complete' % x for x in d
 do_create_tarball[depends] += "pantavisor-bsp:do_compile pv-pvr-sdk:do_deploy"
 do_create_tarball[depends] += "pv-example-app:do_image_complete pv-example-norole:do_image_complete"
 do_create_tarball[depends] += "pv-example-ready:do_image_complete pv-example-ready-timeout:do_image_complete"
-do_create_tarball[depends] += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'xconnect-dbus-systembus', 'pv-example-dbus-host-server:do_image_complete pv-example-dbus-host-client:do_image_complete', '', d)}"
+do_create_tarball[depends] += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'xconnect-dbus-systembus', 'pv-example-dbus-host-server:do_image_complete pv-example-dbus-host-server2:do_image_complete pv-example-dbus-host-client:do_image_complete', '', d)}"
 do_create_tarball[depends] += "${@bb.utils.contains('PANTAVISOR_FEATURES', 'xconnect-dbus-systembus', 'pv-avahi:do_image_complete pv-avahi-browse:do_image_complete', '', d)}"
 do_create_tarball[depends] += "pantavisor-pvtests-local:do_deploy pantavisor-pvtests-remote:do_deploy"
 
@@ -129,6 +129,12 @@ do_create_tarball() {
     for f in ${DEPLOY_DIR_IMAGE}/pv-example-dbus-host-server.pvrexport.tgz; do
         if [ -e "$f" ]; then
             cp -v "$f" "${STAGING_DIR}/local/common/tarballs/pv-example-dbus-host-server.tgz"
+            break
+        fi
+    done
+    for f in ${DEPLOY_DIR_IMAGE}/pv-example-dbus-host-server2.pvrexport.tgz; do
+        if [ -e "$f" ]; then
+            cp -v "$f" "${STAGING_DIR}/local/common/tarballs/pv-example-dbus-host-server2.tgz"
             break
         fi
     done


### PR DESCRIPTION
## What

Adds the pvtest `local/xconnect/dbus-collision`, covering the one hosted-bus design property not yet exercised by `dbus-systembus` / `avahi-systembus`: **two apps owning the same well-known name on the same bus fail validation and the revision rolls back.**

## Mechanism

`pv_dbus_daemon_validate()` runs at the top of `pv_state_run()` and rejects a state with two owners of one name on one bus, before any container starts. `pv_state_run` returns -1 → pantavisor tears the platforms down → INPROGRESS/TESTING rolls back to the previous revision.

## Changes

- **`pv-example-dbus-host-server2`** — minimal busybox owner declaring `owns org.pantavisor.Example` on `system-bus` with role `example-service-2`. Never runs a real D-Bus server; validation fires on the `owns` declaration at apply time.
- Wire server2 into `pantavisor-appengine-distro` (depends + staging copy).
- New pvtest posts a revision carrying both owners; asserts the step reaches `ERROR`, `pantavisor.status` returns to `READY`, and the device rolls back to the base revision.
- Todo row added to `docs/testing/automated-workflow.md`.

## Verification (empirical, not hand-written)

Built the appengine distro, deployed a two-owner revision, and observed real behavior before writing the golden:

\`\`\`
status: ERROR — "A container could not be started"
  dbus-daemon: well-known name 'org.pantavisor.Example' on bus 'system-bus' is owned by more than one app
  controller:  a platform did not work as expected. Tearing down...
final revision → 0  (rolled back to base)
\`\`\`

Golden captured with `-o`; verified deterministic with a plain `run` (PASSED).

https://claude.ai/code/session_01U2rJVppJSaJpwE4xLXmmYv