### PR TITLE
fix(pv-examples): rename legacy dbus export off reserved system-bus name

### DIFF
--- a/recipes-containers/pv-examples/files/pv-example-dbus-client-attacker.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-dbus-client-attacker.args.json
@@ -1,7 +1,7 @@
 {
     "PV_SERVICES_REQUIRED": [
         {
-            "name": "system-bus",
+            "name": "example-system-bus",
             "type": "dbus",
             "role": "nobody",
             "interface": "org.pantavisor.Example",

--- a/recipes-containers/pv-examples/files/pv-example-dbus-client-nobody.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-dbus-client-nobody.args.json
@@ -1,7 +1,7 @@
 {
     "PV_SERVICES_REQUIRED": [
         {
-            "name": "system-bus",
+            "name": "example-system-bus",
             "type": "dbus",
             "role": "nobody",
             "interface": "org.pantavisor.Example",

--- a/recipes-containers/pv-examples/files/pv-example-dbus-client.args.json
+++ b/recipes-containers/pv-examples/files/pv-example-dbus-client.args.json
@@ -1,7 +1,7 @@
 {
     "PV_SERVICES_REQUIRED": [
         {
-            "name": "system-bus",
+            "name": "example-system-bus",
             "type": "dbus",
             "role": "root",
             "interface": "org.pantavisor.Example",

--- a/recipes-containers/pv-examples/files/pv-example-dbus-server.services.json
+++ b/recipes-containers/pv-examples/files/pv-example-dbus-server.services.json
@@ -1,6 +1,6 @@
 {
   "#spec": "service-manifest-xconnect@1",
   "services": [
-    {"name": "system-bus", "type": "dbus", "socket": "/run/dbus/system_bus_socket"}
+    {"name": "example-system-bus", "type": "dbus", "socket": "/run/dbus/system_bus_socket"}
   ]
 }


### PR DESCRIPTION
## Problem

On a build with the hosted system bus enabled (`PANTAVISOR_FEATURES` contains `xconnect-dbus-systembus`), the name `system-bus` is **reserved** for the pantavisor-hosted bus. `pv_dbus_daemon_validate()` rejects any container that exports it:

```
dbus-daemon ERROR (pv_dbus_daemon_validate:...)
  platform 'pv-example-dbus-server' exports reserved service name 'system-bus'
  while the hosted system bus is enabled
controller ERROR (_pv_wait:...)  a platform did not work as expected. Tearing down...
```

The **legacy** `pv-example-dbus-server` (which runs its *own* dbus-daemon inside the container and shares the socket over xconnect) declared its export as `system-bus`, so on any hosted-bus build the whole revision tears down and rolls back.

This was hit live on `labslave_rpi5` upgrading into the 029-rc2 hosted-bus BSP: the pre-existing legacy example container flipped from valid → rejected → rollback.

## Fix

Rename the legacy xconnect export (and the matching `pv-example-dbus-client{,-attacker,-nobody}` requirements) from `system-bus` → `example-system-bus`. Pure metadata; no rootfs change. The legacy example still demonstrates the container-hosted-daemon pattern, just off the reserved name.

The hosted-bus example family (`pv-example-dbus-host-*`, which uses `owns` on `bus: system-bus` the correct way) is unaffected — the reserved-name check keys on the export `name`, not the `bus` field.

## Validation

- CI green across the build matrix + `pvtest-local`.
- Deployed the freshly-built containers (from this branch's source) to `labslave_rpi5` (armhf, hosted-bus BSP) as a new revision → reached `UPDATED` and runs stably, no reserved-name teardown, no rollback.
- Link confirmed functionally in `pantavisor.log`:
  ```
  pvx-dbus: Accepted connection for service example-system-bus from pid ...
  pvx-dbus: Masquerading D-Bus identity as role 'root' (UID 0) for service example-system-bus
  ```

## Follow-up (not in this PR)

Clearer hosted-bus examples: rename `pv-example-dbus-host-*` → `pv-example-system-dbus-*` and split the client into allowed/denied containers.
