### PR TITLE
ci: add manual workflow to generate latest docs from master

### DIFF
--- a/.github/workflows/manual-docs-scarthgap.yaml
+++ b/.github/workflows/manual-docs-scarthgap.yaml
@@ -1,0 +1,74 @@
+name: "manual: generate latest docs"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    env:
+      TMPDIR: "tmp-scarthgap"
+    runs-on: ["self-hosted"]
+    container:
+      image: ghcr.io/pantacor/kas/kas:next-v7
+      volumes:
+        - shared:/shared
+      options: --user root
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+
+      - name: setup workspace
+        run: |
+          chown -R builder:builder $RUNNER_WORKSPACE
+          chown -R builder:builder /__w
+          mkdir -p /shared/sstate && chown builder:builder /shared/sstate && mkdir -p /shared/dldir && chown builder:builder /shared/dldir
+          su - builder -c "cd $GITHUB_WORKSPACE && git fetch origin master && git reset --hard origin/master && rm -rf build/ && git clean -f -f -d -x"
+          git config --global --add safe.directory /__w/meta-pantavisor/meta-pantavisor
+
+      - name: build docs
+        run: |
+          su - builder -c "cd $GITHUB_WORKSPACE && kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine-distro"
+
+      - name: collect docs tarball
+        run: |
+          chmod -R 777 $GITHUB_WORKSPACE
+          mkdir -p docs-out
+          find build/${{ env.TMPDIR }}/deploy/images/docker-x86_64 -name "*.rootfs.docs.tar.zst" ! -type l -exec cp {} docs-out/ \;
+          ls -l docs-out
+
+      - name: upload docs to S3 and update latest.json
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          AWS_S3_URL="https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor"
+
+          ORIG_FILEPATH=$(ls docs-out/*.rootfs.docs.tar.zst)
+          ORIG_FILENAME=$(basename "${ORIG_FILEPATH}")
+          NEW_FILENAME=$(echo "${ORIG_FILENAME}" \
+            | sed 's/pantavisor-appengine-distro-/pantavisor-/' \
+            | sed 's/\.rootfs\.docs\.tar\.zst$/.docs.tar.zst/')
+          cp "${ORIG_FILEPATH}" "docs-out/${NEW_FILENAME}"
+
+          DOCS_CSUM=$(sha256sum "docs-out/${NEW_FILENAME}" | cut -d' ' -f1)
+
+          aws s3 cp "docs-out/${NEW_FILENAME}" "s3://${AWS_S3_BUCKET}/docs/latest/${NEW_FILENAME}"
+          DOCS_S3_URL="${AWS_S3_URL}/docs/latest/${NEW_FILENAME}"
+
+          jq -n \
+            --arg docs_name "${NEW_FILENAME}" \
+            --arg docs_sha "${DOCS_CSUM}" \
+            --arg docs_url "${DOCS_S3_URL}" \
+            --arg branch "master" \
+            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          '{
+            name: $docs_name,
+            hash: $docs_sha,
+            url: $docs_url,
+            branch: $branch,
+            generated: $timestamp
+          }' > latest.json
+
+          aws s3 cp latest.json "s3://${AWS_S3_BUCKET}/docs/latest.json"

--- a/docs/overview/ci/builds.md
+++ b/docs/overview/ci/builds.md
@@ -247,6 +247,47 @@ The tag is taken from `workflow_run.head_branch` (the tag that triggered
 present on the default branch, this workflow takes effect once it is on
 `master`.
 
+## Manual Documentation Build (manual-docs-scarthgap.yaml)
+
+`manual-docs-scarthgap.yaml` is a `workflow_dispatch` counterpart to
+`tag-docs-scarthgap.yaml`. It generates the latest documentation tarball from
+the `master` branch on demand (unlike the tag-triggered workflow, which only
+runs on push).
+
+The job:
+
+1. Checks out the latest `master` commit (always ignores the triggering
+   branch/ref).
+2. Runs `kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine-distro`
+   inside the KAS container. `docker-x86_64-scarthgap` is used because it
+   targets `pantavisor-appengine-distro`, which pulls in the full component
+   set needed for documentation.
+3. Collects the real tarball (non-symlink `*.rootfs.docs.tar.zst`) from
+   `build/tmp-scarthgap/deploy/images/docker-x86_64/`.
+4. Renames the tarball: `pantavisor-appengine-distro-<rest>.rootfs.docs.tar.zst` →
+   `pantavisor-<rest>.docs.tar.zst`.
+5. Uploads the renamed tarball to the `docs/latest/` prefix in S3:
+   ```
+   s3://<BUCKET>/meta-pantavisor/docs/latest/pantavisor-<rest>.docs.tar.zst
+   ```
+6. Writes a `latest.json` metadata file to
+   `s3://<BUCKET>/meta-pantavisor/docs/latest.json`:
+
+```json
+{
+  "name": "pantavisor-<rest>.docs.tar.zst",
+  "hash": "<sha256>",
+  "url": "https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor/docs/latest/pantavisor-<rest>.docs.tar.zst",
+  "branch": "master",
+  "generated": "<ISO 8601 timestamp>"
+}
+```
+
+Unlike `tag-docs-scarthgap.yaml`, this workflow does **not** upload to GitHub
+Releases or send a `repository_dispatch` to `docs.pantavisor` — it is purely
+a build-and-upload-to-S3 convenience for getting the latest docs during
+development.
+
 ## CI Badges (upload-badges)
 
 After all build jobs finish, the `summary` job in `release.yaml` calls `upload-badges`. The script:


### PR DESCRIPTION
Adds a manually triggered workflow (`manual-docs-scarthgap.yaml`) that:

- Checks out the `master` branch
- Builds docs via `kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine-distro`
- Collects the docs tarball from `build/tmp-scarthgap/deploy/images/docker-x86_64/`
- Uploads the tarball to `s3://<bucket>/docs/latest/` and writes `latest.json` metadata to `s3://<bucket>/docs/latest.json`

Patterned after `tag-docs-scarthgap.yaml` but using `workflow_dispatch` instead of `workflow_run`.