### PR TITLE
fix(ci): avoid gh pr edit's read:org requirement in scheduled workflows

### DIFF
--- a/.github/workflows/schedule-updatemachines.yaml
+++ b/.github/workflows/schedule-updatemachines.yaml
@@ -42,9 +42,8 @@ jobs:
         run: |
           .github/scripts/makecommit && \
           git push origin -f autopr/machine-update-$GITHUB_REF_NAME-next && \
-          gh pr create --base $GITHUB_REF_NAME \
+          { gh pr create --base $GITHUB_REF_NAME \
             --title "AutoPR: update kas meta layers to latest branch commits" \
-            --body "Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog." || \
-          gh pr edit autopr/machine-update-$GITHUB_REF_NAME-next --title "AutoPR: update kas meta layers to latest branch commits"
+            --body "Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog." || true; }
         env:
           GH_TOKEN: ${{ secrets.PANTAVISOR_TAG_SYNC_TOKEN }}

--- a/.github/workflows/schedule-updates.yaml
+++ b/.github/workflows/schedule-updates.yaml
@@ -53,9 +53,14 @@ jobs:
             PR_TITLE=$(head -n 1 "$COMMIT_MSG_FILE")
             PR_BODY=$(tail -n +3 "$COMMIT_MSG_FILE")
 
-            # Create or update the PR
-            gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base master --head "$BRANCH_NAME" || \
-            gh pr edit "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
+            # Create the PR, or update it via the REST API if it already exists.
+            # (gh pr edit pulls in GraphQL fields — e.g. assignable users —
+            # that require the read:org scope on org-owned repos; the plain
+            # REST PATCH endpoint doesn't, so it works with a repo-scoped PAT.)
+            if ! gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base master --head "$BRANCH_NAME"; then
+              PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH_NAME&state=open" --jq '.[0].number')
+              gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" -X PATCH -f title="$PR_TITLE" -f body="$PR_BODY"
+            fi
 
             rm -f "$COMMIT_MSG_FILE" || true
           else


### PR DESCRIPTION
## Summary
- Follow-up to #396. Running `schedule-updatemachines.yaml` against a live PR after that fix landed showed `gh pr edit` failing with GraphQL scope errors (`read:org`, `read:discussion`) — `PANTAVISOR_TAG_SYNC_TOKEN` only has `repo` scope. `gh pr edit` pulls in GraphQL fields (e.g. assignable users) that require `read:org` on org-owned repos; other PAT-based workflows in this repo (`sync-pantavisor.yaml`, `tag-changelogs.yaml`) never call `gh pr edit`/`gh pr view`, so they never hit this.
- `schedule-updatemachines.yaml`'s title/body are static, so the fallback edit was a no-op anyway — dropped it, keeping `|| true` to swallow the "PR already exists" exit code.
- `schedule-updates.yaml`'s title/body vary per run (from the commit message), so it still needs to update an existing PR. Replaced `gh pr edit` with a plain REST `PATCH` via `gh api`, which doesn't require `read:org`.

## Test plan
- [ ] Trigger `schedule-updatemachines.yaml` via `workflow_dispatch` and confirm the "make PR" step succeeds without GraphQL scope errors when PR #389 already exists
- [ ] Trigger `schedule-updates.yaml` via `workflow_dispatch` and confirm it can update an existing PR's title/body via the REST PATCH path
- [ ] Confirm the resulting PR gets `onpush-scarthgap` checks (from #396's fix)