### PR TITLE
docs(migrate): disambiguate commit, link jargon to glossary, add power-cut/boot-attempt detail

### DIFF
--- a/docs/getting-started/benchmarks/vs-mender.md
+++ b/docs/getting-started/benchmarks/vs-mender.md
@@ -48,7 +48,7 @@ device including the base).
   containers in one signed revision.
 - **Per-container health gating.** Mender also commits only after a successful
   boot, and state scripts can add custom checks. Pantavisor's edge is
-  granularity: each container declares a `status_goal`, and the commit is held
+  granularity: each container declares a [`status_goal`](/meta-pantavisor/overview/glossary#status-goal), and the commit is held
   until every container reaches it — per-component health gating with no
   scripting.
 

--- a/docs/getting-started/migrate/mender.md
+++ b/docs/getting-started/migrate/mender.md
@@ -21,13 +21,21 @@ and no separate updater running on top of the OS.
 | Mender | Pantavisor | Notes |
 |---|---|---|
 | `meta-mender` Yocto layer | [`meta-pantavisor`](/meta-pantavisor/overview/get-started) | Swap the layer; Pantavisor builds the BSP, kernel, and containers. |
-| A/B rootfs slots | [Revisions in the trail](/pantavisor/overview/revisions) | Rollback is to the previous revision, not a mirrored partition — no doubled storage for the full rootfs. |
-| Mender Artifact (`.mender`) | A `pvr` revision (`pvr commit` + `pvr post`) | The unit of update is a signed, diffable revision. |
-| `mender-binary-delta` (commercial delta) | Object-level diffs (built in) | Only changed content-addressed objects are transferred — no separate delta add-on. |
+| A/B rootfs slots | [Revisions](/pantavisor/overview/revisions) in the [trail](/meta-pantavisor/overview/glossary#trail) | Rollback is to the previous revision, not a mirrored partition — no doubled storage for the full rootfs. |
+| Mender Artifact (`.mender`) | A [`pvr`](/meta-pantavisor/getting-started/develop/cli-tools/pvr-cli) revision (`pvr commit` + `pvr post`) | The unit of update is a signed, diffable revision. |
+| `mender-binary-delta` (commercial delta) | Object-level diffs (built in) | Only changed content-addressed [objects](/meta-pantavisor/overview/glossary#object) are transferred — no separate delta add-on. |
 | Update Modules (partial/app updates) | [Containers](/meta-pantavisor/getting-started/develop) | Every component is already an independent container; app updates never touch the base. |
 | Mender client (a service on the OS) | Pantavisor **is** PID 1 | No agent layered on top — the runtime and the updater are the same process. |
 | Mender server / Hosted Mender | [Pantahub](/meta-pantavisor/getting-started/operate/device-access/remote-pantahub) (optional) | Or deploy directly over the local network with `pvr`; the cloud is not required. |
-| Commit after successful boot (+ state scripts) | [Health-gated commit + bootloader try/rollback](/meta-pantavisor/getting-started/security/atomicity-and-trust) | Both gate the commit on a healthy boot; Pantavisor gates per container on its `status_goal`, with no scripts to write. |
+| Commit after successful boot (+ state scripts) | [Health-gated commit + bootloader try/rollback](/meta-pantavisor/getting-started/security/atomicity-and-trust) | Both gate the commit on a healthy boot; Pantavisor gates per container on its [`status_goal`](/meta-pantavisor/overview/glossary#status-goal), with no scripts to write. |
+
+**A note on "commit":** the table above uses it for two different things.
+`pvr commit` is a CLI action on your workstation that seals a revision
+*before* it's ever sent to a device — closer to `git commit`. The runtime's
+health-gated commit is a separate, later, device-side event: the bootloader
+marking a revision that has already booted and passed its health checks as
+the new known-good state. They're both gates on a healthy boot, but they
+happen in different places at different times.
 
 ## Migration path
 

--- a/docs/getting-started/security/atomicity-and-trust.md
+++ b/docs/getting-started/security/atomicity-and-trust.md
@@ -29,14 +29,41 @@ before it is marked good, otherwise the bootloader reverts.
 
 ## Mechanism
 
-- **Bootloader-enforced try/rollback** (U-Boot `bootcount` + a trial/known-good
-  revision pair, or `grub-editenv` one-shot).
+- **Bootloader-enforced try/rollback**: a one-shot trial boot of the new
+  revision (`pv_try`/`pv_trying` markers, or `grub-editenv` one-shot on GRUB
+  machines) — not a multi-attempt bootcount. The first failure or power cut
+  during the trial falls back to the last committed revision on the next
+  boot. See [Boot Flow](/meta-pantavisor/overview/boot-flow) for the exact
+  sequence.
 - **Health-gated commit** on per-container readiness probes with a global
   timeout → auto-rollback.
 - **Crash-consistent object store**: objects are written and `fsync`'d before
   the manifest is written and atomically renamed; a manifest is never referenced
   before its objects are durable.
 - **Hardware watchdog** as the backstop, fed by PID 1 (Pantavisor).
+
+## What's on the device if power is cut, by stage
+
+Derived from the mechanism above and [Boot Flow](/meta-pantavisor/overview/boot-flow)
+— this is a logical walkthrough of the documented mechanism, not a substitute
+for the empirical test results below, which cover the same ground by
+actually cutting power.
+
+| Stage | State after a cut here |
+|---|---|
+| Mid-download | The new revision's objects aren't all `fsync`'d yet, so its manifest is never written or referenced. The device boots the last committed revision next power-up; there's nothing to roll back. |
+| Mid-write of an object | Same as above — an unfsync'd, unreferenced object is simply orphaned and re-fetched on retry. |
+| After write, before reboot | All objects are durable and the new revision's manifest is atomically renamed in, but `pv_try` isn't set yet — the device still boots the previously committed revision. |
+| Mid-reboot into the trial revision | If `pv_try` was already recorded as attempted before the cut, the next boot falls back to the committed revision. If the record itself didn't persist (this write is skipped on UBI/NAND — see Boot Flow), the device retries the same trial once more. |
+| After boot, before the health check commits | `pv_try`/`pv_trying` is already recorded as attempted, so the next boot falls back to the last committed revision automatically — no operator action needed. The hardware watchdog covers the case where the device hangs instead of losing power outright. |
+
+## Boot-attempt limit
+
+The bootloader-side mechanism above is a single trial attempt, not a
+configurable "boot N times before giving up" counter.
+[`PV_REVISION_RETRIES`](/pantavisor/reference/pantavisor-configuration)
+(default `10`) is a separate, Pantavisor-side setting for revision-transition
+retries — not a boot-attempt count.
 
 > **📝 Note**
 >

--- a/docs/getting-started/troubleshooting/faq.md
+++ b/docs/getting-started/troubleshooting/faq.md
@@ -129,5 +129,5 @@ PANTAVISOR_FEATURES:append = " appengine"
 ## Getting Help
 
 - [Pantavisor Community Forum](https://community.pantavisor.io)
-- [Official pvr Reference](https://docs.pantahub.com/pvr/)
+- [pvr CLI Reference](/meta-pantavisor/getting-started/develop/cli-tools/pvr-cli)
 - [Pantahub Documentation](https://docs.pantahub.com/)


### PR DESCRIPTION
## Origin

Draft fix for findings across all three docs-eval reports for persona 05
(OTA/fleet engineer migrating off Mender or RAUC), run 2026-08-04:

- [`answers/05-ota-migrator/2026-08-04-promptA-claude-sonnet-5-development.md`](https://github.com/pantavisor/docs-framework/blob/master/answers/05-ota-migrator/2026-08-04-promptA-claude-sonnet-5-development.md)
- [`.../2026-08-04-promptB-...md`](https://github.com/pantavisor/docs-framework/blob/master/answers/05-ota-migrator/2026-08-04-promptB-claude-sonnet-5-development.md)
- [`.../2026-08-04-promptC-...md`](https://github.com/pantavisor/docs-framework/blob/master/answers/05-ota-migrator/2026-08-04-promptC-claude-sonnet-5-development.md)

## Worst finding (prompt C)

`migrate/mender.md`'s concept-mapping table uses **"commit" for two
different things**: `pvr commit` (a CLI action, run on a workstation before
an update ever reaches a device) and the runtime's health-gated commit (the
bootloader marking a *booted* trial revision as good). The table's own text
— "Both gate the commit on a healthy boot" — reads as if they're the same
action. Getting this confused means trusting the wrong step to gate on boot
health. Added an explicit disambiguation note under the table.

## What changed, by file

- **`migrate/mender.md`, `benchmarks/vs-mender.md`** — link `trail`,
  `object`, and `status_goal` to their existing glossary definitions, and
  `pvr` to the CLI reference — all used on these pages as though already
  known.
- **`security/atomicity-and-trust.md`** — two related findings, flagged
  independently by prompts A and B:
  - "Bootloader-enforced try/rollback (U-Boot `bootcount`...)" implied a
    configurable multi-attempt counter. Verified against
    `docs/overview/boot-flow.md`'s actual `pv_try`/`pv_trying` logic — it's
    a **single trial boot**, not a bootcount. Corrected the wording and
    added a "Boot-attempt limit" section distinguishing it from the
    unrelated `PV_REVISION_RETRIES` setting (verified in the `pantavisor`
    repo's own config reference) a reader could otherwise conflate with it.
  - The page asserted power-fail safety in one sentence with no
    stage-by-stage detail. Added a table for the five power-cut moments an
    OTA engineer would actually check — derived from the already-documented
    object-store + boot-flow mechanism, explicitly framed as a logical
    walkthrough, **not** a substitute for the page's own still-unpublished
    empirical test results.
- **`troubleshooting/faq.md`** — "Official pvr Reference" pointed
  off-domain to `docs.pantahub.com/pvr/` even though this repo already has
  its own `pvr-cli` reference page, linked elsewhere on the same page —
  repointed it locally.

## Not fixed — these ask for resources that don't exist yet, not for existing content to be surfaced

- **Fleet-scale canary/staged rollout**: the docs already say outright
  these guides are "coming soon." Honest gap, not a documentation defect —
  there's no capability to document yet.
- **Published power-cut test logs/rig**: still "to be published" per the
  page's own note. The new stage-by-stage table narrows this a lot but
  doesn't replace real measured evidence.
- **Real KB/MB benchmark numbers** (app-only vs. kernel-changing revision):
  requires actual measurement, not something to fabricate.
- **Three-way overload of "state"** (state-JSON manifest / update-lifecycle
  state / container status state) spans multiple pages across both
  `meta-pantavisor` and `pantavisor` — flagged for human triage rather than
  a piecemeal per-page fix.

## Status

**This is a draft for human review** — opened from an automated docs-eval
fix pass. The boot-attempt/power-cut technical detail was verified against
this repo's own `boot-flow.md` and the `pantavisor` repo's config
reference, but please double-check the stage-by-stage table's framing
before merging — it's a derivation from documented mechanism, not new
empirical evidence.