### PR TITLE
recipes-pv: automated srcrev update

### DIFF
--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,3 +1,3 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
-PANTAVISOR_SRCREV = "3bfaa42b8b81c79a7290f22618817f582d0f18a4"
+PANTAVISOR_SRCREV = "4b00ba422d26ad6ddc002f493a9804770a28ca71"

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -36,7 +36,7 @@ SRC_URI = "${PANTAVISOR_URI};branch=${PANTAVISOR_BRANCH} \
 SRCREV = "${PANTAVISOR_SRCREV}"
 
 PE = "1"
-PV = "029~rc4+git0"
+PV = "029+git0"
 PKGV = "${PV}+${GITPKGV}"
 
 PACKAGES =+ "${PN}-hooks-mdev ${PN}-pvtx ${PN}-pvtx-static ${PN}-config ${PN}-pvtest ${PN}-pvcontrol ${PN}-pvcurl ${PN}-debug-hooks"


### PR DESCRIPTION
Updating pantavisor in ./recipes-pv/pantavisor/pantavisor.inc:
  3bfaa42b8b81c79a7290f22618817f582d0f18a4 -> 4b00ba422d26ad6ddc002f493a9804770a28ca71
    * 4b00ba4 docs: name the watchdog config keys on the overview page
    * 4c04825 Merge pull request #788 from pantavisor/feature/wakelock-drain-queue
    * df2da19 feat(power): drain queued revisions without sleeping in between
    * c5901a6 Merge pull request #768 from pantavisor/feature/wakelock-managed
    * 410d7db docs(overview): link Pantahub's licensing/self-host answer from remote-control
    * 89bece6 docs(overview): kernel requirements checklist, disambiguate the 4-way "platform" overload
    * 777e96f ci(on-push): skip Yocto builds on docs-only changes
    * 910209f docs(storage): add hands-on actionable examples
    * 6a60f22 docs(power): tighten wakelock comments
    * 92507d7 fix(power): always arm the first managed wake alarm
    * 15682d8 fix(power): brace the heartbeat-armed if/else in _managed_arm_alarm
    * 06e0bec feat(power): phase 0 container run window (power.wake.run_window)
    * aedb961 docs(power): wakelocks and power modes overview
    * 14af9fb feat(power): degrade locks, fail managed without kernel wakelock support
    * 20b4d5a feat(power): hold wakelocks across hub roundtrips, updates and debug shell
    * ff875dc feat(power): GET /wakelocks control endpoint
    * eec0726 feat(power): wakelock subsystem with locks and managed autosleep modes
    * 7452c4e fix(shutdown): make pre-FSM teardown paths safe against uninitialized state
    * 188f507 fix(config): accept symbolic bool values (true/false/yes/no/on/off)