### PR TITLE
ci: notify docs.pantavisor from the manual-docs workflow

### DIFF
--- a/.github/workflows/manual-docs-scarthgap.yaml
+++ b/.github/workflows/manual-docs-scarthgap.yaml
@@ -72,3 +72,14 @@ jobs:
           }' > latest.json
 
           aws s3 cp latest.json "s3://${AWS_S3_BUCKET}/docs/latest.json"
+
+      - name: notify docs.pantavisor to sync
+        env:
+          PANTAVISOR_DOCS_SYNC: ${{ secrets.PANTAVISOR_DOCS_SYNC }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${PANTAVISOR_DOCS_SYNC}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d '{"event_type":"docs-release","client_payload":{"tag":"latest"}}' \
+            https://api.github.com/repos/pantavisor/docs.pantavisor/dispatches

--- a/docs/overview/ci/builds.md
+++ b/docs/overview/ci/builds.md
@@ -287,9 +287,8 @@ The job:
 ```
 
 Unlike `tag-docs-scarthgap.yaml`, this workflow does **not** upload to GitHub
-Releases or send a `repository_dispatch` to `docs.pantavisor` — it is purely
-a build-and-upload-to-S3 convenience for getting the latest docs during
-development.
+Releases. It does send a `repository_dispatch` to `docs.pantavisor` with
+`"tag": "latest"` so the docs site can pull in the latest documentation.
 
 ## CI Badges (upload-badges)
 


### PR DESCRIPTION
## Summary

`manual-docs-scarthgap.yaml` builds the docs from `master`, uploads the tarball to `s3://…/meta-pantavisor/docs/latest/` and writes `docs/latest.json` — but it stopped there, so the docs site never learned that fresh development docs were available and kept serving the previous build until an unrelated change happened to trigger a redeploy.

This adds a final `notify docs.pantavisor to sync` step that fires a `repository_dispatch` at `pantavisor/docs.pantavisor` once the upload succeeds:

```json
{"event_type":"docs-release","client_payload":{"tag":"latest"}}
```

This mirrors what `tag-docs-scarthgap.yaml` already does for tagged releases, reusing the same `PANTAVISOR_DOCS_SYNC` secret and the same event type. The `"tag": "latest"` payload is what distinguishes a development build from a tagged one on the receiving side.

`docs/overview/ci/builds.md` is updated to match — it previously stated this workflow does *not* send a dispatch.

## Receiving side

Handled by pantavisor/docs.pantavisor#21, which adds a `docs-latest.yml` workflow that picks up the `tag: latest` payload and rebuilds + redeploys the site. That PR should merge first (or alongside this one); until it does, this dispatch is simply a no-op on the receiving repo.

## Test plan

- [ ] Merge pantavisor/docs.pantavisor#21 first.
- [ ] Run **manual: generate latest docs** from the Actions tab and confirm the notify step exits 0 (`curl -f`, so a rejected dispatch fails the job).
- [ ] Confirm a **Docs: latest (development) sync** run starts in docs.pantavisor and deploys.
- [ ] Confirm the deployed `development` docs match the `name` / `generated` fields in https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor/docs/latest.json