### PR TITLE
ci(manual): show machine name in the manual dispatch run title

### DIFF
--- a/.github/scripts/make-manual-dispatch.py
+++ b/.github/scripts/make-manual-dispatch.py
@@ -22,6 +22,7 @@ content = f"""\
 # ##############################################################################
 
 name: "manual: {branch}"
+run-name: "manual: ${{{{ inputs.machine }}}} ({branch}) — ${{{{ github.ref_name }}}} by ${{{{ github.actor }}}}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-scarthgap.yaml
+++ b/.github/workflows/manual-scarthgap.yaml
@@ -6,6 +6,7 @@
 # ##############################################################################
 
 name: "manual: scarthgap"
+run-name: "manual: ${{ inputs.machine }} (scarthgap) — ${{ github.ref_name }} by ${{ github.actor }}"
 
 on:
   workflow_dispatch:

--- a/docs/overview/ci/status.md
+++ b/docs/overview/ci/status.md
@@ -8,6 +8,7 @@ sidebar_position: 4
 <!-- WORKFLOW_TABLE_START -->
 | Workflow | Status |
 | :--- | :--- |
+| **manual-docs-scarthgap** | [![MAN](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/manual-docs-scarthgap.yaml?style=flat-square&logo=github-actions&logoColor=white&label=MAN)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/manual-docs-scarthgap.yaml) |
 | **manual-pvtests** | [![MAN](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/manual-pvtests.yaml?style=flat-square&logo=github-actions&logoColor=white&label=MAN)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/manual-pvtests.yaml) |
 | **manual-scarthgap** | [![MAN](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/manual-scarthgap.yaml?style=flat-square&logo=github-actions&logoColor=white&label=MAN)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/manual-scarthgap.yaml) |
 | **onpush-scarthgap** | [![PUSH](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/onpush-scarthgap.yaml?style=flat-square&logo=github-actions&logoColor=white&label=PUSH)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/onpush-scarthgap.yaml) |


### PR DESCRIPTION
## Summary

Manually-dispatched runs of \`manual-scarthgap.yaml\` all showed up in the
Actions view as the generic **"manual: scarthgap"**, indistinguishable from
one another until you opened the run. Adds a \`run-name\` so each one reads
e.g. **"manual: sunxi-orange-pi-3lts (scarthgap) — feat/opi3-crust-suspend by
asac"** instead.

Edited the generator (\`.github/scripts/make-manual-dispatch.py\`), not the
generated workflow file directly, then ran \`.github/scripts/makeworkflows\`
— which also picked up one unrelated pre-existing drift in
\`docs/overview/ci/status.md\` (a missing table row for
\`manual-docs-scarthgap\`).

## Test plan

- [x] \`.github/scripts/makeworkflows\` regenerates cleanly, diff is scoped to
      the intended files
- [ ] Dispatch a manual run and confirm the Actions view shows the new title