### PR TITLE
fix(pv-flash-bundle): match imx-boot deploy filename suffix

### DIFF
--- a/recipes-bsp/pv-flash/pv-flash-bundle.bb
+++ b/recipes-bsp/pv-flash/pv-flash-bundle.bb
@@ -26,9 +26,9 @@ PV_FLASH_RECOVERY_IMAGE ?= ""
 # Toradex's distro_bootcmd override which requires a stripped recovery build.
 # Installed into the bundle as the fixed name "imx-boot.bin".
 PV_FLASH_BOOT_IMAGE ?= ""
-PV_FLASH_BOOT_IMAGE:imx8mm-var-dart = "imx-boot-imx8mm-var-dart*.bin"
-PV_FLASH_BOOT_IMAGE:imx8mn-var-som = "imx-boot-imx8mn-var-som*.bin"
-PV_FLASH_BOOT_IMAGE:imx8qxp-b0-mek = "imx-boot-imx8qxp-b0-mek*.bin"
+PV_FLASH_BOOT_IMAGE:imx8mm-var-dart = "imx-boot-imx8mm-var-dart*.bin-*"
+PV_FLASH_BOOT_IMAGE:imx8mn-var-som = "imx-boot-imx8mn-var-som*.bin-*"
+PV_FLASH_BOOT_IMAGE:imx8qxp-b0-mek = "imx-boot-imx8qxp-b0-mek*.bin-*"
 
 # For NAND machines: production NAND U-Boot binary filename in the recovery
 # multiconfig deploy dir (the same tezi-recovery build also produces the rawnand


### PR DESCRIPTION
## Summary
- `do_deploy` was failing on `imx8mn-var-som-scarthgap`, `imx8qxp-b0-mek-scarthgap`, and `imx8mm-var-dart-scarthgap` with `ExecutionError` from `install`.
- Root cause: `imx-boot`'s `do_deploy` names its output `imx-boot-<machine>-<config>.bin-<target>` (e.g. `imx-boot-imx8mn-var-som-sd.bin-flash_ddr4_evk`) — `.bin` is mid-string, not the file extension.
- The `PV_FLASH_BOOT_IMAGE` globs for these three machines required a literal `.bin` suffix, so they matched nothing; `ls ... | head -n1` returned empty, and `install -m 644 "" bundle_dir/imx-boot.bin` failed.
- Fix: append `-*` to each glob so it matches the actual `<target>` suffix.

## Test plan
- [ ] Confirmed via shell glob test that the old pattern (`imx-boot-imx8mn-var-som*.bin`) matches nothing against a real deploy filename, and the new pattern (`imx-boot-imx8mn-var-som*.bin-*`) matches it.
- [ ] Verified each machine's `.conf` (`UBOOT_CONFIG`, `IMXBOOT_TARGETS`) yields exactly one boot image file, so `head -n1` remains safe.
- [ ] Run CI on the three affected build targets (`imx8mn-var-som-scarthgap`, `imx8qxp-b0-mek-scarthgap`, `imx8mm-var-dart-scarthgap`) to confirm `do_deploy` succeeds end-to-end.