### PR TITLE
recipes-pv: bump pvr to 052 and package its docs

### DIFF
--- a/classes/pantacor-component-docs.bbclass
+++ b/classes/pantacor-component-docs.bbclass
@@ -5,12 +5,21 @@
 #   DOCS_FILES          — space-separated list of specific files to include instead of
 #                         a whole directory; takes precedence over DOCS_SRC_DIR
 #   DOCS_COMPONENT_NAME — directory name in the combined image tarball (default: ${BPN})
+#   DOCS_SRC_URI        — optional extra SRC_URI entry (fetcher URL + params) needed only to
+#                         obtain the docs, e.g. when a recipe's normal source fetch doesn't
+#                         include docs/. Appended to SRC_URI, but dropped for class-native/
+#                         class-nativesdk since do_create_component_docs doesn't run there.
 #
 # Recipes that have neither a valid DOCS_SRC_DIR nor DOCS_FILES are skipped with a warning.
 
 DOCS_SRC_DIR ?= "${S}/docs"
 DOCS_FILES ?= ""
 DOCS_COMPONENT_NAME ?= "${BPN}"
+DOCS_SRC_URI ?= ""
+
+SRC_URI:append = " ${DOCS_SRC_URI}"
+SRC_URI:remove:class-native = "${DOCS_SRC_URI}"
+SRC_URI:remove:class-nativesdk = "${DOCS_SRC_URI}"
 
 SSTATETASKS += "do_create_component_docs"
 

--- a/recipes-pv/pvr/pvr_052.bb
+++ b/recipes-pv/pvr/pvr_052.bb
@@ -5,13 +5,13 @@ HOMEPAGE = "https://golang.org/"
 inherit pvgo_mod deploy pantacor-component-docs
 
 
-# TODO: docs moved from the root README.md to a docs/ folder (pvr commit
-# fd286b27, "docs: add full command reference and simplify README"), but that
-# commit isn't in any tagged release yet (latest tag is 051; this recipe
-# pins 050). Neither a raw-URL fetch nor the release src tarball can reach
-# docs/ until pvr cuts a release that includes it. Re-wire DOCS_FILES/
-# DOCS_SRC_DIR to pull from docs/ once this recipe is bumped to such a tag.
+# pvr's release src.tar.gz only ever contains go.mod/go.sum/Makefile/*.go
+# (see pvr's .gitlab-ci.yml package-deploy job), so docs/ is fetched
+# separately via GitLab's repository archive API pinned to the same tag (see
+# DOCS_SRC_URI below) and relocated into ${S}/docs by relocate_source,
+# matching pantacor-component-docs' default DOCS_SRC_DIR.
 DOCS_COMPONENT_NAME = "pvr"
+DOCS_SRC_URI = "https://gitlab.com/api/v4/projects/pantacor%2Fpvr/repository/archive.tar.gz?sha=${PV}&path=docs;name=docs;subdir=docs-src;downloadfilename=pvr.${PV}.docs.tar.gz"
 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
@@ -23,8 +23,9 @@ SRC_URI = " \
         https://gitlab.com/api/v4/projects/pantacor%2Fpvr/packages/generic/pvr/${PV}/pvr.${PV}.vendor.tar.gz;name=vendor;subdir=src/${GO_IMPORT} \
 "
 
-SRC_URI[pvr.sha256sum] = "9cba05717f2fd6e8d8fa2bd8aaef0e4b641f7ef81afebbf498c50eaf4bc83bf5"
-SRC_URI[vendor.sha256sum] = "019feba257ee70b0d10775cc1a8547e113f8adc07c66898e041d09f8a6413e6d"
+SRC_URI[pvr.sha256sum] = "1048412375116e33d8b1facb58c2d68adf53df549cf3a12e425675afdd3b3b18"
+SRC_URI[vendor.sha256sum] = "ad9a7822b907e6c25a34d385ad589b1b94d90beda78b7bbe218b921abf266bef"
+SRC_URI[docs.sha256sum] = "95d1e1c4244921e2657389f866ecaa2c7a97b0cd44c1a9eb066433d7ea5faf52"
 
 GO_IMPORT = "gitlab.com/pantacor/pvr"
 export GO111MODULE="on"
@@ -38,6 +39,9 @@ GO_LINKMODE:class-native = ""
 do_unpack[cleandirs] += "${S}/src/${GO_IMPORT}"
 relocate_source() {
   cp -fr ${S}/pvr-*/* ${S}/src/${GO_IMPORT}
+  if [ -d ${S}/docs-src ]; then
+    cp -r ${S}/docs-src/*/docs ${S}/docs
+  fi
 }
 do_patch[postfuncs] += "relocate_source"
 


### PR DESCRIPTION
## Summary
- Bump the `pvr` recipe from 050 to 052, updating `SRC_URI` checksums accordingly.
- pvr's release `src.tar.gz` only ever contains `go.mod`/`go.sum`/`Makefile`/`*.go` (see pvr's `.gitlab-ci.yml` `package-deploy` job), so `docs/` (added upstream in commit `fd286b27`, first reachable from tag `052`) is fetched separately via GitLab's repository archive API scoped to `docs/` at the same tag, and relocated into `${S}/docs` during `relocate_source`.
- Add a `DOCS_SRC_URI` hook to `pantacor-component-docs.bbclass` so any recipe that needs an extra docs-only fetch (like `pvr`) can opt in with one variable; it's appended to `SRC_URI` for target builds and dropped for `class-native`/`class-nativesdk`, where `do_create_component_docs` doesn't run.

## Test plan
- [x] Verified the `052` tag's `docs/` tree is reachable via the GitLab repository archive API (`.../repository/archive.tar.gz?sha=052&path=docs`) and that its sha256 is stable across repeated fetches.
- [x] Verified new `pvr.052.src.tar.gz`/`pvr.052.vendor.tar.gz` checksums against GitLab's own `x-checksum-sha256` response header.
- [x] Simulated the fetch → unpack → `relocate_source` flow locally with the real downloaded tarballs; confirmed `${S}/docs` ends up populated with `index.md` and `commands/*.md`, and go source relocation still works.
- [ ] Full `bitbake pvr` / `bitbake pvr-native` build (not run — this checkout's `bblayers.conf` references kas-managed layers that aren't checked out locally).