### PR TITLE
ci: remove pvtest retries so failures surface directly

### DIFF
--- a/.github/workflows/call-pvtests.yaml
+++ b/.github/workflows/call-pvtests.yaml
@@ -72,9 +72,9 @@ jobs:
           PARALLEL=${{ inputs.parallel }}
 
           if [[ -z "$TEST_TARGET" ]]; then
-            ./test.docker.sh run -V --retry 2 -p "$PARALLEL" -w $PVTEST_WORKSPACE
+            ./test.docker.sh run -V -p "$PARALLEL" -w $PVTEST_WORKSPACE
           elif [[ "$TEST_TARGET" == remote* ]]; then
-            ./test.docker.sh run "$TEST_TARGET" -V --retry 2 -w $PVTEST_WORKSPACE
+            ./test.docker.sh run "$TEST_TARGET" -V -w $PVTEST_WORKSPACE
           else
             ./test.docker.sh run "$TEST_TARGET" -V -p "$PARALLEL" -w $PVTEST_WORKSPACE
           fi

--- a/docs/ci/builds.md
+++ b/docs/ci/builds.md
@@ -267,7 +267,7 @@ The `call-pvtests.yaml` reusable workflow:
 
 1. Downloads the `pvtest-distro-docker-x86_64-scarthgap` artifact.
 2. Installs Docker images via `test.docker.sh install-docker`.
-3. Runs `test.docker.sh run <test_path>` with `--retry 3` for remote tests.
+3. Runs `test.docker.sh run <test_path>` (no retries — failures surface directly).
 4. Appends the SUMMARY section of `test.docker.log` to the step summary.
 5. Uploads the pvtest workspace (logs, valgrind output) as an artifact.
 6. Cleans up Docker containers and images.


### PR DESCRIPTION
## Summary
- pvtest runs passed `--retry 2` to `test.docker.sh`, silently re-running failed tests and masking flakiness; remove the flag so every failure surfaces on the first run
- Applies to all users of the `call-pvtests.yaml` reusable workflow: scheduled, manual, PR validation and release runs
- The `-r/--retry` option in `test.docker.sh` itself is kept (default: 0) for ad-hoc manual use

## Changes
- `.github/workflows/call-pvtests.yaml`: drop `--retry 2` from both `test.docker.sh run` invocations
- `docs/ci/builds.md`: update stale `--retry 3` mention to reflect no retries