### PR TITLE
recipes-pv: automated srcrev update

### DIFF
--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,3 +1,3 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
-PANTAVISOR_SRCREV = "47925eb842761cf624bcc9e056d57b8fb475f032"
+PANTAVISOR_SRCREV = "c5721b9d0fb9e6b635ec56c7f0963cee867cd946"


### PR DESCRIPTION
Updating pantavisor in ./recipes-pv/pantavisor/pantavisor.inc:
  47925eb842761cf624bcc9e056d57b8fb475f032 -> c5721b9d0fb9e6b635ec56c7f0963cee867cd946
    * c5721b9 feat(logserver): send lxc logs to stdout_direct when active
    * 4b54197 feat(loop): new PV_LOOP_INDEX_BASE config to assign 64 loop device slots to device
    * c5e6cec feat(pantavisor): add PV_LOG_TIMESTAMP config to switch between absolut and relative timestamp
    * f1f339f fix(ctrl): log every rejected pv-ctrl command with its op
    * 1052328 fix(ctrl): cmd struct not being freed