### PR TITLE
fix(ci): exclude tag pushes and PR open events from onpush workflow

### DIFF
--- a/.github/scripts/make-onpush-matrix.py
+++ b/.github/scripts/make-onpush-matrix.py
@@ -28,6 +28,8 @@ lines = [
     "",
     "on:",
     "  push:",
+    "    branches:",
+    "      - '**'",
     "    paths:",
     "      - '**'",
     "      # Skip pushes that only touch CI internals (generators,",
@@ -48,7 +50,7 @@ if pvtest_machines:
 lines += [
     f"      - '.github/workflows/onpush-{branch}.yaml'",
     "  pull_request:",
-    "    types: [opened, ready_for_review]",
+    "    types: [ready_for_review]",
     "",
     "concurrency:",
     "  group: ${{ github.workflow }}-${{ github.ref }}",

--- a/.github/workflows/onpush-scarthgap.yaml
+++ b/.github/workflows/onpush-scarthgap.yaml
@@ -9,6 +9,8 @@ name: "onpush: scarthgap"
 
 on:
   push:
+    branches:
+      - '**'
     paths:
       - '**'
       # Skip pushes that only touch CI internals (generators,
@@ -24,7 +26,7 @@ on:
       - '.github/workflows/call-pvtests.yaml'
       - '.github/workflows/onpush-scarthgap.yaml'
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION

The onpush-scarthgap workflow had two trigger issues:

1. **Double-triggering on PR creation** — When a non-draft PR is opened, both the `push` event
   (from the initial commit) and the `pull_request [opened]` event fire, causing two workflow runs.
   Fixed by dropping `opened` from `pull_request` types, keeping only `ready_for_review` (needed
   for draft → ready transitions). The `push` trigger already covers the initial commit.

2. **Triggering on tag pushes** — The `push` trigger had no `branches` or `tags` filter, so it
   fired on tag pushes handled by `tag-scarthgap.yaml`. Fixed by adding `branches: ['**']` to
   restrict the trigger to branch pushes only.

### Changes

- `.github/scripts/make-onpush-matrix.py` — generator script updated (source of truth)
- `.github/workflows/onpush-scarthgap.yaml` — regenerated from the script

### Test Plan

- CI on this PR should show a single run (not duplicated)
- Tag pushes should only trigger `tag-scarthgap.yaml`
- Draft → ready transitions should still trigger a build
