### PR TITLE
fix(ci): succeed when there are no machine updates to propose

### DIFF
--- a/.github/scripts/makecommit
+++ b/.github/scripts/makecommit
@@ -5,9 +5,11 @@ set -xe
 changed=`git diff HEAD kas/build-configs/release | lsdiff | sed 's/.\///'`
 changed2=`git diff HEAD .github/workflows/ | lsdiff | sed 's/.\///'`
 
+# Exit code 3 means "nothing to commit" and is not an error; callers are
+# expected to distinguish it from a real failure.
 if [ -z "$changed" -a -z "$changed2" ]; then
 	echo "NO changes"
-	exit 1
+	exit 3
 fi
 
 echo "Changes: $changed $changed2"

--- a/.github/workflows/schedule-updatemachines.yaml
+++ b/.github/workflows/schedule-updatemachines.yaml
@@ -40,10 +40,18 @@ jobs:
       - name: make PR
         if: github.ref_name == 'master'
         run: |
-          .github/scripts/makecommit && \
-          git push origin -f autopr/machine-update-$GITHUB_REF_NAME-next && \
-          { gh pr create --base $GITHUB_REF_NAME \
+          set -e
+          .github/scripts/makecommit && rc=0 || rc=$?
+          if [ "$rc" -eq 3 ]; then
+            echo "No machine or workflow updates to propose — nothing to do."
+            echo "No machine or workflow updates to propose." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          elif [ "$rc" -ne 0 ]; then
+            exit "$rc"
+          fi
+          git push origin -f autopr/machine-update-$GITHUB_REF_NAME-next
+          gh pr create --base $GITHUB_REF_NAME \
             --title "AutoPR: update kas meta layers to latest branch commits" \
-            --body "Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog." || true; }
+            --body "Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog." || true
         env:
           GH_TOKEN: ${{ secrets.PANTAVISOR_TAG_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

The `schedule: update machines` job failed on every run that had nothing to update — which is most of them.

`makecommit` exits non-zero when neither `kas/build-configs/release` nor `.github/workflows/` has changed. The `make PR` step chained everything with `&&`, so that exit code became the step's exit code and the job went red even though the outcome was perfectly normal.

This gives the no-changes path a dedicated exit code (`3`) so it can be told apart from a genuine failure (a yq error, a failed patch, a broken fetch), and has the workflow treat it as success while still propagating any other non-zero status. The `&&` chain is unwound into sequential commands under `set -e`, which short-circuits the same way without collapsing every exit code into one.

`schedule-updates.yaml` was checked for the same bug and does not have it — it already guards with `git diff --cached --quiet` and its update script exits 0 either way. No changes needed there.

## Test plan

- `makecommit` returns 3 on a clean tree (verified in a throwaway clone, since the working tree carries these edits).
- The step's branching was exercised against exit codes 0, 3 and 1, giving push-and-PR, a clean pass, and a propagated failure respectively.
- Real confirmation comes from the next scheduled run (or a `workflow_dispatch` on master): a no-op run should now finish green with "No machine or workflow updates to propose" in the step summary.