### PR TITLE
fix(pv-manifest-audit): gate every build via nostamp task

### DIFF
--- a/classes/pv-manifest-audit.bbclass
+++ b/classes/pv-manifest-audit.bbclass
@@ -58,7 +58,7 @@ PV_MANIFEST_REFERENCE_NAME ??= "${PV_MANIFEST_PREFIX}_${DISTRO}-${MACHINE}${@'-'
 # files themselves (binaries, libs, configs).
 PV_MANIFEST_EXCLUDES ??= "/var/lib/rpm /var/lib/dnf /var/lib/opkg /usr/lib/opkg /var/cache/ldconfig /var/cache/dnf /var/cache/yum"
 
-python pv_manifest_audit_run() {
+python do_pv_manifest_audit() {
     import os, stat, difflib
 
     rootfs = d.getVar('IMAGE_ROOTFS')
@@ -68,7 +68,7 @@ python pv_manifest_audit_run() {
     # manifest.txt + manifest.patch survive a bb.fatal in strict mode.
     # IMGDEPLOYDIR is per-recipe staging that bitbake only rsyncs to
     # DEPLOY_DIR_IMAGE on successful task completion — a strict-mode
-    # abort during ROOTFS_POSTPROCESS_COMMAND would otherwise leave the
+    # abort in do_pv_manifest_audit would otherwise leave the
     # diagnostic artifact stranded in WORKDIR where CI never finds it.
     deploy_dir = d.getVar('DEPLOY_DIR_IMAGE')
     workdir = d.getVar('WORKDIR') or ''
@@ -206,13 +206,14 @@ python pv_manifest_audit_run() {
               '# patch file: %s (relative to TOPDIR)' % patch_rel,
               '# manifest:   %s (relative to TOPDIR)' % manifest_rel,
               '# apply with: cd <layer>/files && patch < $TOPDIR/%s' % patch_rel,
+              '# or copy with: cd <layer>/files && cp $TOPDIR/%s' % patch_rel,
               '']
     bb.plain('\n'.join(banner) + patch + '=== end pv-manifest-audit PATCH ===\n')
 
-    advice = (" Patch: " + patch_rel +
+    advice = (" Manifest: " + manifest_rel + ". Patch: " + patch_rel +
               ". To adopt: ship the regenerated reference via "
               "SRC_URI += \"file://%s\" (or apply the patch under the "
-              "layer's files/ directory)." % ref_name)
+              "layer's files/ directory or copy the new manifest %s)." % (ref_name, manifest_rel))
 
     if strict:
         bb.fatal(headline + advice +
@@ -223,7 +224,13 @@ python pv_manifest_audit_run() {
                 "PANTAVISOR_FEATURES to gate the build)")
 }
 
-ROOTFS_POSTPROCESS_COMMAND += "pv_manifest_audit_run;"
+# Dedicated task, not a ROOTFS_POSTPROCESS_COMMAND: [nostamp] so it re-runs
+# every build (a postprocess is skipped whenever do_rootfs is served from
+# stamp/sstate, silently bypassing the gate).
+addtask do_pv_manifest_audit after do_rootfs before do_image
+do_pv_manifest_audit[nostamp] = "1"
+do_pv_manifest_audit[vardeps] += "PANTAVISOR_FEATURES PV_MANIFEST_PREFIX PV_MANIFEST_REFERENCE_NAME PV_MANIFEST_EXCLUDES"
 
-# Make the audit re-run when feature flags or naming inputs change.
-pv_manifest_audit_run[vardeps] += "PANTAVISOR_FEATURES PV_MANIFEST_PREFIX PV_MANIFEST_REFERENCE_NAME PV_MANIFEST_EXCLUDES"
+# Run under pseudo so os.lstat() records the image's uid/gid, not the builder's.
+do_pv_manifest_audit[fakeroot] = "1"
+do_pv_manifest_audit[depends] += "virtual/fakeroot-native:do_populate_sysroot"

--- a/classes/pv-manifest-audit.bbclass
+++ b/classes/pv-manifest-audit.bbclass
@@ -39,9 +39,12 @@
 # Output:
 #   - Manifest is always written to
 #       ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.manifest.txt
+#     with a stable, build-id-free symlink alongside it:
+#       ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.manifest.txt
 #   - On any deviation (missing reference or mismatch) a unified-diff patch
 #     is written next to the manifest as
 #       ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.manifest.patch
+#     (also symlinked as ${IMAGE_LINK_NAME}.manifest.patch)
 #     and printed in full to the bitbake log via bb.plain (CI-visible).
 #     The patch headers use the reference's bare basename, so a maintainer
 #     can apply it with:
@@ -80,6 +83,24 @@ python do_pv_manifest_audit() {
     manifest_path = os.path.join(deploy_dir, image_name + '.manifest.txt')
     patch_path = os.path.join(deploy_dir, image_name + '.manifest.patch')
     ref_path = os.path.join(workdir, ref_name)
+
+    # Stable, build-id-free symlinks pointing at the latest versioned files.
+    link_name = d.getVar('IMAGE_LINK_NAME') or ''
+    manifest_link = os.path.join(deploy_dir, link_name + '.manifest.txt') if link_name else ''
+    patch_link = os.path.join(deploy_dir, link_name + '.manifest.patch') if link_name else ''
+
+    def _relink(link, target):
+        if not link:
+            return
+        try: os.remove(link)
+        except OSError: pass
+        os.symlink(os.path.basename(target), link)
+
+    def _rmlink(link):
+        if not link:
+            return
+        try: os.remove(link)
+        except OSError: pass
 
     # Render paths relative to TOPDIR so the strings are usable both inside
     # the kas/bitbake container and on the host (TOPDIR maps to build/).
@@ -164,6 +185,7 @@ python do_pv_manifest_audit() {
             f.write('# exclude: %s\n' % ' '.join(excludes))
         f.write(body)
 
+    _relink(manifest_link, manifest_path)
     bb.note('pv-manifest-audit: wrote %s (%d entries)' % (manifest_rel, len(entries)))
 
     have_ref = os.path.exists(ref_path)
@@ -179,6 +201,7 @@ python do_pv_manifest_audit() {
         if os.path.exists(patch_path):
             try: os.unlink(patch_path)
             except OSError: pass
+        _rmlink(patch_link)
         return
 
     # Build a patch whose headers carry the bare basename so it applies
@@ -191,6 +214,7 @@ python do_pv_manifest_audit() {
         tofile=ref_name))
     with open(patch_path, 'w') as f:
         f.write(patch)
+    _relink(patch_link, patch_path)
 
     if have_ref:
         headline = ("pv-manifest-audit: rootfs manifest for MACHINE '%s' "

--- a/docs/how-to-build/manifest-audit.md
+++ b/docs/how-to-build/manifest-audit.md
@@ -102,6 +102,10 @@ Two files land in the image deploy dir for every build:
 | `${IMAGE_NAME}.manifest.txt`      | Always                                |
 | `${IMAGE_NAME}.manifest.patch`    | Only when there is a drift to record  |
 
+Each is accompanied by a stable, build-id-free symlink
+(`${IMAGE_LINK_NAME}.manifest.txt` / `.manifest.patch`) pointing at the latest
+versioned file, so tooling can reference a fixed path.
+
 The patch is also dumped in full into the bitbake log via `bb.plain` so it
 shows in CI output without any extra plumbing. Look for the banner:
 

--- a/docs/how-to-build/manifest-audit.md
+++ b/docs/how-to-build/manifest-audit.md
@@ -193,9 +193,16 @@ Currently inherited by:
 
 ## Implementation
 
-`classes/pv-manifest-audit.bbclass` registers a `ROOTFS_POSTPROCESS_COMMAND`
-(`pv_manifest_audit_run`). It runs under pseudo, so the uid/gid recorded in
-the manifest are the same ones that end up in the cpio / tarball. The task is
-re-invalidated when `PANTAVISOR_FEATURES`, `PV_MANIFEST_PREFIX`,
-`PV_MANIFEST_REFERENCE_NAME`, or `PV_MANIFEST_EXCLUDES` change (declared via
-`vardeps`).
+`classes/pv-manifest-audit.bbclass` adds a dedicated `do_pv_manifest_audit`
+task that runs after `do_rootfs` and before `do_image`. It is marked
+`[fakeroot]`, so it runs under pseudo and the uid/gid recorded in the manifest
+are the same ones that end up in the cpio / tarball.
+
+The task is marked `[nostamp]`, so it re-runs on **every** build. This is
+deliberate: a `ROOTFS_POSTPROCESS_COMMAND` only executes while `do_rootfs`
+itself runs, so once the rootfs stamp is valid or the image is restored from
+sstate via setscene, the gate would be silently skipped — a strict-mode
+deviation would fail the first build but pass every rebuild. As a `nostamp`
+task consuming the live `IMAGE_ROOTFS`, it always runs (and forces `do_rootfs`
+to produce a real rootfs), so a strict deviation keeps failing until the
+reference is updated.


### PR DESCRIPTION
## Problem

The manifest audit ran as a `ROOTFS_POSTPROCESS_COMMAND`, so it only executed while `do_rootfs` ran. In strict mode the first build failed correctly, but any rebuild that served `do_rootfs` from a valid stamp — or restored `do_image*` from sstate via setscene — skipped the gate entirely and the build "succeeded".

## Changes

- Promote to a dedicated `[nostamp]` `do_pv_manifest_audit` task (`after do_rootfs`, `before do_image`) so it re-runs on every build and keeps failing until the reference is updated.
- Mark it `[fakeroot]` so `os.lstat` records the image's uid/gid, not the builder's (a postprocess command got pseudo for free; a standalone task does not).
- Fix a latent format-string bug in the deviation advice (`not enough arguments for format string`), now reachable on every strict run.
- Add stable, build-id-free `IMAGE_LINK_NAME` symlinks (`.manifest.txt` / `.manifest.patch`) pointing at the latest versioned artifacts, so tooling can reference a fixed path. The patch symlink is removed when the rootfs matches the reference.

Docs updated in `docs/how-to-build/manifest-audit.md`.