### PR TITLE
recipes-pv: automated srcrev update

### DIFF
--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,3 +1,3 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
-PANTAVISOR_SRCREV = "feb08e7fa802e863c2294da1011160d9638b58ff"
+PANTAVISOR_SRCREV = "714f299b6d6649b673103012d6af09844a6ea075"


### PR DESCRIPTION
Updating pantavisor in ./recipes-pv/pantavisor/pantavisor.inc:
  feb08e7fa802e863c2294da1011160d9638b58ff -> 714f299b6d6649b673103012d6af09844a6ea075
    * 714f299 fix(update): report download progress on the mainloop heartbeat, not per object
    * b6620a6 feat(pvtx): support explicit commit revision name, fix ctrl socket lookup order