### PR TITLE
feat(pantavisor-starter): add pv-avahi-browse; fix container-pvrexport do_deploy hook

### DIFF
--- a/classes/container-pvrexport.bbclass
+++ b/classes/container-pvrexport.bbclass
@@ -23,6 +23,23 @@ python __anonymous() {
     d.appendVar("IMAGE_INSTALL", " pvcontrol")
     d.setVarFlag("do_image_pvrexportit", "dirs", " ${TOPDIR} ${PVSTATE} ${PVR_CONFIG_DIR} ")
     d.setVarFlag("do_image_pvrexportit", "cleandirs", " ${PVSTATE} ")
+
+    # A pvrexport container's sole deliverable is the pvrexport, so give it the
+    # no-op do_deploy that pvroot-image depends on. Schedule it only when the
+    # image is a container (IMAGE_FSTYPES is exactly pvrexportit): this class is
+    # applied to every image via IMAGE_CLASSES, and on a wic-building system
+    # image do_image_wic[recrdeps]=do_build would make the task loop.
+    if set((d.getVar("IMAGE_FSTYPES") or "").split()) == {"pvrexportit"}:
+        bb.build.addtask("do_deploy", "do_build", "do_image_complete", d)
+}
+
+# pvroot-image consumes each container as ${PN}.pvrexport.tgz from
+# DEPLOY_DIR_IMAGE and depends on its do_deploy as the "artifact ready" signal.
+# For image containers the tgz is already deployed by do_image_complete's
+# sstate, so this is a no-op ordering task (scheduled by __anonymous above). We
+# do NOT `inherit deploy`: a real deploy task would re-deploy the tgz and clash.
+fakeroot do_deploy() {
+    :
 }
 
 PVR_FORMAT_OPTS ?= "${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', '-comp lz4 -Xhc', '-comp xz', d)}"

--- a/recipes-containers/pantavisor/pv-avahi-browse_1.0.bb
+++ b/recipes-containers/pantavisor/pv-avahi-browse_1.0.bb
@@ -8,6 +8,8 @@ IMAGE_BASENAME = "pv-avahi-browse"
 
 PVRIMAGE_AUTO_MDEV = "0"
 
+IMAGE_FSTYPES = "pvrexportit"
+
 # Single-pid consumer: avahi client tools to browse over the injected bus, plus
 # dbus-send so the pvtest can drive an explicit D-Bus roundtrip. No dbus-daemon,
 # no policy XML, no /etc/passwd: identity is the 'monitor' role, masqueraded by

--- a/recipes-containers/pantavisor/pv-avahi_1.1.bb
+++ b/recipes-containers/pantavisor/pv-avahi_1.1.bb
@@ -34,13 +34,7 @@ PVR_APP_ADD_GROUP = "platform"
 # Sign including config (override --noconfig default from container-pvrexport)
 PVR_SIG_ADD_ARGS = "--part ${PN}"
 
-# pvroot-image expects do_deploy to provide the .pvrexport.tgz
-# do_image_complete sstate also deploys it, so use symlink to avoid conflict
-fakeroot do_deploy() {
-    :
-}
-
-addtask deploy after do_image_complete before do_build
+# do_deploy hook for pvroot-image consumption is provided by container-pvrexport
 
 install_scripts() {
     install -d ${IMAGE_ROOTFS}${bindir}

--- a/recipes-containers/pantavisor/pvwificonnect_v1.7.0.bb
+++ b/recipes-containers/pantavisor/pvwificonnect_v1.7.0.bb
@@ -89,10 +89,4 @@ do_image_pvrexportit:append() {
     pvr export ${IMGDEPLOYDIR}/${PN}.pvrexport.tgz
 }
 
-# pvroot-image expects do_deploy to provide the .pvrexport.tgz
-# do_image_complete sstate also deploys it, so use symlink to avoid conflict
-fakeroot do_deploy() {
-    :
-}
-
-addtask deploy after do_image_complete before do_build
+# do_deploy hook for pvroot-image consumption is provided by container-pvrexport

--- a/recipes-pv/images/pantavisor-starter.bb
+++ b/recipes-pv/images/pantavisor-starter.bb
@@ -6,7 +6,7 @@ inherit image pvroot-image pantavisor-docs
 FILESPATH = "${@base_set_filespath(["${FILE_DIRNAME}/${BP}", \
         "${FILE_DIRNAME}/${BPN}", "${FILE_DIRNAME}/files"], d)}"
 
-PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pvwificonnect pv-avahi"
+PVROOT_CONTAINERS_CORE ?= "pv-pvr-sdk pv-alpine-connman pvwificonnect pv-avahi pv-avahi-browse"
 
 PVROOT_IMAGE_BSP ?= "core-image-minimal"
 


### PR DESCRIPTION
Adds `pv-avahi-browse` (the mDNS browse consumer) to the starter image's `PVROOT_CONTAINERS_CORE`, alongside the existing `pv-avahi` provider — shipping both sides of the hosted-bus Avahi example.

## The catch: container-pvrexport didn't provide `do_deploy`

`pvroot-image` makes `do_rootfs_pvroot` depend on each container's **`do_deploy`** task (not `do_image_complete`, which is only used for the BSP). But `container-pvrexport` — the "build a Yocto image, then pvrexport it" path — never provided a `do_deploy` task. Recipes had to hand-roll a no-op, and `pv-avahi-browse` didn't, so pulling it into the starter failed parse:

```
Task do_rootfs_pvroot ... depends upon non-existent task do_deploy in pv-avahi-browse_1.0.bb
```

## Fix: put the hook in the class

Moved the no-op ordering hook into `container-pvrexport.bbclass`, so **any Yocto image becomes a valid pvroot container just by inheriting the class** — no per-recipe boilerplate. The `.pvrexport.tgz` is already deployed to `DEPLOY_DIR_IMAGE` by `do_image_complete`'s sstate, so the task stays a no-op; we deliberately do **not** `inherit deploy` (a real deploy task would re-deploy the same tgz and conflict).

The download/pull path (`pvrexport.bbclass`, used by `pv-pvr-sdk`/`pv-alpine-connman`) is untouched — it inherits `deploy` and builds the export in a real `do_deploy`.

Also dropped the now-redundant per-recipe hooks from `pv-avahi` and `pvwificonnect`.