### PR TITLE
fix(pv-avahi): app group + on-demand D-Bus activation examples

### DIFF
--- a/classes/container-pvrexport.bbclass
+++ b/classes/container-pvrexport.bbclass
@@ -56,6 +56,13 @@ PVRIMAGE_AUTO_MDEV ??= "1"
 
 PVR_SIG_ADD_ARGS ??= "--noconfig --part ${PN}"
 
+# Hook for a recipe to fix up the generated ${PN}/run.json (or other tracked
+# files) after `pvr app add` but before signing/export. No-op by default. Runs
+# from ${PVSTATE}, same cwd as the rest of IMAGE_CMD:pvrexportit. A recipe
+# using this must itself run `pvr add` if it changes tracked file content --
+# the class re-adds/commits unconditionally right after invoking this hook.
+PVR_APP_POST_FIXUP ??= ":"
+
 # Define a config overlay directory that the image recipe will make available
 # in ${WORKDIR} before the IMAGE_CMD task for ${PN} container.
 # This directory will be added to the pvrexport as _config/${PN}
@@ -136,6 +143,7 @@ EOF1
         mkdir -p _config
         cp -rf ${WORKDIR}/${PV_CONFIG_OVERLAY_DIR} _config/${PN}
     fi
+    ${PVR_APP_POST_FIXUP}
     pvr add
     pvr commit
     pvr sig add ${PVR_SIG_ADD_ARGS}

--- a/recipes-containers/pantavisor/pv-avahi-browse/pv-avahi-browse-start.sh
+++ b/recipes-containers/pantavisor/pv-avahi-browse/pv-avahi-browse-start.sh
@@ -10,6 +10,17 @@
 DBUS_SOCKET=/run/dbus/system_bus_socket
 DBUS_WAIT=${PV_AVAHI_DBUS_WAIT:-5}
 
+# Auto-browse can be disabled per-device via the usermeta key
+# `pv-avahi-browse.autostart`, exposed here as /pantavisor/user-meta/autostart
+# (container-scoped usermeta, see docs/reference/pantavisor-metadata.md). Any
+# value of "0" disables the loop below so on-demand activation can instead be
+# demonstrated by execing into this container and running an avahi D-Bus
+# command by hand. Absent (the default) or any other value keeps today's
+# behavior: browse automatically.
+AUTOSTART_FILE=/pantavisor/user-meta/autostart
+AUTOSTART=1
+[ -r "$AUTOSTART_FILE" ] && read -r AUTOSTART < "$AUTOSTART_FILE"
+
 i=0
 while [ ! -S "$DBUS_SOCKET" ] && [ "$i" -lt "$DBUS_WAIT" ]; do
 	i=$((i + 1))
@@ -22,7 +33,14 @@ if [ ! -S "$DBUS_SOCKET" ]; then
 fi
 
 export DBUS_SYSTEM_BUS_ADDRESS="unix:path=$DBUS_SOCKET"
-echo "pv-avahi-browse: hosted D-Bus system bus at $DBUS_SOCKET -> browsing via org.freedesktop.Avahi"
+echo "pv-avahi-browse: hosted D-Bus system bus at $DBUS_SOCKET"
+
+if [ "$AUTOSTART" = "0" ]; then
+	echo "pv-avahi-browse: pv-avahi-browse.autostart=0 -> idling; exec in and run e.g. 'avahi-browse -atrp' to trigger on-demand activation manually"
+	while true; do sleep 3600; done
+fi
+
+echo "pv-avahi-browse: browsing via org.freedesktop.Avahi"
 
 while true; do
 	echo "--- avahi-browse: all services (resolved) ---"

--- a/recipes-containers/pantavisor/pv-avahi-browse/pv-avahi-browse-start.sh
+++ b/recipes-containers/pantavisor/pv-avahi-browse/pv-avahi-browse-start.sh
@@ -11,15 +11,24 @@ DBUS_SOCKET=/run/dbus/system_bus_socket
 DBUS_WAIT=${PV_AVAHI_DBUS_WAIT:-5}
 
 # Auto-browse can be disabled per-device via the usermeta key
-# `pv-avahi-browse.autostart`, exposed here as /pantavisor/user-meta/autostart
-# (container-scoped usermeta, see docs/reference/pantavisor-metadata.md). Any
+# `pv-avahi-browse.autostart` (see docs/reference/pantavisor-metadata.md). Any
 # value of "0" disables the loop below so on-demand activation can instead be
 # demonstrated by execing into this container and running an avahi D-Bus
 # command by hand. Absent (the default) or any other value keeps today's
 # behavior: browse automatically.
-AUTOSTART_FILE=/pantavisor/user-meta/autostart
+#
+# This container carries the `mgmt` role, so it gets the *general*
+# /pantavisor/user-meta mount (one file per full key, e.g.
+# pv-avahi-browse.autostart) rather than the per-platform-scoped mount
+# (plugins/pv_lxc.c: PLAT_ROLE_MGMT branch vs the else branch) that a plain
+# `app`-only container would get, where the file would instead be the
+# platform-stripped `autostart`. Check both so this keeps working if the role
+# ever changes.
 AUTOSTART=1
-[ -r "$AUTOSTART_FILE" ] && read -r AUTOSTART < "$AUTOSTART_FILE"
+for AUTOSTART_FILE in /pantavisor/user-meta/pv-avahi-browse.autostart \
+		      /pantavisor/user-meta/autostart; do
+	[ -r "$AUTOSTART_FILE" ] && read -r AUTOSTART < "$AUTOSTART_FILE" && break
+done
 
 i=0
 while [ ! -S "$DBUS_SOCKET" ] && [ "$i" -lt "$DBUS_WAIT" ]; do

--- a/recipes-containers/pantavisor/pv-avahi_1.1.bb
+++ b/recipes-containers/pantavisor/pv-avahi_1.1.bb
@@ -44,6 +44,25 @@ PVR_SIG_ADD_ARGS = "--part ${PN}"
 
 # do_deploy hook for pvroot-image consumption is provided by container-pvrexport
 
+# WORKAROUND for a `pvr app add` bug (isolated 2026-07-22): passing
+# --status-goal together with --group silently drops the top-level "type"
+# and "config" keys from the generated run.json. Without "type", pantavisor's
+# _pv_platforms_get_ctrl(p->type) calls strcmp() on a NULL p->type and
+# segfaults the whole mainloop on every boot that reconciles this platform
+# (confirmed via on-device core dump + gdb backtrace, platforms.c:691). Patch
+# the fields back in and recommit so the exported pvrexport is valid.
+#
+# Appending directly to do_image_pvrexportit here does not work: image.bbclass
+# regenerates that task's body from IMAGE_CMD:pvrexportit after this recipe is
+# parsed, clobbering any :append on the task itself. Append to the IMAGE_CMD
+# variable instead so our fixup ends up inside the generated task body.
+IMAGE_CMD:pvrexportit:append() {
+    cd ${PVSTATE}
+    jq '. + {"type": "lxc", "config": "lxc.container.conf"}' ${PN}/run.json > ${PN}/run.json.tmp && mv ${PN}/run.json.tmp ${PN}/run.json
+    pvr add
+    pvr commit
+}
+
 install_scripts() {
     install -d ${IMAGE_ROOTFS}${bindir}
     install -m 0755 ${WORKDIR}/pv-avahi-start.sh ${IMAGE_ROOTFS}${bindir}/pv-avahi-start

--- a/recipes-containers/pantavisor/pv-avahi_1.1.bb
+++ b/recipes-containers/pantavisor/pv-avahi_1.1.bb
@@ -50,18 +50,15 @@ PVR_SIG_ADD_ARGS = "--part ${PN}"
 # _pv_platforms_get_ctrl(p->type) calls strcmp() on a NULL p->type and
 # segfaults the whole mainloop on every boot that reconciles this platform
 # (confirmed via on-device core dump + gdb backtrace, platforms.c:691). Patch
-# the fields back in and recommit so the exported pvrexport is valid.
-#
-# Appending directly to do_image_pvrexportit here does not work: image.bbclass
-# regenerates that task's body from IMAGE_CMD:pvrexportit after this recipe is
-# parsed, clobbering any :append on the task itself. Append to the IMAGE_CMD
-# variable instead so our fixup ends up inside the generated task body.
-IMAGE_CMD:pvrexportit:append() {
-    cd ${PVSTATE}
+# the fields back in via the PVR_APP_POST_FIXUP hook (container-pvrexport.bbclass),
+# which runs after `pvr app add` but before signing/export -- appending
+# directly to IMAGE_CMD:pvrexportit runs too late (that class body still has
+# `pvr sig add` + `pvr export` after the point any :append lands, so the
+# already-packaged pvrexport.tgz never saw the fix).
+pv_avahi_fixup_runjson() {
     jq '. + {"type": "lxc", "config": "lxc.container.conf"}' ${PN}/run.json > ${PN}/run.json.tmp && mv ${PN}/run.json.tmp ${PN}/run.json
-    pvr add
-    pvr commit
 }
+PVR_APP_POST_FIXUP = "pv_avahi_fixup_runjson"
 
 install_scripts() {
     install -d ${IMAGE_ROOTFS}${bindir}

--- a/recipes-containers/pantavisor/pv-avahi_1.1.bb
+++ b/recipes-containers/pantavisor/pv-avahi_1.1.bb
@@ -27,9 +27,17 @@ PV_CONFIG_OVERLAY_DIR = "pv-avahi-config"
 
 PVR_APP_ADD_EXTRA_ARGS += " \
     --volume ovl:/tmp:permanent \
+    --status-goal MOUNTED \
 "
 
-PVR_APP_ADD_GROUP = "platform"
+# app, not platform: pv-avahi is just a daemon in the host net namespace, and
+# staying passive (status-goal MOUNTED) until on-demand D-Bus activation
+# starts it needs the app group's "container" restart policy so it can also
+# be stopped/started manually via the containers API. args.json's PV_GROUP
+# already said "app" (fix(pv-avahi): move container to app group /
+# fix(pv-avahi): drop system restart policy), but this --group flag was
+# never updated to match and silently overrode it at build time.
+PVR_APP_ADD_GROUP = "app"
 
 # Sign including config (override --noconfig default from container-pvrexport)
 PVR_SIG_ADD_ARGS = "--part ${PN}"


### PR DESCRIPTION
## Summary
- `pv-avahi` moved from `platform` to `app` group and made passive (`status_goal: MOUNTED`) so it demonstrates on-demand D-Bus activation (pantavisor/pantavisor#738) instead of starting at boot; `app` group also gives it the `container` restart policy so it's stoppable/startable via the containers API.
- `pv-avahi-browse` gets a `pv-avahi-browse.autostart` usermeta toggle (default: auto-browse, matching prior behavior) so the demo can instead be triggered manually by execing in and running `avahi-browse -atrp`.
- New `PVR_APP_POST_FIXUP` hook in `container-pvrexport.bbclass`, used by `pv-avahi` to patch `type`/`config` back into `run.json` after `pvr app add` — works around a `pvr app add --status-goal` bug that silently drops those keys when combined with `--group`, which otherwise segfaults pantavisor's mainloop (`_pv_platforms_get_ctrl` on a NULL `type`) on every boot.

## Test plan
- [x] Built pv-avahi/pv-avahi-browse images with the changes and deployed to `labslave_bpi_m2` (rev176)
- [x] Confirmed `pv-avahi`: `group: app`, `status: MOUNTED`, `restart_policy: container`, no crash across multiple reboots
- [x] Confirmed on-demand activation from a fresh boot: `pv-avahi` stays passive until `avahi-browse -atrp` inside `pv-avahi-browse` triggers activation via pv-xconnect
- [x] Confirmed `pv-avahi` stoppable/startable manually via the containers API
- [ ] Automated pvtest coverage (tracked as follow-up, mirrors phase 6 in pantavisor/pantavisor#738)

Depends on pantavisor/pantavisor#738 (on-demand D-Bus service activation feature).