### PR TITLE
fix: use pantavisor-appengine target in manual-docs workflow

### DIFF
--- a/.github/workflows/manual-docs-scarthgap.yaml
+++ b/.github/workflows/manual-docs-scarthgap.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: build docs
         run: |
-          su - builder -c "cd $GITHUB_WORKSPACE && kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine-distro"
+          su - builder -c "cd $GITHUB_WORKSPACE && kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine"
 
       - name: collect docs tarball
         run: |
@@ -48,7 +48,7 @@ jobs:
           ORIG_FILEPATH=$(ls docs-out/*.rootfs.docs.tar.zst)
           ORIG_FILENAME=$(basename "${ORIG_FILEPATH}")
           NEW_FILENAME=$(echo "${ORIG_FILENAME}" \
-            | sed 's/pantavisor-appengine-distro-/pantavisor-/' \
+            | sed 's/pantavisor-appengine-/pantavisor-/' \
             | sed 's/\.rootfs\.docs\.tar\.zst$/.docs.tar.zst/')
           cp "${ORIG_FILEPATH}" "docs-out/${NEW_FILENAME}"
 

--- a/docs/overview/ci/builds.md
+++ b/docs/overview/ci/builds.md
@@ -258,13 +258,14 @@ The job:
 
 1. Checks out the latest `master` commit (always ignores the triggering
    branch/ref).
-2. Runs `kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine-distro`
-   inside the KAS container. `docker-x86_64-scarthgap` is used because it
-   targets `pantavisor-appengine-distro`, which pulls in the full component
-   set needed for documentation.
+2. Runs `kas build build-targets/docker-x86_64-scarthgap.yaml -- -c create_pantacor_docs pantavisor-appengine`
+   inside the KAS container. `docker-x86_64-scarthgap` is used because
+   `pantavisor-appengine` inherits `pantavisor-docs` (via
+   `pantavisor-appengine.inc`) and pulls in the full component set needed
+   for documentation.
 3. Collects the real tarball (non-symlink `*.rootfs.docs.tar.zst`) from
    `build/tmp-scarthgap/deploy/images/docker-x86_64/`.
-4. Renames the tarball: `pantavisor-appengine-distro-<rest>.rootfs.docs.tar.zst` →
+4. Renames the tarball: `pantavisor-appengine-<rest>.rootfs.docs.tar.zst` →
    `pantavisor-<rest>.docs.tar.zst`.
 5. Uploads the renamed tarball to the `docs/latest/` prefix in S3:
    ```


### PR DESCRIPTION
The original workflow used `pantavisor-appengine-distro` as the bitbake target, but that recipe inherits `nopackages` and does not have the `do_create_pantacor_docs` task.\n\nChanged to `pantavisor-appengine` which inherits `pantavisor-docs` via `pantavisor-appengine.inc:4` and provides that task.\n\nAlso fixed the rename sed pattern in the workflow and the corresponding docs section in `docs/overview/ci/builds.md`.