### PR TITLE
test(pvtests): update basic-endpoints outputs for new config keys

### DIFF
--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints-curl/output
@@ -384,6 +384,16 @@ object count: 6
     "modified": "default"
   },
   {
+    "key": "PV_LOG_TIMESTAMP",
+    "value": "relative",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOOP_INDEX_BASE",
+    "value": "-1",
+    "modified": "default"
+  },
+  {
     "key": "PV_LXC_LOG_LEVEL",
     "value": "2",
     "modified": "default"

--- a/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
+++ b/recipes-pv/pantavisor-pvtests/files/local/control/basic-endpoints/output
@@ -376,6 +376,16 @@ object count: 6
     "modified": "default"
   },
   {
+    "key": "PV_LOG_TIMESTAMP",
+    "value": "relative",
+    "modified": "default"
+  },
+  {
+    "key": "PV_LOOP_INDEX_BASE",
+    "value": "-1",
+    "modified": "default"
+  },
+  {
     "key": "PV_LXC_LOG_LEVEL",
     "value": "2",
     "modified": "default"


### PR DESCRIPTION
## Summary
- `local/control/basic-endpoints` and `local/control/basic-endpoints-curl` fail on master since the SRCREV bump in 87f5e3c (run 30565239356).
- pantavisor added two config keys (`config.c`: `PV_LOG_TIMESTAMP` default `RELATIV_TIMER`, `PV_LOOP_INDEX_BASE` default `-1`), so the pv-ctrl config listing returns two entries the goldens do not have. Not a regression — the expected outputs are stale.
- These are the only two pvtest outputs carrying the config dump.

## Changes
- Add `PV_LOG_TIMESTAMP` (`relative`, default) and `PV_LOOP_INDEX_BASE` (`-1`, default) to the `basic-endpoints` golden output.
- Same two entries added to the `basic-endpoints-curl` golden output.