### PR TITLE
fix(rockchip): register meta-rockchip-mainline dynamic layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -26,6 +26,7 @@ BBFILES_DYNAMIC += "\
 	ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti-bsp/recipes-*/*/*.bbappend \
 	variscite-bsp:${LAYERDIR}/dynamic-layers/meta-variscite-bsp/recipes-*/*/*.bbappend \
 	toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/recipes-*/*/*.bbappend \
+	rockchip:${LAYERDIR}/dynamic-layers/meta-rockchip-mainline/recipes-*/*/*.bbappend \
 "
 
 IMAGE_CLASSES += "image_types_vfat"


### PR DESCRIPTION
Adds the missing `BBFILES_DYNAMIC` entry for `meta-rockchip-mainline` so its bbappends under `dynamic-layers/meta-rockchip-mainline/recipes-*/*/*.bbappend` are picked up when the rockchip layer is present.

Without this entry the rockchip mainline appends are silently ignored.