### PR TITLE
feat(power): BSP enablement for wakelocks + managed mode (PM config + SNVS RTC)

### DIFF
--- a/classes/pvbase.bbclass
+++ b/classes/pvbase.bbclass
@@ -12,7 +12,11 @@ PANTAVISOR_FEATURES ??= " \
 	xconnect-dbus-systembus \
 	container-mdev \
 "
-# PANTAVISOR_FEATURES += "lxc-next"
-# PANTAVISOR_FEATURES += "console-logging"
+
+# Available, off by default:
+# PANTAVISOR_FEATURES:append = " lxc-next"
+# PANTAVISOR_FEATURES:append = " console-logging"
+# PM wakelocks + autosleep
+# PANTAVISOR_FEATURES:append = " wakelocks"
 
 

--- a/dynamic-layers/meta-variscite-bsp/recipes-kernel/linux/files/0001-arm64-dts-imx8mn-var-som-symphony-enable-snvs-rtc.patch
+++ b/dynamic-layers/meta-variscite-bsp/recipes-kernel/linux/files/0001-arm64-dts-imx8mn-var-som-symphony-enable-snvs-rtc.patch
@@ -1,0 +1,34 @@
+From: Alexander Sack <alexander.sack@pantacor.com>
+Date: Thu, 16 Jul 2026 00:00:00 +0000
+Subject: [PATCH] arm64: dts: imx8mn-var-som-symphony: enable SNVS RTC
+
+The VAR-SOM-MX8M-NANO Symphony board disables the SoC SNVS low-power RTC
+(&snvs_rtc) in favour of the battery-backed external DS1307 on I2C2. The
+DS1307 as wired on the SoM has no alarm interrupt routed, so it is not a
+system wakeup source and exposes no /sys/class/rtc/rtcN/wakealarm.
+
+Pantavisor "managed" power mode uses a CLOCK_BOOTTIME_ALARM timer to wake
+the device from suspend-to-RAM on a schedule to poll the Hub; that needs a
+wakeup-capable RTC alarm. The i.MX8MN SNVS RTC lives in the always-on
+domain and its alarm IRQ (GIC_SPI 19/20) is a valid GPC suspend wakeup
+source. Enable it so the kernel alarmtimer framework can arm wakeups. The
+DS1307 remains rtc0 (RTC_HCTOSYS_DEVICE); the SNVS RTC registers as an
+additional wakeup-capable rtc used only for alarms.
+
+Signed-off-by: Alexander Sack <alexander.sack@pantacor.com>
+---
+ arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts b/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
+--- a/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
+@@ -448,7 +448,7 @@
+ };
+ 
+ &snvs_rtc {
+-	status = "disabled";
++	status = "okay";
+ };
+ 
+ /* Header */

--- a/dynamic-layers/meta-variscite-bsp/recipes-kernel/linux/linux-variscite-fslc-imx_%.bbappend
+++ b/dynamic-layers/meta-variscite-bsp/recipes-kernel/linux/linux-variscite-fslc-imx_%.bbappend
@@ -4,7 +4,10 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 # "managed" power mode has a wakeup-capable RTC alarm (CLOCK_BOOTTIME_ALARM) to
 # wake the device from suspend-to-RAM. The board otherwise only exposes the
 # external DS1307, whose alarm IRQ is not wired as a wakeup source. Guarded on
-# virtual/kernel so it only applies to the kernel recipe, not shared providers.
+# virtual/kernel so it only applies to the kernel recipe, not shared providers,
+# and on the wakelocks feature since it makes snvs_rtc rtc0 (the board then
+# boots at 1970 until the DS1307/NTP corrects it) — a side effect nobody should
+# take who is not using managed power.
 SRC_URI:append:imx8mn-var-som = " \
-	${@'file://0001-arm64-dts-imx8mn-var-som-symphony-enable-snvs-rtc.patch' if bb.utils.contains('PROVIDES', 'virtual/kernel', True, False, d) else ''} \
+	${@'file://0001-arm64-dts-imx8mn-var-som-symphony-enable-snvs-rtc.patch' if bb.utils.contains('PROVIDES', 'virtual/kernel', True, False, d) and bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', True, False, d) else ''} \
 "

--- a/dynamic-layers/meta-variscite-bsp/recipes-kernel/linux/linux-variscite-fslc-imx_%.bbappend
+++ b/dynamic-layers/meta-variscite-bsp/recipes-kernel/linux/linux-variscite-fslc-imx_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Enable the SoC SNVS RTC on the VAR-SOM-MX8M-NANO Symphony board so Pantavisor
+# "managed" power mode has a wakeup-capable RTC alarm (CLOCK_BOOTTIME_ALARM) to
+# wake the device from suspend-to-RAM. The board otherwise only exposes the
+# external DS1307, whose alarm IRQ is not wired as a wakeup source. Guarded on
+# virtual/kernel so it only applies to the kernel recipe, not shared providers.
+SRC_URI:append:imx8mn-var-som = " \
+	${@'file://0001-arm64-dts-imx8mn-var-som-symphony-enable-snvs-rtc.patch' if bb.utils.contains('PROVIDES', 'virtual/kernel', True, False, d) else ''} \
+"

--- a/kas/build-configs/release/imx8mn-var-som-scarthgap.yaml
+++ b/kas/build-configs/release/imx8mn-var-som-scarthgap.yaml
@@ -128,6 +128,8 @@ local_conf_header:
         PANTAVISOR_FEATURES:append = " tailscale"
     pantavisor-debug: |
         PANTAVISOR_FEATURES:append = " debug"
+    pantavisor-wakelocks: |
+        PANTAVISOR_FEATURES:append = " wakelocks"
     __menu_config_locals: ''
     __menu_config_vars: |-
         EXTRA_IMAGE_FEATURES:append = " debug-tweaks"

--- a/kas/machines/imx8mn-var-som.yaml
+++ b/kas/machines/imx8mn-var-som.yaml
@@ -11,3 +11,10 @@ header:
 
 # The machine as it is written into the `local.conf` of bitbake.
 machine: imx8mn-var-som
+
+local_conf_header:
+ platform-imx8mn-var-som: |
+  # Wakelocks / managed power. This is the board managed mode is validated on:
+  # it has real PSCI suspend-to-RAM and, via the SNVS RTC patch this feature
+  # gates, a wakeup-capable RTC alarm to wake from it on schedule.
+  PANTAVISOR_FEATURES:append = " wakelocks"

--- a/recipes-kernel/linux/files/wakelock.cfg
+++ b/recipes-kernel/linux/files/wakelock.cfg
@@ -1,0 +1,10 @@
+#
+# Pantavisor wakelocks: userspace suspend-blocking via the mainline
+# /sys/power/wake_lock interface, plus opportunistic-suspend autosleep for
+# Pantavisor "managed" power mode. CONFIG_SUSPEND / CONFIG_PM_SLEEP are already
+# enabled by the base defconfig on supported machines.
+#
+CONFIG_PM_WAKELOCKS=y
+CONFIG_PM_WAKELOCKS_LIMIT=100
+CONFIG_PM_WAKELOCKS_GC=y
+CONFIG_PM_AUTOSLEEP=y

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -36,6 +36,7 @@ PANTAVISOR_SRC_URI = " \
 	file://pantavisor.cfg \
 	file://pvcrypt.cfg \
 	file://dm.cfg \
+	file://wakelock.cfg \
 	${TAILSCALE_KERNEL_SRC_URI} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', 'file://pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', 'file://caam-nxp.cfg', '', d)} \
@@ -48,6 +49,7 @@ PANTAVISOR_KERNEL_FRAGMENTS = " \
 	${WORKDIR}/pvcrypt.cfg \
 	${WORKDIR}/overlayfs.cfg \
 	${WORKDIR}/dm.cfg \
+	${WORKDIR}/wakelock.cfg \
 	${TAILSCALE_KERNEL_FRAGMENT} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', '${WORKDIR}/pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', '${WORKDIR}/caam-nxp.cfg', '', d)} \

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -36,7 +36,7 @@ PANTAVISOR_SRC_URI = " \
 	file://pantavisor.cfg \
 	file://pvcrypt.cfg \
 	file://dm.cfg \
-	file://wakelock.cfg \
+	${@bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', 'file://wakelock.cfg', '', d)} \
 	${TAILSCALE_KERNEL_SRC_URI} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', 'file://pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', 'file://caam-nxp.cfg', '', d)} \
@@ -49,7 +49,7 @@ PANTAVISOR_KERNEL_FRAGMENTS = " \
 	${WORKDIR}/pvcrypt.cfg \
 	${WORKDIR}/overlayfs.cfg \
 	${WORKDIR}/dm.cfg \
-	${WORKDIR}/wakelock.cfg \
+	${@bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', '${WORKDIR}/wakelock.cfg', '', d)} \
 	${TAILSCALE_KERNEL_FRAGMENT} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', '${WORKDIR}/pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', '${WORKDIR}/caam-nxp.cfg', '', d)} \


### PR DESCRIPTION
BSP enablement for the Pantavisor wakelock / managed-power feature (pantavisor#768).

This is the **single BSP base for all wakelock work**. meta-pantavisor#426 (crust SCP firmware for orange-pi-3lts) is stacked on top of it, and branch `wakelock-cadence-kernel` parks the PSI fragment for the not-yet-submitted cadence work. The `wakelock-cadence`, `wakelock-opi3` and `wakelock-pvtests` branches still branch from master and each re-add their own copy of `wakelock.cfg`; they should rebase onto this.

## Opt-in, not fleet-wide

Everything here sits behind a new `wakelocks` entry in `PANTAVISOR_FEATURES`, matching how `squash-lz4` / `caam-nxp` / `dcp` are gated in the same file. It is deliberately **not** a `pvbase.bbclass` default — it is listed there commented out, alongside the other available-but-off features — so nothing changes for a build that does not ask for it:

```
PANTAVISOR_FEATURES:append = " wakelocks"
```

Without the feature the kernel is untouched — no `CONFIG_PM_WAKELOCKS`, no `PM_AUTOSLEEP`, no DT change.

**Enabled on `imx8mn-var-som` only**, the board managed mode is validated on. Set in both `kas/machines/imx8mn-var-som.yaml` (the CI path via `machines.json`) and `kas/build-configs/release/imx8mn-var-som-scarthgap.yaml`, which is standalone and does not include the machine yaml. The release entry is its own `pantavisor-wakelocks` section rather than an append to the shared `scarthgap-variscite` one, so no other Variscite machine picks it up. `sunxi-orange-pi-3lts` is enabled separately in #426.

**No matching gate is needed on the Pantavisor side.** `power.mode` defaults to `locks`, but `pv_wakelock_init()` probes `/sys/power/wake_lock` at startup and, when the kernel lacks support, warns once and degrades — every `acquire`/`release` becomes a no-op. So a build without the feature is unaffected by the runtime default. (`managed` fails loudly instead of degrading, but reaching it requires explicitly setting `power.mode`.)

## What it enables

- **Kernel** — `wakelock.cfg`: `CONFIG_PM_WAKELOCKS` + `CONFIG_PM_AUTOSLEEP`, the mainline `/sys/power/wake_lock` suspend-blocking interface plus opportunistic-suspend autosleep.
- **imx8mn-var-som** — a DT patch enabling the SoC SNVS RTC. The VAR-SOM-MX8M-NANO Symphony board disables it in favour of the external DS1307, whose alarm is not wired as a system wakeup source, and managed mode needs a wakeup-capable RTC to wake from suspend-to-RAM on schedule. Gated on the feature as well as the machine: it makes `snvs_rtc` become `rtc0`, so the board boots at 1970 until the DS1307/NTP corrects it — a side effect nobody should inherit who is not using managed power.

Note that enabling the kernel side does not by itself start suspending anything. Autosleep is only ever switched on by `power.mode=managed`; in `locks` Pantavisor merely holds a wakelock while busy, which gates nothing unless something else has enabled autosleep.

## Validation

- [x] Validated on VAR-SOM-MX8M-NANO together with pantavisor#768 — managed mode runs the full sequence (settle → autosleep → RTC-alarm wake → Hub poll) with real deep suspend/resume cycles and networking intact across resume.
- [x] Gated form builds clean on the three `onpush` machines (`docker-x86_64`, `raspberrypi-armv8`, `sunxi-bananapi-m2-berry`) — none of which opt into the feature, so this confirms the *absent* side of the gate.
- [ ] `imx8mn-var-som` is `manual`/`tag` only, never built on push, so the *enabled* side of the gate is still unbuilt in CI. A manual dispatch on this branch confirming `CONFIG_PM_WAKELOCKS` reaches the final `.config` and the SNVS DT patch applies is the last open item.