### PR TITLE
docs(overview): define trail/container/LXC/xconnect on first use, add cost note

### DIFF
--- a/docs/overview/images.md
+++ b/docs/overview/images.md
@@ -5,9 +5,9 @@ sidebar_position: 6
 
 `pantavisor-starter` (`recipes-pv/images/pantavisor-starter.bb`) is the layer's
 top-level **deployable image**: a complete, bootable rootfs whose initial
-Pantavisor trail (`/trails/0`) is pre-populated with a working set of containers
-and the board's BSP. It is what you flash to get a device that boots Pantavisor
-and brings up a usable system out of the box.
+Pantavisor [trail](glossary.md#trail) (`/trails/0`) is pre-populated with a working set of
+[containers](glossary.md#container) and the board's BSP. It is what you flash to get a
+device that boots Pantavisor and brings up a usable system out of the box.
 
 ```bitbake
 inherit image pvroot-image pantavisor-docs
@@ -25,6 +25,18 @@ container `pvrexport` bundles plus the BSP. The "starter" image is the opinionat
 default mix — enough to boot, get on the network, and be claimed/managed — as
 opposed to the bare [`pantavisor-remix`](#related-image-recipes) which ships only
 the SDK container.
+
+## Cost vs a monolithic image
+
+Splitting the payload into a BSP plus per-app containers isn't free, but it isn't
+paid in flash size either — squashfs container volumes run 50–70% smaller than an
+equivalent plain rootfs, and the Pantavisor runtime itself is a ~1 MB PID 1 with no
+daemon overhead. What you get for that: a single Python app update becomes a 2–5
+minute container update instead of a 30–60 minute full-image rebuild-and-reflash,
+with automatic health-gated rollback if it fails. See [Reduce firmware
+size](/meta-pantavisor/getting-started/solutions/firmware-size) for the full
+footprint breakdown and [Pantavisor vs Yocto](/meta-pantavisor/getting-started/benchmarks/vs-yocto)
+for the update-cost comparison against a monolithic image.
 
 ## What it ships
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -8,7 +8,8 @@ sidebar_position: 1
 
 meta-pantavisor is the Yocto/OpenEmbedded layer that builds Pantavisor-based
 BSP images for embedded Linux. It provides recipes, BitBake classes, and KAS
-configurations for producing initramfs images and container pvrexport bundles.
+configurations for producing initramfs images and [container](glossary.md#container)
+pvrexport bundles.
 
 This section covers the project structure, build system architecture, and how
 the layer is organized. Start here, then follow the build guide below.

--- a/docs/overview/meta-pantavisor.md
+++ b/docs/overview/meta-pantavisor.md
@@ -34,7 +34,7 @@ meta-pantavisor/
 | `recipes-pv/images/pantavisor-initramfs.bb` | Initramfs image |
 | `recipes-pv/images/pantavisor-bsp.bb` | BSP image (generates pvrexport bundles) |
 | `recipes-pv/pvr/pvr_*.bb` | PVR CLI tool (Go-based) |
-| `recipes-pv/lxc-pv/lxc-pv_git.bb` | Pantavisor-specific LXC fork |
+| `recipes-pv/lxc-pv/lxc-pv_git.bb` | Pantavisor-specific fork of [LXC](https://linuxcontainers.org/lxc/introduction/), the OS-level container runtime containers run under |
 
 ## BitBake Classes
 
@@ -59,7 +59,7 @@ Controls which optional Pantavisor components are compiled in and installed. Def
 | `tailscale` | Tailscale VPN integration |
 | `debug` | Debug features |
 | `pvcontrol` | pv-ctrl socket and CLI tools (pvcurl, pvcontrol) |
-| `xconnect` | Service mesh for container-to-container communication |
+| `xconnect` | [Service mesh](/pantavisor/overview/xconnect) for container-to-container communication |
 | `rngdaemon` | Random number generator daemon |
 | `squash-lz4` | LZ4 squashfs compression |
 | `squash-zstd` | Zstd squashfs compression |


### PR DESCRIPTION
## Origin

Draft fix for 5 of the 6 findings in a docs-eval persona report:
[`answers/01-yocto-no-containers/2026-07-30-promptA-claude-sonnet-5-development.md`](https://github.com/pantacor/docs-framework/blob/master/answers/01-yocto-no-containers/2026-07-30-promptA-claude-sonnet-5-development.md)
(persona 01 — Yocto integrator, no containers — cold-start prompt A, run 2026-07-30).

The persona read `overview` → `Layer Layout` → `Starter Image` top-down, the path a
skeptical Yocto veteran evaluating this layer would plausibly take.

## What blocked the reader

- **"trail" undefined (S1):** *"the whole page pivots on 'trail' as if I already know
  what it is — a rootfs? a git-like history? a running state? — and I never saw it
  defined anywhere I clicked from the overview."* Evidence: `overview/images` — "the
  real payload is an initial signed trail under `/trails/0`".
- **No cost/benefit case for containers (S1):** *"I came here to decide what containers
  cost me in flash, RAM, boot time, and build complexity versus my current full-image
  rebuild. Three pages in, nobody has made that case or given numbers."*
- **"container" undefined (S2):** first sentence of `overview` uses it as a known term
  with no link or contrast to a plain rootfs/image.
- **"LXC" and "service mesh" undefined jargon (S3, S3):** the `lxc-pv` and `xconnect`
  table rows in `overview/meta-pantavisor` name concepts with zero context.

## What changed and why

- `docs/overview/images.md` — link "trail" and "container" on first use to the repo's
  existing (but completely unlinked — nothing else in `docs/` referenced it) glossary
  page; add a short "Cost vs a monolithic image" section pointing to the existing
  firmware-size and vs-Yocto benchmark pages rather than duplicating their numbers here.
- `docs/overview/index.md` — link "container" on first use to the glossary.
- `docs/overview/meta-pantavisor.md` — gloss "LXC" inline with a link to
  linuxcontainers.org; link "Service mesh" (xconnect) to its reference page.

The report's 6th finding (an unlinked "Install guides" bullet in `images.md`) was
re-verified against this repo and found already fixed by a later, unrelated commit —
no change needed for it.

## Status

**This is a draft for human review** — opened by an automated docs-eval fix pass, not
verified against the rendered site. Please review wording/placement before merging.