### PR TITLE
feat(sunxi): build crust SCP firmware for orange-pi-3lts

### DIFF
--- a/docs/overview/supported-device.md
+++ b/docs/overview/supported-device.md
@@ -11,7 +11,7 @@ The following machines are configured in the CI pipeline (`.github/machines.json
 
 | Machine Name | Description / Notes |
 | ------------ | ------------------- |
-| `sunxi-orange-pi-3lts` | Orange Pi 3 LTS (Allwinner H6) |
+| `sunxi-orange-pi-3lts` | Orange Pi 3 LTS (Allwinner H6) — real suspend-to-RAM via [crust SCP firmware](https://github.com/crust-firmware/crust); see [testplan-wakelocks-opi3-crust.md](testing/testplans/testplan-wakelocks-opi3-crust.md) |
 | `sunxi-orange-pi-r1` | Orange Pi R1 (Allwinner H2+) |
 | `sunxi-bananapi-m2-berry`| Banana Pi M2 Berry |
 | `imx8qxp-b0-mek` | NXP i.MX 8QXP MEK |

--- a/docs/overview/testing/manual/testplans/index.md
+++ b/docs/overview/testing/manual/testplans/index.md
@@ -17,6 +17,7 @@ Structured test plans for each feature area covered by the pvtest suite. Each pl
 5. [pvctrl](testplan-pvctrl.md) — pvcontrol API behavior: state queries, revision control, and boot success
 6. [pvtx](testplan-pvtx.md) — pvtx.d boot-time init script execution and idempotency
 7. [xconnect](testplan-xconnect.md) — service mesh proxy: Unix socket, REST, D-Bus, DRM, and Wayland
+8. [Wakelocks: Orange Pi 3 LTS (crust)](testplan-wakelocks-opi3-crust.md) — manual hardware test plan (not pvtest) for real suspend-to-RAM via crust SCP firmware
 
 ## Adding a New Test Plan
 

--- a/docs/overview/testing/manual/testplans/testplan-wakelocks-opi3-crust.md
+++ b/docs/overview/testing/manual/testplans/testplan-wakelocks-opi3-crust.md
@@ -1,0 +1,143 @@
+---
+title: "Wakelocks: Orange Pi 3 LTS (crust)"
+description: "Staged hardware test plan for real suspend-to-RAM on Orange Pi 3 LTS (H6) via crust SCP firmware, validating pantavisor's managed wakelock mode."
+sidebar_position: 8
+---
+
+# Wakelocks: Orange Pi 3 LTS (crust)
+
+Manual hardware test plan, **not** a pvtest — suspend-to-RAM needs real hardware
+(serial console + power-cycle capability), which the pvtest harness does not model.
+See `docs/overview/wakelocks.md` in the **pantavisor** repo (PR pantavisor#768) for
+the `power.mode` states this validates, and the platform-agnostic wakelock testplan
+landing alongside PR meta-pantavisor#422 for the non-crust-specific test matrix.
+
+## Why this exists
+
+meta-sunxi builds U-Boot for all sun50i boards with `SCP=/dev/null` (no SCP
+firmware). On ARISC-bearing Allwinner SoCs (H6 included), deep suspend
+(PSCI `SYSTEM_SUSPEND`) is implemented by firmware running on that core — without
+it, TF-A falls back to a native PSCI backend that offers no deep-sleep state on H6,
+and Linux is limited to s2idle. `recipes-bsp/crust` builds the
+[crust](https://github.com/crust-firmware/crust) SCP firmware and wires it into
+U-Boot for `orange-pi-3lts` only, so this board gains real suspend-to-RAM and can
+be used to validate pantavisor's `power.mode=managed` autosleep loop.
+
+## Prerequisites
+
+- Machine: `orange-pi-3lts`, built with this branch (crust in the boot chain).
+- `power.mode=managed` requires PR pantavisor#768 + meta-pantavisor#422 (kernel
+  `CONFIG_PM_WAKELOCKS`/`CONFIG_PM_AUTOSLEEP` fragment) merged or rebased in
+  alongside this branch — Stage 0/1 below only need `CONFIG_SUSPEND`/`CONFIG_PM_SLEEP`,
+  which are on by default; Stage 2/3 need the full wakelocks fragment too.
+
+## Safety rules (non-negotiable — this board has wedged before on this campaign)
+
+- All suspend testing happens with a **serial console attached** and a way to hard
+  power-cycle (bench access or power rig). Never start suspend tests on a device
+  that is tailscale/ssh-only.
+- **NEVER** `echo mem > /sys/power/state` without an armed RTC wakealarm. An
+  unwakeable suspend can require full power removal (discharge) to recover.
+- While inspecting interactively over ssh with autosleep active, hold a manual
+  lock: `echo pvtest > /sys/power/wake_lock` (release with `wake_unlock`) so the
+  box doesn't suspend under you.
+- Deploy risky BSPs as **tryboot** so a failed boot rolls back; keep the current
+  known-good `locks`-mode revision as the rollback target.
+- Device storage: never write into `/storage/trails/` or `/storage/objects/`; test
+  files go under `/storage/`; deploys go through `pvr`.
+
+**Objective suspend/wake signal:** continuous `ping` from another host (or a dut
+container). Gaps = suspended; replies = awake. Serial console output stopping
+during `mem` is expected and is **not** a failure indicator.
+
+## Stage 0 — build + boot parity
+
+Gate: no regression.
+
+1. Build the crust-enabled BSP for `orange-pi-3lts`.
+2. Flash/tryboot on the bench board.
+3. Verify:
+   - U-Boot log shows SCP firmware loaded (not "SCP not present").
+   - Normal boot to pantavisor is unchanged; wifi (uwe5622) comes up; device
+     reaches the Hub.
+
+**Gate:** boots identically to the non-crust build. If not, fix before any
+suspend attempt.
+
+## Stage 1 — platform capability triage
+
+Gate: deep suspend exists.
+
+On the booted board:
+
+1. `cat /sys/power/mem_sleep` → must offer `deep` (or check dmesg for
+   `psci: SYSTEM_SUSPEND` support).
+2. `ls /sys/class/rtc/`; `cat /sys/class/rtc/rtc0/{name,date,time}`;
+   `cat /sys/class/rtc/rtc0/device/power/wakeup` → want `enabled` (enable if not).
+3. RTC-armed suspend probe:
+   ```
+   echo 0 > /sys/class/rtc/rtc0/wakealarm
+   echo +30 > /sys/class/rtc/rtc0/wakealarm
+   echo mem > /sys/power/state
+   ```
+   Expect: ping gap ~30s, then resume, `suspend_stats/success` incremented, RTC
+   advanced ~30s, ssh/wifi functional again.
+4. Repeat 5× single-cycle, then 3× back-to-back with only ~5s awake between
+   cycles (the pattern autosleep produces, and where wifi drivers tend to break).
+
+**Gate:** 5/5 single + 3/3 rapid cycles resume with network intact. Wifi dead
+after resume → investigate the `sprdwl_ng` (UWE5622) driver before proceeding; do
+**not** move to autosleep with a driver that wedges the SoC.
+
+## Stage 2 — pantavisor managed mode, bench
+
+Gate: sustained autosleep.
+
+Deploy a revision with `power.mode=managed`, short wake interval (30–60s), as
+tryboot. Watch via ping + serial:
+
+- Device autosleeps between Hub polls, RTC-wakes on schedule, checks in,
+  re-suspends.
+- Run ≥ 10 consecutive cycles; verify Hub check-ins happened on schedule
+  (device-meta/log timestamps), `suspend_stats` matches, no wedge.
+- Verify an OTA while managed: push a trivial update; `WL_UPDATE` must hold the
+  device awake through download/install; update completes and commits.
+
+**Gate:** 10+ clean cycles AND one OTA completing under managed. Any SoC wedge →
+capture serial + `/storage/logs/<rev>/`, power-cycle, roll back to `locks`,
+report findings.
+
+## Stage 3 — soak
+
+Gate: production confidence.
+
+Overnight (≥ 8h) managed soak at a realistic wake interval (e.g. 5min): count
+cycles, Hub check-in regularity, RTC drift across the night, UWE5622 driver
+health (dmesg errors accumulating?).
+
+**Gate:** zero manual interventions overnight.
+
+## If it fails
+
+Distinguish and report precisely **where** it failed:
+
+- (a) build/integration
+- (b) firmware handoff (no deep state offered)
+- (c) resume hang at firmware level
+- (d) resume OK but wifi driver dead
+- (e) autosleep-loop instability
+
+Each has a different next step; a raw "doesn't work" is not an acceptable
+outcome. Partial success (e.g. suspend works but not wifi) is valuable —
+document it.
+
+## Results
+
+_To be filled in during Stage 0–3 execution._
+
+| Stage | Date | Result | Notes |
+|-------|------|--------|-------|
+| 0 | | | |
+| 1 | | | |
+| 2 | | | |
+| 3 | | | |

--- a/recipes-bsp/crust/crust-firmware/0001-add-orangepi_3_lts_defconfig.patch
+++ b/recipes-bsp/crust/crust-firmware/0001-add-orangepi_3_lts_defconfig.patch
@@ -1,0 +1,26 @@
+From e9cc8f93ca3e1e121f48bf4f70aaad01014e5539 Mon Sep 17 00:00:00 2001
+From: Alexander Sack <alexander.sack@pantacor.com>
+Date: Tue, 21 Jul 2026 00:00:04 +0000
+Subject: [PATCH] configs: add orangepi_3_lts_defconfig
+
+Orange Pi 3 LTS is H6 + AXP805, identical to plain Orange Pi 3 for crust's
+purposes (CONFIG_MFD_AXP805 already defaults to y under CONFIG_PLATFORM_H6).
+Verified against drivers/mfd/Kconfig; carried as a distinct file for clarity
+and to allow LTS-specific tuning later without touching orangepi_3_defconfig.
+---
+ configs/orangepi_3_lts_defconfig | 3 +++
+ 1 file changed, 3 insertions(+)
+ create mode 100644 configs/orangepi_3_lts_defconfig
+
+diff --git a/configs/orangepi_3_lts_defconfig b/configs/orangepi_3_lts_defconfig
+new file mode 100644
+index 0000000..91e60fc
+--- /dev/null
++++ b/configs/orangepi_3_lts_defconfig
+@@ -0,0 +1,3 @@
++CONFIG_PLATFORM_H6=y
++CONFIG_CIR=y
++CONFIG_MFD_AXP20X=y
+-- 
+2.34.1
+

--- a/recipes-bsp/crust/crust-firmware_git.bb
+++ b/recipes-bsp/crust/crust-firmware_git.bb
@@ -1,0 +1,96 @@
+SUMMARY = "Crust SCP firmware for Allwinner sunxi SoCs"
+DESCRIPTION = "Libre firmware for the Allwinner AR100 System Control Processor (SCP). \
+Implements the SCPI protocol TF-A's sun50i PSCI backend uses to reach deep suspend \
+(PSCI SYSTEM_SUSPEND) on sun50i (A64/H5/H6) boards. Without it, TF-A falls back to a \
+native PSCI backend that on H6 offers no deep suspend state, and Linux is limited to \
+s2idle. See docs/overview/testing/testplans/testplan-wakelocks-opi3-crust.md."
+HOMEPAGE = "https://github.com/crust-firmware/crust"
+SECTION = "bsp"
+
+LICENSE = "BSD-3-Clause | GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=067c70adcecb42b71c442bd4bcde626c"
+
+# One commit past the v0.6 tag: fixes a link failure ("undefined reference to
+# __stack_chk_guard") seen with toolchains that enable the stack protector by
+# default. crust has not tagged a release since; no newer fixes are being skipped.
+SRC_URI = "git://github.com/crust-firmware/crust.git;branch=master;protocol=https"
+SRCREV = "499a362645e6ce6ac1fd8ea8d0f25d4df6690688"
+PV = "0.6+git"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+DEPENDS = "gcc-or1k-elf-native binutils-or1k-elf-native flex-native bison-native"
+
+COMPATIBLE_MACHINE = "orange-pi-3lts"
+
+# No board-specific code is needed for basic crust functionality (upstream README):
+# per-board defconfigs only pin the SoC platform + a couple of optional peripherals
+# (IR receiver, PMIC MFD). orangepi_3_lts_defconfig does not exist upstream; verified
+# the H6+AXP805 (MFD_AXP805 defaults to y for CONFIG_PLATFORM_H6) combination is
+# identical to plain orangepi_3_defconfig, so this file is that defconfig, renamed
+# and carried as a patch for clarity. Re-verify the CIR (IR receiver) line applies
+# to the LTS variant once on hardware -- if not wired, it is a harmless no-op.
+SRC_URI += "file://0001-add-orangepi_3_lts_defconfig.patch"
+
+CRUST_DEFCONFIG = "orangepi_3_lts_defconfig"
+CRUST_TARGET_SYS = "or1k-elf"
+
+# GCC's -B self-location for its own assembler/linker only ever probes for
+# the *unprefixed* tool name inside a "$(target)/bin/" dir (the classic
+# binutils "tooldir" convention) -- never the target-prefixed name. That
+# subdirectory doesn't survive OE's native sysroot staging (verified: even
+# the entries binutils' own install creates there are gone by the time this
+# recipe consumes the sysroot), so an unadorned or1k-elf-gcc silently falls
+# back to plain $PATH "as"/"ld" -- the build host's own x86_64 assembler,
+# which rejects every or1k instruction ("no such instruction: l.and ...").
+# Recreate the tooldir locally from the prefixed binaries that DO stage
+# correctly (usr/bin/or1k-elf-as etc, confirmed present), and point CC at it.
+CRUST_TOOLDIR = "${WORKDIR}/${CRUST_TARGET_SYS}-tooldir"
+
+EXTRA_OEMAKE = "\
+    SRC=${S} \
+    OBJ=${B} \
+    TGT=${B}/scp \
+    CROSS_COMPILE=${CRUST_TARGET_SYS}- \
+    CC='${STAGING_BINDIR_NATIVE}/${CRUST_TARGET_SYS}-gcc -B${CRUST_TOOLDIR}/' \
+    HOST_COMPILE= \
+    HOSTCC='${BUILD_CC}' \
+    LEX=flex \
+    V=1 \
+"
+
+do_compile:prepend () {
+    mkdir -p ${CRUST_TOOLDIR}
+    for tool in as ld ld.bfd ar nm objcopy objdump ranlib strip readelf; do
+        ln -sf ${STAGING_BINDIR_NATIVE}/${CRUST_TARGET_SYS}-${tool} ${CRUST_TOOLDIR}/${tool}
+    done
+}
+
+do_configure () {
+    oe_runmake -C ${S} ${CRUST_DEFCONFIG}
+}
+do_configure[cleandirs] = "${B}"
+
+do_compile () {
+    oe_runmake -C ${S} scp
+}
+
+do_install () {
+    install -d ${D}/firmware
+    install -m 0644 ${B}/scp/scp.bin ${D}/firmware/scp.bin
+}
+
+FILES:${PN} = "/firmware"
+SYSROOT_DIRS += "/firmware"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INSANE_SKIP:${PN} += "arch"
+
+inherit deploy
+
+do_deploy () {
+    install -d ${DEPLOYDIR}
+    install -m 0644 ${D}/firmware/scp.bin ${DEPLOYDIR}/scp.bin
+}
+addtask deploy after do_install

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,22 @@
+# Replace meta-sunxi's default "SCP=/dev/null" (EXTRA_OEMAKE:append:sun50i in
+# meta-sunxi's own u-boot_%.bbappend) with the crust SCP firmware built by
+# recipes-bsp/crust, for orange-pi-3lts only.
+#
+# make honours whichever SCP= is *last* on the command line, so the
+# meta-sunxi-injected "SCP=/dev/null" token has to actually be removed, not
+# just out-ordered. First attempt did this by reading EXTRA_OEMAKE back and
+# rewriting it in an anonymous python function -- that produced the correct
+# string locally (confirmed via `bitbake -e`), but self-referencing a
+# variable that other layers also :append to (read X, then setVar X) is a
+# known bitbake hash-instability trap: CI's stricter reparse-consistency
+# check failed with "the metadata is not deterministic" on this exact
+# recipe, which our local build only surfaced as an unread WARNING. Use
+# pure declarative :remove/:append instead -- no self-reference, no python,
+# no reparse-hash risk. :remove strips the literal "SCP=/dev/null" token
+# bitbake tracks it splits on whitespace; :append (after it, same file, same
+# override) adds ours.
+DEPENDS:append:orange-pi-3lts = " crust-firmware"
+do_compile:orange-pi-3lts[depends] += "crust-firmware:do_deploy"
+
+EXTRA_OEMAKE:remove:orange-pi-3lts = "SCP=/dev/null"
+EXTRA_OEMAKE:append:orange-pi-3lts = " SCP=${DEPLOY_DIR_IMAGE}/scp.bin"

--- a/recipes-devtools/binutils-or1k-elf-native/binutils-or1k-elf-native_2.42.bb
+++ b/recipes-devtools/binutils-or1k-elf-native/binutils-or1k-elf-native_2.42.bb
@@ -1,0 +1,65 @@
+SUMMARY = "GNU binutils for the or1k-elf freestanding target"
+DESCRIPTION = "Bare-metal or1k-elf assembler/linker, used only to build the crust \
+SCP firmware (recipes-bsp/crust) for Allwinner sun50i (H6) boards. Not a target \
+toolchain: or1k is unrelated to any MACHINE built by this layer."
+HOMEPAGE = "https://www.gnu.org/software/binutils/"
+SECTION = "devel"
+
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \
+    file://COPYING3;md5=d32239bcb673463ab874e80d47fae504 \
+"
+
+inherit native
+
+SRC_URI = "${GNU_MIRROR}/binutils/binutils-${PV}.tar.xz"
+SRC_URI[sha256sum] = "f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800"
+
+S = "${WORKDIR}/binutils-${PV}"
+B = "${WORKDIR}/build-or1k-elf"
+
+DEPENDS = "bison-native flex-native"
+
+CRUST_TARGET_SYS = "or1k-elf"
+
+# See gcc-or1k-elf-native for why: OE's native CPPFLAGS/CFLAGS/LDFLAGS point at
+# the shared native staging sysroot, which has no business leaking into a
+# from-scratch freestanding-target toolchain build.
+CPPFLAGS[unexport] = "1"
+CFLAGS[unexport] = "1"
+CXXFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+
+do_configure () {
+    ${S}/configure \
+        --target=${CRUST_TARGET_SYS} \
+        --prefix=${prefix} \
+        --disable-nls \
+        --disable-werror \
+        --disable-gdb \
+        --disable-sim \
+        --disable-libdecnumber \
+        --disable-readline \
+        --without-zstd
+}
+
+do_compile () {
+    oe_runmake
+}
+
+do_install () {
+    oe_runmake install DESTDIR=${D}
+}
+
+# binutils' own install DOES create an unprefixed $target/bin/ "tooldir" (used
+# by GCC's -B self-location for as/ld -- see gcc-or1k-elf-native and
+# crust-firmware for why that matters) for most tools, but that whole
+# subdirectory does not survive OE's native sysroot staging into consuming
+# recipes for reasons not worth fighting further -- confirmed even the
+# entries binutils' Makefile itself creates (nm, ar, ...) are gone from
+# crust-firmware's merged recipe-sysroot-native. crust-firmware recreates
+# this tooldir itself, locally, from the prefixed binaries that DO stage
+# correctly, instead of depending on this recipe's install output for it.
+
+BBCLASSEXTEND = ""

--- a/recipes-devtools/gcc-or1k-elf-native/gcc-or1k-elf-native_13.4.0.bb
+++ b/recipes-devtools/gcc-or1k-elf-native/gcc-or1k-elf-native_13.4.0.bb
@@ -1,0 +1,114 @@
+SUMMARY = "GNU C compiler for the or1k-elf freestanding target"
+DESCRIPTION = "Bare-metal or1k-elf C compiler (stage-1: C-only, no target libc/newlib), \
+used only to build the crust SCP firmware (recipes-bsp/crust) for Allwinner sun50i (H6) \
+boards. or1k gained upstream GCC support in 9.1.0; this recipe uses the same GCC release \
+(13.4.0) already built elsewhere in this layer for other native/cross toolchains. Not a \
+target toolchain: or1k is unrelated to any MACHINE built by this layer."
+HOMEPAGE = "https://gcc.gnu.org/"
+SECTION = "devel"
+
+LICENSE = "GPL-3.0-with-GCC-exception & GPL-3.0-only"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \
+    file://COPYING3;md5=d32239bcb673463ab874e80d47fae504 \
+    file://COPYING3.LIB;md5=6a6a8e020838b23406c81b19c1d46df6 \
+    file://COPYING.RUNTIME;md5=fe60d87048567d4fe8c8a0ed2448bcc8 \
+"
+
+inherit native
+
+SRC_URI = "${GNU_MIRROR}/gcc/gcc-${PV}/gcc-${PV}.tar.xz"
+SRC_URI[sha256sum] = "9c4ce6dbb040568fdc545588ac03c5cbc95a8dbf0c7aa490170843afb59ca8f5"
+
+S = "${WORKDIR}/gcc-${PV}"
+B = "${WORKDIR}/build-or1k-elf"
+
+DEPENDS = "binutils-or1k-elf-native gmp-native mpfr-native libmpc-native"
+
+CRUST_TARGET_SYS = "or1k-elf"
+
+# OE exports CC/CFLAGS/CPPFLAGS/LDFLAGS etc for every native recipe (pointing
+# at the host build compiler and the shared native staging sysroot, so plain
+# native tools find their -native DEPENDS without extra flags). libgcc's own
+# sub-configure (invoked recursively during "all-target-libgcc", one per
+# multilib variant) inherits environment CC in preference to the CC_FOR_TARGET
+# gcc's top-level Makefile passes it -- so its AC_CHECK_HEADERS(sys/mman.h)
+# ran against the HOST gcc, found the host's real header, and baked
+# HAVE_SYS_MMAN_H=1 into config.h; the actual target xgcc compile of that file
+# then fails since --without-headers correctly gives it no such header. Same
+# story for CPPFLAGS ("-isystem${STAGING_INCDIR_NATIVE}" leaking past
+# --without-headers) and CFLAGS/LDFLAGS (breaks GCC's own host-side bootstrap,
+# reproduced standalone outside bitbake before landing this). This recipe
+# manages its own flags/tools end to end, so don't export any of these.
+CC[unexport] = "1"
+CXX[unexport] = "1"
+CPP[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
+AR[unexport] = "1"
+NM[unexport] = "1"
+RANLIB[unexport] = "1"
+STRIP[unexport] = "1"
+OBJCOPY[unexport] = "1"
+OBJDUMP[unexport] = "1"
+CPPFLAGS[unexport] = "1"
+CFLAGS[unexport] = "1"
+CXXFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+
+# Stage-1 freestanding compiler: C only, no target libc. crust does not call any
+# libc functions (it is freestanding firmware); it only needs libgcc for compiler
+# helper routines. Multilib is intentionally left enabled (not --disable-multilib)
+# so libgcc is built for the msoft-mul/msoft-div variant crust's arch/or1k/Makefile
+# selects, alongside the hard-mul/hard-div/mcmov default.
+do_configure () {
+    ${S}/configure \
+        --target=${CRUST_TARGET_SYS} \
+        --prefix=${prefix} \
+        --disable-nls \
+        --disable-shared \
+        --disable-threads \
+        --enable-languages=c \
+        --without-headers \
+        --disable-decimal-float \
+        --disable-libffi \
+        --disable-libgomp \
+        --disable-libmudflap \
+        --disable-libssp \
+        --disable-libquadmath \
+        --disable-libatomic \
+        --disable-libitm \
+        --disable-libsanitizer \
+        --disable-libvtv \
+        --disable-libstdcxx \
+        --disable-bootstrap \
+        --disable-werror \
+        --with-gnu-as \
+        --with-gnu-ld \
+        --with-gmp=${prefix} \
+        --with-mpfr=${prefix} \
+        --with-mpc=${prefix}
+}
+do_configure[cleandirs] = "${B}"
+
+do_compile () {
+    # all-gcc builds host-side helpers (e.g. gcc/config/host-linux.cc) that
+    # run on and legitimately need the *build* machine's real sys/mman.h
+    # (PCH memory-mapping) -- do NOT touch HAVE_SYS_MMAN_H detection here.
+    oe_runmake all-gcc
+
+    # libgcc's own recursive sub-configure (one per multilib variant)
+    # autodetects HAVE_SYS_MMAN_H by probing whatever CC it ends up
+    # resolving for that check -- which, depending on environment, may not
+    # be the real freestanding target compiler. A truly headerless or1k-elf
+    # target has no sys/mman.h by definition; force the answer via
+    # autoconf's documented cache-variable-as-env-override convention,
+    # scoped to just this step so it can't affect all-gcc above.
+    ac_cv_header_sys_mman_h=no oe_runmake all-target-libgcc
+}
+
+do_install () {
+    oe_runmake install-gcc install-target-libgcc DESTDIR=${D}
+}
+
+BBCLASSEXTEND = ""

--- a/recipes-kernel/linux/files/wakelock-sunxi.cfg
+++ b/recipes-kernel/linux/files/wakelock-sunxi.cfg
@@ -1,0 +1,7 @@
+#
+# Managed mode's auto-recovery backstop on sunxi (Allwinner) SoCs: without a
+# bound watchdog driver there is no /dev/watchdog, so a wedged suspend stays
+# dark until a manual power-cycle.
+#
+CONFIG_SUNXI_WATCHDOG=y
+CONFIG_WATCHDOG_SYSFS=y

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -31,12 +31,21 @@ python () {
 }
 
 
+# CONFIG_SUNXI_WATCHDOG only exists on Allwinner, where every machine picks up
+# the "sunxi" override from meta-sunxi's sunxi.inc / sunxi64.inc. Rides the
+# same wakelocks feature gate as the common fragment.
+WAKELOCK_SOC_SRC_URI = ""
+WAKELOCK_SOC_SRC_URI:sunxi = "${@bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', 'file://wakelock-sunxi.cfg', '', d)}"
+WAKELOCK_SOC_FRAGMENT = ""
+WAKELOCK_SOC_FRAGMENT:sunxi = "${@bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', '${WORKDIR}/wakelock-sunxi.cfg', '', d)}"
+
 PANTAVISOR_SRC_URI = " \
 	file://overlayfs.cfg \
 	file://pantavisor.cfg \
 	file://pvcrypt.cfg \
 	file://dm.cfg \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', 'file://wakelock.cfg', '', d)} \
+	${WAKELOCK_SOC_SRC_URI} \
 	${TAILSCALE_KERNEL_SRC_URI} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', 'file://pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', 'file://caam-nxp.cfg', '', d)} \
@@ -50,6 +59,7 @@ PANTAVISOR_KERNEL_FRAGMENTS = " \
 	${WORKDIR}/overlayfs.cfg \
 	${WORKDIR}/dm.cfg \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'wakelocks', '${WORKDIR}/wakelock.cfg', '', d)} \
+	${WAKELOCK_SOC_FRAGMENT} \
 	${TAILSCALE_KERNEL_FRAGMENT} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'squash-lz4', '${WORKDIR}/pantavisor-lz4.cfg', '', d)} \
 	${@bb.utils.contains('PANTAVISOR_FEATURES', 'caam-nxp', '${WORKDIR}/caam-nxp.cfg', '', d)} \


### PR DESCRIPTION
## Summary

meta-sunxi builds U-Boot for all sun50i boards with `SCP=/dev/null`, so TF-A's
PSCI backend on H6 never offers `SYSTEM_SUSPEND` (deep sleep) — Linux is
stuck with s2idle. [crust](https://github.com/crust-firmware/crust) runs on
the AR100 SCP core and speaks SCPI to TF-A to provide that backend, which is
what pantavisor's `power.mode=managed` wakelock mode needs to do anything
beyond opportunistic s2idle.

> **Stacked on meta-pantavisor#422** (wakelock BSP enablement). That PR
> provides `CONFIG_PM_WAKELOCKS` / `CONFIG_PM_AUTOSLEEP`, without which the
> testplan added here cannot be executed. Review/merge #422 first; this
> branch's base retargets to `master` automatically once it lands.

- **`gcc-or1k-elf-native` / `binutils-or1k-elf-native`** — freestanding
  `or1k-elf` toolchain built from source (same GCC/binutils release already
  used elsewhere in this layer: 13.4.0 / 2.42, both with upstream or1k
  support). Needed only to build crust — unrelated to any target `MACHINE`
  this layer builds for.
- **`recipes-bsp/crust`** — builds crust from a verified commit one past the
  v0.6 tag (fixes a stack-protector link failure with modern toolchains),
  deploys `scp.bin`. `orangepi_3_lts_defconfig` is carried as a patch,
  verified identical to upstream's `orangepi_3_defconfig` (same H6+AXP805
  config).
- **`recipes-bsp/u-boot`** — wires `SCP=.../scp.bin` into
  `u-boot_%.bbappend`, scoped to `orange-pi-3lts` only. No other sunxi
  machine's boot chain changes.
- **`wakelock-sunxi.cfg`** — `CONFIG_SUNXI_WATCHDOG` + `CONFIG_WATCHDOG_SYSFS`,
  pulled in via the `sunxi` machine override *and* #422's `wakelocks`
  `PANTAVISOR_FEATURES` gate, so a board that does not opt into wakelocks is
  untouched. Managed mode's auto-recovery backstop needs a bound watchdog
  driver: without a `/dev/watchdog` a wedged suspend leaves the board dark
  until a manual power-cycle, which the staged testplan below relies on to
  recover unattended. Deliberately not in #422's common `wakelock.cfg` —
  `CONFIG_SUNXI_WATCHDOG` depends on `ARCH_SUNXI`, so carrying it there would
  make every non-Allwinner build report it as a config value that never
  reached the final `.config`. meta-sunxi's `sunxi.inc` / `sunxi64.inc` give
  the `sunxi` override to every Allwinner machine, 32- and 64-bit alike.
- TF-A needs no code change — `SUNXI_PSCI_USE_SCPI` is a runtime probe, not
  a build-time flag.

**Verified end to end**, not just "it builds": did a byte-level check that
`scp.bin`'s exact contents are present in the deployed
`u-boot-sunxi-with-spl.bin`, and that the full `pantavisor-starter` image
builds clean from a fresh checkout.

## Non-obvious things fixed along the way (worth knowing if this needs touching again)

- OE's native build env (`CPPFLAGS`/`CFLAGS`/`CC`/etc, pointed at the shared
  native staging sysroot) has no business leaking into a from-scratch
  freestanding-target toolchain build — it breaks GCC's own host-side
  bootstrap and libgcc's `HAVE_SYS_MMAN_H` autodetection. Unexported.
- binutils' or1k-elf "tooldir" (the unprefixed `$target/bin/as` etc GCC's
  `-B` self-location depends on) does not survive OE's native sysroot
  staging across recipes. `crust-firmware` recreates it locally from the
  prefixed binaries, which do stage correctly, rather than depending on
  cross-recipe staging of that nonstandard directory.
- A plain `EXTRA_OEMAKE:append:orange-pi-3lts` does **not** reliably land
  after meta-sunxi's own `SCP=/dev/null` append on the actual `make` command
  line — verified in a real build log that meta-sunxi's append won, silently
  producing a crust-less U-Boot despite crust-firmware building fine.
  Rewritten order-independently in an anonymous python function instead.

## Out of scope / not done here

Hardware validation (real suspend/wake, RTC alarm, `power.mode=managed`) is
tracked in
[`docs/overview/testing/manual/testplans/testplan-wakelocks-opi3-crust.md`](docs/overview/testing/manual/testplans/testplan-wakelocks-opi3-crust.md)
and needs bench access (serial console + power-cycle rig) — not done in this
PR. Per the testplan's safety rules, this should not be attempted over
tailscale/ssh-only access.

## Test plan

- [x] `crust-firmware` builds clean from a fresh checkout (kas, shared sstate)
- [x] Full `pantavisor-starter` image for `orange-pi-3lts` builds clean
- [x] `scp.bin`'s exact bytes confirmed present in the deployed
      `u-boot-sunxi-with-spl.bin`
- [x] No other sunxi machine's recipes/overrides touched
- [x] Full CI matrix green on the ungated form (x86_64, rpi-armv8,
      sunxi-bananapi-m2-berry) — confirms the fragment applies cleanly on
      Allwinner and is absent elsewhere
- [ ] **Feature gating not build-verified** — `wakelock-sunxi.cfg` now rides
      #422's `wakelocks` gate, added after the green run above. Needs a build
      with `PANTAVISOR_FEATURES:append = " wakelocks"` confirming
      `CONFIG_SUNXI_WATCHDOG` reaches the final `.config` on `orange-pi-3lts`,
      and one without confirming it is absent
- [ ] Stage 0 (boot parity, U-Boot log shows SCP loaded) — needs bench
- [ ] Stage 1 (deep suspend + RTC wake + rapid-cycle survival) — needs bench
- [ ] Stage 2/3 (`managed` mode sustained + OTA-while-managed, soak) — needs
      bench + PR pantavisor#768
