### PR TITLE
fix: pin repo for gh workflow run in onpush-pantavisor-docs.yaml

### DIFF
--- a/.github/workflows/onpush-pantavisor-docs.yaml
+++ b/.github/workflows/onpush-pantavisor-docs.yaml
@@ -33,7 +33,7 @@ jobs:
 
           if [ -z "$OLD_SRCREV" ]; then
             echo "Could not resolve previous PANTAVISOR_SRCREV; triggering docs build to be safe."
-            gh workflow run docs-scarthgap.yaml --ref master
+            gh workflow run docs-scarthgap.yaml --repo "$GITHUB_REPOSITORY" --ref master
             exit 0
           fi
 
@@ -61,7 +61,7 @@ jobs:
           if [ -n "$CHANGED_DOCS" ]; then
             echo "docs/ changed in pantavisor between $OLD_SRCREV and $NEW_SRCREV:"
             echo "$CHANGED_DOCS"
-            gh workflow run docs-scarthgap.yaml --ref master
+            gh workflow run docs-scarthgap.yaml --repo "$GITHUB_REPOSITORY" --ref master
           else
             echo "No docs/ changes in pantavisor between $OLD_SRCREV and $NEW_SRCREV; skipping."
           fi


### PR DESCRIPTION
## Summary

`onpush-pantavisor-docs.yaml` failed on its first real run (after the `PANTAVISOR_SRCREV` bump in c14bff7) with:

```
HTTP 404: workflow docs-scarthgap.yaml not found on the default branch
```

The diff step `cd`s into a throwaway clone of `pantavisor/pantavisor` to compare `docs/` between the old and new SRCREV, but never `cd`s back to `$GITHUB_WORKSPACE` before calling `gh workflow run`. Since `gh` infers the target repo from the git remote in the current directory when `--repo` isn't given, it resolved to `pantavisor/pantavisor` instead of `pantavisor/meta-pantavisor`.

## Fix

Pin `--repo "$GITHUB_REPOSITORY"` explicitly on both `gh workflow run` calls so the target repo is correct regardless of cwd.

## Test plan

- [ ] YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/onpush-pantavisor-docs.yaml'))"`
- [ ] Next `PANTAVISOR_SRCREV` bump (or a manual re-run of the failed job) should successfully dispatch `docs-scarthgap.yaml` in this repo