### PR TITLE
fix(recipes): set explicit PV on git recipes for SBOM/CVE accuracy

### DIFF
--- a/recipes-pv/dropbear/dropbear-pv_git.bb
+++ b/recipes-pv/dropbear/dropbear-pv_git.bb
@@ -20,7 +20,8 @@ RDEPENDS:${PN}-dev = ""
 SRC_URI = "git://github.com/pantacor/dropbear-pv;branch=pv/master;protocol=https"
 SRCREV = "a5052fd488a1071ae7b0ee0877f6b0e17bc2a216"
 PE = "1"
-PKGV = "2020.81+git0+pv+${GITPKGV}"
+PV = "2020.81+git0+pv"
+PKGV = "${PV}+${GITPKGV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-pv/libthttp/libthttp_git.bb
+++ b/recipes-pv/libthttp/libthttp_git.bb
@@ -16,7 +16,8 @@ PACKAGES =+ "libthttp-certs"
 SRC_URI = "git://github.com/pantavisor/libthttp;protocol=https;branch=master"
 SRCREV = "ce916c562c5b11bcb0b5165043ded543dfea322a"
 PE = "1"
-PKGV = "011+git0+${GITPKGV}"
+PV = "011+git0"
+PKGV = "${PV}+${GITPKGV}"
 
 FILES:${PN}-certs += "/etc/thttp/certs"
 

--- a/recipes-pv/lxc-pv/lxc-pv_git.bb
+++ b/recipes-pv/lxc-pv/lxc-pv_git.bb
@@ -48,7 +48,8 @@ SRC_URI:append:panta-appengine = " \
 	file://0002-fix-avoid-infinite-loop-when-closing-inherited-fd.patch"
 
 PE = "1"
-PKGV = "3.0.4+git0+pv+${GITPKGV}"
+PV = "3.0.4+git0+pv"
+PKGV = "${PV}+${GITPKGV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -36,7 +36,8 @@ SRC_URI = "${PANTAVISOR_URI};branch=${PANTAVISOR_BRANCH} \
 SRCREV = "${PANTAVISOR_SRCREV}"
 
 PE = "1"
-PKGV = "026+git0+${GITPKGV}"
+PV = "029~rc4+git0"
+PKGV = "${PV}+${GITPKGV}"
 
 PACKAGES =+ "${PN}-hooks-mdev ${PN}-pvtx ${PN}-pvtx-static ${PN}-config ${PN}-pvtest ${PN}-pvcontrol ${PN}-pvcurl ${PN}-debug-hooks"
 


### PR DESCRIPTION
## Summary
- `pantavisor_git.bb`, `libthttp_git.bb`, `lxc-pv_git.bb`, and `dropbear-pv_git.bb` are all named `<pn>_git.bb`, so `PV` defaulted to the literal string `git`. Yocto's `create-spdx` class and `cve-check` both read `PV` (not `PKGV`) for the component version, so every generated SBOM/CVE entry for these packages showed version `git` instead of anything usable.
- Split the existing hardcoded `PKGV` string into `PV` + `PKGV`, following the pattern documented in `gitpkgv.bbclass` (`GITPKGV` must only be used in `PKGV`, never `PV`, since computing it requires the source to already be fetched — using it in `PV` would create a circular WORKDIR dependency). `PKGV` now derives from `PV` instead of duplicating the version number in two places.
- While at it, bumped `pantavisor`'s version prefix from `026` to `029~rc4` to match the tag reachable from the pinned `SRCREV` (it was 3 releases stale). Used the `~rc4` tilde form per the Yocto recipe style guide so it still sorts correctly before a future `029` final release.
- `libthttp`, `lxc-pv`, and `dropbear-pv` prefixes were checked against upstream tags/embedded version strings at their pinned `SRCREV` and already matched, so left as-is.

## Test plan
- [x] CI build/test matrix passes for affected machines
- [x] `bitbake -e <recipe>` shows expected `PV`/`PKGV` for each of the four recipes
- [x] SBOM (`create-spdx`) output for these packages shows a real version instead of `git`