### PR TITLE
AutoPR: update kas meta layers to latest branch commits

### DIFF
--- a/docs/overview/ci/status.md
+++ b/docs/overview/ci/status.md
@@ -8,6 +8,7 @@ sidebar_position: 4
 <!-- WORKFLOW_TABLE_START -->
 | Workflow | Status |
 | :--- | :--- |
+| **build-docs-latest** | [![BUILD](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/build-docs-latest.yaml?style=flat-square&logo=github-actions&logoColor=white&label=BUILD)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/build-docs-latest.yaml) |
 | **build-docs-scarthgap** | [![BUILD](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/build-docs-scarthgap.yaml?style=flat-square&logo=github-actions&logoColor=white&label=BUILD)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/build-docs-scarthgap.yaml) |
 | **docs-scarthgap** | [![DOCS](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/docs-scarthgap.yaml?style=flat-square&logo=github-actions&logoColor=white&label=DOCS)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/docs-scarthgap.yaml) |
 | **manual-pvtests** | [![MAN](https://img.shields.io/github/actions/workflow/status/pantavisor/meta-pantavisor/manual-pvtests.yaml?style=flat-square&logo=github-actions&logoColor=white&label=MAN)](https://github.com/pantavisor/meta-pantavisor/actions/workflows/manual-pvtests.yaml) |

--- a/kas/build-configs/release/96boards-orangepi-i96-scarthgap.yaml
+++ b/kas/build-configs/release/96boards-orangepi-i96-scarthgap.yaml
@@ -20,14 +20,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: d03f09df0ab0bf326ab1e0d0969f4643a9f8a378
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: 89da4f56b4c510059f8dc1527d289d9fd4fef133
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: d8cc4e44001c7257273d290ce8c4496e93d32841
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/colibri-imx6ull-scarthgap.yaml
+++ b/kas/build-configs/release/colibri-imx6ull-scarthgap.yaml
@@ -16,17 +16,17 @@ repos:
         url: https://github.com/Freescale/meta-freescale-distro.git
     meta-toradex-bsp-common:
         branch: scarthgap-7.x.y
-        commit: 803ac6dab4bfd9dcdd9ef815b572d7f858785c82
+        commit: 2ed62810c9538d6265a8f03222cb23b07faaf060
         path: layers/meta-toradex-bsp-common
         url: https://git.toradex.com/meta-toradex-bsp-common.git
     meta-toradex-nxp:
         branch: scarthgap-7.x.y
-        commit: 71fbee963f2db49e7a29bd231971e1b42d6860bb
+        commit: bafda8d4723fa985bba51746ba0aeb5274a4cb48
         path: layers/meta-toradex-nxp
         url: https://git.toradex.com/meta-toradex-nxp.git
     meta-toradex-tezi:
         branch: scarthgap-7.x.y
-        commit: e4abbbd9034f9de3683ef187ab7d90d0681f8277
+        commit: caa7fd3456b05aeed6979a15bea2a45dce49ae42
         path: layers/meta-toradex-tezi
         url: https://github.com/toradex/meta-toradex-tezi.git
     meta-qt5:
@@ -47,14 +47,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/docker-x86_64-scarthgap.yaml
+++ b/kas/build-configs/release/docker-x86_64-scarthgap.yaml
@@ -16,14 +16,14 @@ repos:
                 repo: meta-pantavisor
         url: https://github.com/yoctoproject/poky.git
         path: layers/poky
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/imx8mm-var-dart-scarthgap.yaml
+++ b/kas/build-configs/release/imx8mm-var-dart-scarthgap.yaml
@@ -18,7 +18,7 @@ repos:
         url: https://github.com/varigit/meta-variscite-bsp-imx.git
         path: layers/meta-variscite-bsp
         branch: scarthgap_6.6.52-2.2.2_var01
-        commit: 97957dd27c8dfef2e197322e62cbad990fe296f1
+        commit: f1bc578396c15f28221550aefd94d2cbc0ab4024
     meta-variscite-hab:
         url: https://github.com/varigit/meta-variscite-hab.git
         path: layers/meta-variscite-hab
@@ -28,12 +28,12 @@ repos:
         url: https://github.com/varigit/meta-variscite-sdk.git
         path: layers/meta-variscite-sdk
         branch: scarthgap_6.6.52-2.2.2_var01
-        commit: 8541b76a56aefab0df9dab75bafdaa7cb4bd2dc4
+        commit: 75853a038ec4686bd5b834062ba4987ace8ec816
     meta-variscite-bsp-common:
         url: https://github.com/varigit/meta-variscite-bsp-common.git
         path: layers/meta-variscite-bsp-common
         branch: scarthgap_6.6.52-2.2.2_var01
-        commit: 5d0e70808292f7fe1470142acf0c3830aeee9193
+        commit: 3148bb4a349e4d6d8f2cf0e49562a89aa3fec42a
     meta-variscite-sdk-common:
         url: https://github.com/varigit/meta-variscite-sdk-common.git
         path: layers/meta-variscite-sdk-common
@@ -62,7 +62,7 @@ repos:
             meta-oe:
             meta-python:
         url: https://github.com/openembedded/meta-openembedded.git
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
     meta-swupdate:
         url: https://github.com/sbabic/meta-swupdate.git
         path: layers/meta-swupdate
@@ -94,10 +94,10 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
 local_conf_header:

--- a/kas/build-configs/release/imx8mn-var-som-scarthgap.yaml
+++ b/kas/build-configs/release/imx8mn-var-som-scarthgap.yaml
@@ -18,7 +18,7 @@ repos:
         url: https://github.com/varigit/meta-variscite-bsp-imx.git
         path: layers/meta-variscite-bsp
         branch: scarthgap_6.6.52-2.2.2_var01
-        commit: 97957dd27c8dfef2e197322e62cbad990fe296f1
+        commit: f1bc578396c15f28221550aefd94d2cbc0ab4024
     meta-variscite-hab:
         url: https://github.com/varigit/meta-variscite-hab.git
         path: layers/meta-variscite-hab
@@ -28,12 +28,12 @@ repos:
         url: https://github.com/varigit/meta-variscite-sdk.git
         path: layers/meta-variscite-sdk
         branch: scarthgap_6.6.52-2.2.2_var01
-        commit: 8541b76a56aefab0df9dab75bafdaa7cb4bd2dc4
+        commit: 75853a038ec4686bd5b834062ba4987ace8ec816
     meta-variscite-bsp-common:
         url: https://github.com/varigit/meta-variscite-bsp-common.git
         path: layers/meta-variscite-bsp-common
         branch: scarthgap_6.6.52-2.2.2_var01
-        commit: 5d0e70808292f7fe1470142acf0c3830aeee9193
+        commit: 3148bb4a349e4d6d8f2cf0e49562a89aa3fec42a
     meta-variscite-sdk-common:
         url: https://github.com/varigit/meta-variscite-sdk-common.git
         path: layers/meta-variscite-sdk-common
@@ -62,7 +62,7 @@ repos:
             meta-oe:
             meta-python:
         url: https://github.com/openembedded/meta-openembedded.git
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
     meta-swupdate:
         url: https://github.com/sbabic/meta-swupdate.git
         path: layers/meta-swupdate
@@ -94,10 +94,10 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
 local_conf_header:
@@ -107,6 +107,11 @@ local_conf_header:
         BB_DANGLINGAPPENDS_WARNONLY = "1"
         PANTAVISOR_FEATURES:append = " caam-nxp"
         PV_UBOOT_AUTOFDT = "1"
+    platform-imx8mn-var-som: |
+        # Wakelocks / managed power. This is the board managed mode is validated on:
+        # it has real PSCI suspend-to-RAM and, via the SNVS RTC patch this feature
+        # gates, a wakeup-capable RTC alarm to wake from it on schedule.
+        PANTAVISOR_FEATURES:append = " wakelocks"
     pvgo: |
         PREFERRED_VERSION_pvgo-binary-native = "1.24.13"
     rm_work: |
@@ -128,8 +133,6 @@ local_conf_header:
         PANTAVISOR_FEATURES:append = " tailscale"
     pantavisor-debug: |
         PANTAVISOR_FEATURES:append = " debug"
-    pantavisor-wakelocks: |
-        PANTAVISOR_FEATURES:append = " wakelocks"
     __menu_config_locals: ''
     __menu_config_vars: |-
         EXTRA_IMAGE_FEATURES:append = " debug-tweaks"

--- a/kas/build-configs/release/imx8qxp-b0-mek-scarthgap.yaml
+++ b/kas/build-configs/release/imx8qxp-b0-mek-scarthgap.yaml
@@ -23,7 +23,7 @@ repos:
             meta-python:
         url: https://github.com/openembedded/meta-openembedded.git
         path: layers/meta-openembedded
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
     meta-imx:
         url: https://github.com/nxp-imx/meta-imx.git
         path: layers/meta-imx
@@ -57,10 +57,10 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
 local_conf_header:

--- a/kas/build-configs/release/radxa-rock5a-scarthgap.yaml
+++ b/kas/build-configs/release/radxa-rock5a-scarthgap.yaml
@@ -30,14 +30,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/raspberrypi-armv8-scarthgap.yaml
+++ b/kas/build-configs/release/raspberrypi-armv8-scarthgap.yaml
@@ -27,14 +27,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/rpi-scarthgap.yaml
+++ b/kas/build-configs/release/rpi-scarthgap.yaml
@@ -27,14 +27,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/sunxi-bananapi-m2-berry-scarthgap.yaml
+++ b/kas/build-configs/release/sunxi-bananapi-m2-berry-scarthgap.yaml
@@ -30,14 +30,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
+++ b/kas/build-configs/release/sunxi-orange-pi-3lts-scarthgap.yaml
@@ -30,14 +30,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/sunxi-orange-pi-r1-scarthgap.yaml
+++ b/kas/build-configs/release/sunxi-orange-pi-r1-scarthgap.yaml
@@ -30,14 +30,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:

--- a/kas/build-configs/release/verdin-imx8mm-scarthgap.yaml
+++ b/kas/build-configs/release/verdin-imx8mm-scarthgap.yaml
@@ -16,17 +16,17 @@ repos:
         url: https://github.com/Freescale/meta-freescale-distro.git
     meta-toradex-bsp-common:
         branch: scarthgap-7.x.y
-        commit: 803ac6dab4bfd9dcdd9ef815b572d7f858785c82
+        commit: 2ed62810c9538d6265a8f03222cb23b07faaf060
         path: layers/meta-toradex-bsp-common
         url: https://git.toradex.com/meta-toradex-bsp-common.git
     meta-toradex-nxp:
         branch: scarthgap-7.x.y
-        commit: 71fbee963f2db49e7a29bd231971e1b42d6860bb
+        commit: bafda8d4723fa985bba51746ba0aeb5274a4cb48
         path: layers/meta-toradex-nxp
         url: https://git.toradex.com/meta-toradex-nxp.git
     meta-toradex-tezi:
         branch: scarthgap-7.x.y
-        commit: e4abbbd9034f9de3683ef187ab7d90d0681f8277
+        commit: caa7fd3456b05aeed6979a15bea2a45dce49ae42
         path: layers/meta-toradex-tezi
         url: https://github.com/toradex/meta-toradex-tezi.git
     meta-qt5:
@@ -47,14 +47,14 @@ repos:
         layers:
             meta:
             meta-poky:
-        commit: 9916b7471edd0e9a95d94364398c241d1c3bac33
+        commit: 64e69ed23703f6358ec431d3f5f1f8483f974cae
     meta-pantavisor:
     meta-virtualization:
-        commit: f851f730ec415d266bfe0c5941c228a63a896298
+        commit: f980aefbc8b3eeafb8d144e7fdac3c3b701a4fea
         path: layers/meta-virtualization
         url: https://git.yoctoproject.org/meta-virtualization
     meta-openembedded:
-        commit: 7eb94107580092f79ff1b639a87762fe6f96aa12
+        commit: bec755063a8b5da65df626f5749496aadaa4f4bb
         layers:
             meta-filesystems:
             meta-networking:


### PR DESCRIPTION
Automated update of kas meta layers to latest branch commits. See the commit message for the full per-repo changelog.