### PR TITLE
recipes-pv: automated srcrev update

### DIFF
--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,3 +1,3 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
-PANTAVISOR_SRCREV = "714f299b6d6649b673103012d6af09844a6ea075"
+PANTAVISOR_SRCREV = "2b921223de5ad27e9275d216dce170ea83075c90"


### PR DESCRIPTION
Updating pantavisor in ./recipes-pv/pantavisor/pantavisor.inc:
  714f299b6d6649b673103012d6af09844a6ea075 -> 2b921223de5ad27e9275d216dce170ea83075c90
    * 2b92122 docs: fix dead docs.pantavisor.io links, use relative cross-repo refs
    * 913f9f7 fix(ci): checkout the PR's actual head commit, not GitHub's synthetic merge SHA
    * 471b659 changelogs(029-rc3): autoadd changelog
    * cb979ae changelogs(029-rc2): autoadd changelog
    * e42b89c changelogs(029-rc1): autoadd changelog
    * 88bcd3d fix(ci): use GITHUB_TOKEN instead of missing PANTAVISOR_TAG_SYNC_TOKEN
    * 078734a fix(ci): scope on-push workflow to master/pull_request, exclude tag pushes
    * aa66a3f fix(pvtx): force to use "locals/" as prefix in custom revision names