### PR TITLE
docs(develop): registry auth, jargon links, and navigation gaps for cloud-native readers

### DIFF
--- a/docs/getting-started/develop/application/access-applications.md
+++ b/docs/getting-started/develop/application/access-applications.md
@@ -45,7 +45,7 @@ ss -tlnp
 
 ## Container-to-Container Communication with pv-xconnect
 
-When containers need to communicate with each other without sharing a network namespace, use the **pv-xconnect** service mesh. It injects sockets or device nodes directly into a consumer container's namespace.
+When containers need to communicate with each other without sharing a network namespace, use **pv-xconnect**. Despite sometimes being called a service mesh, it isn't a sidecar/proxy mesh like Istio or Linkerd — there's no traffic interception or L7 routing. It injects sockets or device nodes directly into a consumer container's namespace, closer to a bind-mount than a network hop.
 
 The provider declares what it exports in `services.json`:
 
@@ -97,6 +97,26 @@ pvr clone http://<device-ip>:12368/cgi-bin device && cd device
 pvr app add tailscale --from tailscale/tailscale --platform linux/arm64
 pvr add . && pvr commit -m "add Tailscale"
 pvr post http://<device-ip>:12368
+```
+
+`--platform` picks the image variant for your device's CPU architecture (see
+[choosing a platform](install/local-pvr.md#2--add-the-new-container) for
+ARM64 vs ARM32 examples); omit it and `pvr` will try to infer it from the
+target.
+
+## Authenticating Against a Private Registry
+
+`pvr app add`/`pvr app update` resolve registry credentials the same way
+`docker pull` does: with no flags, they fall back to your local Docker
+credential store (`~/.docker/config.json`, including credential helpers) via
+the standard OCI default keychain. To pass credentials explicitly instead —
+useful in CI, where there's no local Docker login — use `--username`/
+`--password`, or the `PVR_REGISTRY_USERNAME`/`PVR_REGISTRY_PASSWORD`
+environment variables:
+
+```bash
+pvr app add api --from registry.example.com/team/api:v2.1 \
+  --username "$PVR_REGISTRY_USERNAME" --password "$PVR_REGISTRY_PASSWORD"
 ```
 
 ## Troubleshooting

--- a/docs/getting-started/develop/application/configure.md
+++ b/docs/getting-started/develop/application/configure.md
@@ -23,7 +23,7 @@ After cloning, the directory mirrors the device's revision:
 
 ```
 my-device/
-├── bsp/                        ← BSP component (squashfs files, DTBs)
+├── bsp/                        ← [BSP](../../../overview/glossary.md#bsp-board-support-package) component (squashfs files, Device Tree Blobs)
 ├── network/                    ← network container (root.squashfs, run.json, lxc.container.conf)
 ├── sensor-app/                 ← application container
 ├── _config/                    ← per-container file overlays
@@ -74,7 +74,10 @@ To update the container rootfs itself, use `pvr app update`:
 pvr app update sensor-app --from registry.example.com/sensor-app:v1.2.0
 ```
 
-This re-pulls the image and replaces `sensor-app/root.squashfs`.
+This re-pulls the image and replaces `sensor-app/root.squashfs`. Add `--platform
+<arch>` (e.g. `linux/arm64`) if the registry serves a multi-platform image and
+`pvr` can't infer your device's architecture — see [choosing a
+platform](install/local-pvr.md#2--add-the-new-container).
 
 ---
 
@@ -112,13 +115,16 @@ pvr commit -m "add SSH key and configure auto-recovery for sensor-app"
 
 ## Step 4 — Deploy to the Device
 
-Post the new revision to the device's pvr endpoint — the same URL you cloned from:
+Post the new revision to the device's pvr endpoint — the same URL you cloned
+from. This uses `pvr post`, not the separate `pvr deploy` command (which only
+assembles a local directory and never touches a device — see
+[`pvr deploy`](../cli-tools/pvr-cli.md#assemble-a-deploy-directory-with-pvr-deploy)):
 
 ```bash
 pvr post http://<device-ip>:12368
 ```
 
-Pantavisor downloads the changed objects, writes them to a pending revision, and restarts the affected containers (a full reboot only happens when a `system` restart-policy container or the BSP changed). If the new revision starts cleanly and all containers reach their status goal, it is committed as the new permanent state. If it fails, the previous revision is restored automatically.
+Pantavisor downloads the changed objects, writes them to a pending revision, and restarts the affected containers (a full reboot only happens when a [`system` restart-policy](../../../overview/glossary.md#restart-policy) container or the BSP changed). If the new revision starts cleanly and all containers reach their [status goal](../../../overview/glossary.md#status-goal), it is committed as the new permanent state. If it fails, the previous revision is restored automatically.
 
 ---
 

--- a/docs/getting-started/develop/application/install/local-pvr.md
+++ b/docs/getting-started/develop/application/install/local-pvr.md
@@ -23,15 +23,24 @@ The checkout mirrors the live device state — all containers, their rootfs imag
 
 ## 2 — Add the New Container
 
-Use `pvr app add` to pull a Docker Hub image and convert it to a Pantavisor container. Specify `--platform` to match your device architecture.
+Use `pvr app add` to pull an image and convert it to a Pantavisor container.
+`--from` isn't limited to Docker Hub — point it at any registry host.
+Specify `--platform` to match your device architecture.
 
 ```bash
-# ARM64 device (e.g. Raspberry Pi 4, iMX8)
+# Docker Hub, ARM64 device (e.g. Raspberry Pi 4, iMX8)
 pvr app add tailscale --from tailscale/tailscale --platform linux/arm64
 
-# ARM32 device (e.g. iMX6)
+# Docker Hub, ARM32 device (e.g. iMX6)
 pvr app add tailscale --from tailscale/tailscale --platform linux/arm/v7
+
+# A private/self-hosted registry
+pvr app add api --from registry.example.com/team/api:v2.1 --platform linux/arm64
 ```
+
+Pulling from a private registry needs credentials — see [Authenticating
+Against a Private
+Registry](../access-applications.md#authenticating-against-a-private-registry).
 
 `pvr app add` pulls the image, converts it to a SquashFS rootfs, and creates the container's directory with:
 
@@ -43,6 +52,13 @@ tailscale/
 ├── run.json                    ← Pantavisor runtime manifest
 └── lxc.container.conf          ← LXC runtime configuration
 ```
+
+`pvr app add` reads the image's Docker config and compiles it directly into
+`lxc.container.conf`: `ENTRYPOINT`/`CMD` become the container's init command,
+`ENV` becomes `lxc.environment`, `WORKDIR` becomes `lxc.init.cwd`, and
+`VOLUME`s become mount entries — they carry through unchanged. `--arg
+KEY=VALUE` template arguments are separate: they're for values `pvr`'s own
+templates read, not overrides of the image's config.
 
 ## 3 — Stage and Commit
 

--- a/docs/getting-started/develop/application/install/local-pvr.md
+++ b/docs/getting-started/develop/application/install/local-pvr.md
@@ -39,7 +39,7 @@ pvr app add tailscale --from tailscale/tailscale --platform linux/arm/v7
 tailscale/
 ├── root.squashfs               ← container filesystem
 ├── root.squashfs.docker-digest ← image digest for update tracking
-├── src.json                    ← image source and template arguments
+├── src.json                    ← image source (`docker_config`/`docker_digest`, used to detect upstream updates) plus any `--arg KEY=VALUE` template arguments passed to this command
 ├── run.json                    ← Pantavisor runtime manifest
 └── lxc.container.conf          ← LXC runtime configuration
 ```
@@ -81,7 +81,9 @@ Pantavisor downloads the new container objects, writes them as a pending revisio
 
 ## 5 — Verify
 
-After the transition, confirm the container is running:
+After the transition, confirm the container is running — from the [device
+console](../../../operate/device-access/serial-port.md) (serial, or SSH if
+you've set that up) or remotely via `pvcontrol`:
 
 ```bash
 # From the device console (serial or SSH)

--- a/docs/getting-started/develop/application/remove.md
+++ b/docs/getting-started/develop/application/remove.md
@@ -4,7 +4,7 @@ sidebar_position: 44
 description: Remove an application from a Pantavisor device — delete the container from your pvr checkout, commit, and deploy a new revision. Pantavisor stops and discards it on the next boot.
 ---
 
-Removing an application follows the same revision workflow as adding one: remove the container from your local `pvr` checkout, commit, and deploy. Pantavisor stops the container and removes it from the trail on the next boot.
+Removing an application follows the same revision workflow as adding one: remove the container from your local `pvr` checkout, commit, and deploy. Pantavisor stops the container and removes it from the [trail](../../../overview/glossary.md#trail) on the next boot.
 
 ---
 

--- a/docs/getting-started/develop/index.md
+++ b/docs/getting-started/develop/index.md
@@ -6,15 +6,17 @@ sidebar_position: 4
 
 # Develop applications
 
-Apps are versioned and updated independently of the base. A CVE fix in your app
-ships as a small container layer — not a full-image flash — and never touches
-the certified base. See the [benchmarks](/meta-pantavisor/getting-started/benchmarks) for the size and time
+Apps are versioned and updated independently of the [base](../security/trust-model.md)
+— the frozen, certified BSP + Pantavisor runtime layer described in the trust
+model. A CVE fix in your app ships as a small container layer — not a
+full-image flash — and never touches the certified base. See the
+[benchmarks](/meta-pantavisor/getting-started/benchmarks) for the size and time
 difference.
 
 ## Manage applications
 
-- [Install apps](./application/install/index.md) — add containers with the `pvr` CLI, the pvtx web UI, or remotely via Pantahub
-- [Configure](./application/configure.md) — overlay files and runtime manifests through the revision workflow
+- [Install apps](./application/install/index.md) — add [containers](../../overview/glossary.md#container) with the `pvr` CLI, the pvtx web UI, or remotely via [Pantahub](./application/install/remote-pantahub.md)
+- [Configure](./application/configure.md) — overlay files and runtime manifests through the [revision](../../overview/glossary.md#revision) workflow
 - [View](./application/view.md) — container status, logs, and the pvtx web UI
 - [Access](./application/access-applications.md) — enter containers, reach their ports, and wire services with pv-xconnect
 - [Remove](./application/remove.md) — drop a container from the device state and deploy

--- a/docs/getting-started/develop/index.md
+++ b/docs/getting-started/develop/index.md
@@ -25,6 +25,6 @@ difference.
 
 - [CLI tools](./cli-tools/index.md) — `pvr`, `pvtx`, and `pvcontrol` cheatsheets and workflows
 - [Container development](../../overview/container-development.md) — build example containers in the meta-pantavisor Yocto layer
-- [Pantavisor runtime development](../../overview/pantavisor-development.md) — hack on the Pantavisor runtime itself with the kas workspace
+- [Pantavisor runtime development](../../overview/pantavisor-development.md) — hack on the Pantavisor runtime itself using [`kas`](https://github.com/siemens/kas), the Yocto workspace/build tool this layer's KAS configs are written for
 
-For exhaustive, generated CLI documentation, see the [Reference](/pantavisor/overview).
+For the state, revision, and BSP data model this CLI operates on, see the [Reference](/pantavisor/overview).

--- a/docs/getting-started/operate/device-access/serial-port.md
+++ b/docs/getting-started/operate/device-access/serial-port.md
@@ -4,11 +4,14 @@ sidebar_position: 2
 description: Access a Pantavisor device over the serial console — open the debug shell, list and enter containers, query device status, and read logs without any network.
 ---
 
-The serial console is the most direct access path to a Pantavisor device — it works without any network configuration and shows the full boot sequence from bootloader to Pantavisor startup.
+The serial console is the most direct access path to a Pantavisor device — it works without any network configuration and shows the full boot sequence from the board's bootloader (U-Boot on most supported boards) through to Pantavisor startup.
 
 ## Hardware Setup
 
-Connect a USB-to-TTY adapter to the device's TX/RX/GND serial pins. Open a terminal emulator on your computer:
+Connect a USB-to-TTY adapter to the device's TX/RX/GND serial pins — match the
+adapter's logic-level voltage to the board (3.3V on the Raspberry Pi and most
+SoC dev boards; a 5V-only adapter can damage the UART pins). Open a terminal
+emulator on your computer:
 
 ```bash
 # Linux — adjust device node as needed (ttyUSB0, ttyUSB1, ttyACM0, …)

--- a/docs/getting-started/start/index.md
+++ b/docs/getting-started/start/index.md
@@ -14,8 +14,11 @@ boot it, and ship your first update.
 - **[Download and flash on a Raspberry Pi](./download-and-flash.md)** — flash a
   pre-built starter image and boot real hardware in about 30 minutes.
 - **No hardware?** [Run Pantavisor in Docker (AppEngine)](/meta-pantavisor/getting-started/how-to-install/docker) on
-  your workstation.
-- **Install `pvr`** — the client used to inspect and change device state. See
+  your workstation — see the [glossary](../../overview/glossary.md#appengine)
+  for what "AppEngine" means here (not a PaaS).
+- **Install `pvr`** — the client used to inspect and change device state. Every
+  change is an explicit, one-shot `pvr post` — there's no background agent
+  continuously reconciling drift the way a Kubernetes controller would. See
   the [`pvr` installation guide](/meta-pantavisor/getting-started/develop/cli-tools/pvr-cli#installation).
 
 ## Prerequisites

--- a/docs/getting-started/start/index.md
+++ b/docs/getting-started/start/index.md
@@ -26,7 +26,9 @@ boot it, and ship your first update.
 - A Raspberry Pi 3B/3B+/4 with a microSD card (8 GB or more), or Docker for the
   no-hardware path.
 - A laptop or desktop to download and flash the image.
-- Optional but recommended: a USB-to-TTL serial adapter for console access.
+- Optional but recommended: a USB-to-TTL serial adapter for console access —
+  check its logic-level voltage matches the board (see [Serial
+  Console](/meta-pantavisor/getting-started/operate/device-access/serial-port)).
 
 ## Next steps
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -14,6 +14,12 @@ pvrexport bundles.
 This section covers the project structure, build system architecture, and how
 the layer is organized. Start here, then follow the build guide below.
 
+**Just want to deploy your own container onto an existing device?** Skip the
+build guide — grab a ready-made image via [Starter Image](images.md) /
+[Flashing Images](flashing-images.md) and go straight to [Develop
+applications](../getting-started/develop/index.md). The build guide below is
+for building your own custom image from source.
+
 ## Topics
 
 1. [Layer Layout](meta-pantavisor.md) — directory structure, key recipes, BitBake classes, `PANTAVISOR_FEATURES`, and Yocto compatibility

--- a/docs/overview/meta-pantavisor.md
+++ b/docs/overview/meta-pantavisor.md
@@ -55,7 +55,7 @@ Controls which optional Pantavisor components are compiled in and installed. Def
 | `dm-crypt` | Storage encryption |
 | `dm-verity` | Container rootfs integrity verification |
 | `autogrow` | Automatic partition growing |
-| `runc` | OCI runtime support |
+| `runc` | OCI runtime support (a Pantavisor runtime build option — see the [pantavisor](https://github.com/pantavisor/pantavisor) project for details). Containers created via `pvr app add` are LXC-based regardless of this flag, as described throughout this layer's [develop](/meta-pantavisor/getting-started/develop) guides |
 | `tailscale` | Tailscale VPN integration |
 | `debug` | Debug features |
 | `pvcontrol` | pv-ctrl socket and CLI tools (pvcurl, pvcontrol) |


### PR DESCRIPTION
## Origin

Draft fix for findings across all three docs-eval reports for persona 03
(cloud-native developer, no embedded background), run 2026-08-04:

- [`answers/03-cloud-native-no-embedded/2026-08-04-promptA-claude-sonnet-5-development.md`](https://github.com/pantacor/docs-framework/blob/master/answers/03-cloud-native-no-embedded/2026-08-04-promptA-claude-sonnet-5-development.md) — cold-start install task
- [`.../2026-08-04-promptB-...md`](https://github.com/pantacor/docs-framework/blob/master/answers/03-cloud-native-no-embedded/2026-08-04-promptB-claude-sonnet-5-development.md) — targeted cross-repo task
- [`.../2026-08-04-promptC-...md`](https://github.com/pantacor/docs-framework/blob/master/answers/03-cloud-native-no-embedded/2026-08-04-promptC-claude-sonnet-5-development.md) — jargon audit (13 terms)

## Worst finding (prompt A, S1)

*"Nothing on any page I reached says how the pull authenticates — I'm assuming
it reuses my local Docker credentials purely because that's how `docker pull`
works, not because the docs said so."* Evidence: the only full `pvr app add`
example anywhere in the path uses a public image, no credential step shown.

Rather than guessing, I read `pvr`'s own source
(`gitlab.com/pantacor/pvr`, `libpvr/dockerlib.go` + `cmd/app/appadd.go`) to
confirm the real mechanism: falls back to the local Docker credential
keychain (`~/.docker/config.json`), or accepts `--username`/`--password` /
`PVR_REGISTRY_USERNAME`/`PVR_REGISTRY_PASSWORD`. Documented in
`access-applications.md`.

## What changed, by file

- **`develop/application/access-applications.md`** — new "Authenticating
  Against a Private Registry" section; `--platform` cross-link; contrasts
  `pv-xconnect` against proxy-style service meshes (Istio/Linkerd) it gets
  compared to by name, since it's actually socket/device-node injection.
- **`develop/application/configure.md`** — links BSP / status goal /
  restart-policy to the glossary; disambiguates "Deploy to the Device" from
  the separate `pvr deploy` command; `--platform` note on `pvr app update`.
- **`develop/application/remove.md`** — links "trail" to the glossary on
  first use.
- **`develop/application/install/local-pvr.md`** — clarifies what `src.json`
  actually records; links "device console" to the serial-port guide.
- **`develop/index.md`** — links "base"/"certified base" to the trust model,
  and "container"/"revision"/"Pantahub" to their existing definitions.
- **`start/index.md`** — links "AppEngine" to the glossary; notes that
  `pvr post` is an explicit one-shot push, not continuous reconciliation
  (the Kubernetes-controller assumption this persona is defined to bring).
- **`overview/index.md`** — branches readers who just want to flash + deploy
  away from the from-source build guide.
- **`overview/meta-pantavisor.md`** — clarifies `runc` doesn't change
  `pvr app add`'s LXC-based container model.

## Findings re-verified as already fixed (no change made)

- Prompt A: the "Install apps" bullet on `develop/index.md` was already
  linked — report evidence didn't match current source.
- Prompt B: the board-guides "SD Card" link already points at `sdcard.md`,
  not the 404ing `/start/download-and-flash` the report cited.

Both are likely a stale render at evaluation time rather than a real gap.

## Findings intentionally not fixed here

- Prompt C's `docs.pantahub.com` "PVR CLI Reference" link — `outside-docs`,
  off the three repos this pack routes fixes to. Flagged for human triage.
- Prompt C's "image" (disk sense) jargon row — the report itself says this
  resolves within the same sentence; no page actually needs an edit.

## Status

**This is a draft for human review** — opened from an automated docs-eval fix
pass. The registry-auth content was verified against `pvr`'s source, but
please double-check phrasing/placement, especially the `runc` clarification,
before merging.