### PR TITLE
docs(overview): add Yocto/Buildroot build-vocab glossary entries, fix jargon gaps and a rendering bug

### DIFF
--- a/docs/getting-started/benchmarks/vs-buildroot.md
+++ b/docs/getting-started/benchmarks/vs-buildroot.md
@@ -85,7 +85,7 @@ fleet backend).
 ## Combining Buildroot and Pantavisor
 
 Pantavisor's official Yocto layer is `meta-pantavisor`. Buildroot doesn't have an
-equivalent upstream layer, but Pantavisor is a small static binary plus an LXC
+equivalent upstream layer, but Pantavisor is a small static binary plus an [LXC](/meta-pantavisor/overview/glossary#lxc)
 fork — it can be cross-compiled with Buildroot's toolchain and packaged as the
 init for a Buildroot-built rootfs. In practice, most production users go via
 Yocto + meta-pantavisor because the integration work is already done.

--- a/docs/getting-started/develop/application/configure.md
+++ b/docs/getting-started/develop/application/configure.md
@@ -76,8 +76,7 @@ pvr app update sensor-app --from registry.example.com/sensor-app:v1.2.0
 
 This re-pulls the image and replaces `sensor-app/root.squashfs`. Add `--platform
 <arch>` (e.g. `linux/arm64`) if the registry serves a multi-platform image and
-`pvr` can't infer your device's architecture — see [choosing a
-platform](install/local-pvr.md#2--add-the-new-container).
+`pvr` can't infer your device's architecture — see [choosing a platform](install/local-pvr.md#2--add-the-new-container).
 
 ---
 

--- a/docs/getting-started/develop/application/install/local-pvr.md
+++ b/docs/getting-started/develop/application/install/local-pvr.md
@@ -38,9 +38,7 @@ pvr app add tailscale --from tailscale/tailscale --platform linux/arm/v7
 pvr app add api --from registry.example.com/team/api:v2.1 --platform linux/arm64
 ```
 
-Pulling from a private registry needs credentials — see [Authenticating
-Against a Private
-Registry](../access-applications.md#authenticating-against-a-private-registry).
+Pulling from a private registry needs credentials — see [Authenticating Against a Private Registry](../access-applications.md#authenticating-against-a-private-registry).
 
 `pvr app add` pulls the image, converts it to a SquashFS rootfs, and creates the container's directory with:
 
@@ -97,8 +95,7 @@ Pantavisor downloads the new container objects, writes them as a pending revisio
 
 ## 5 — Verify
 
-After the transition, confirm the container is running — from the [device
-console](../../../operate/device-access/serial-port.md) (serial, or SSH if
+After the transition, confirm the container is running — from the [device console](../../../operate/device-access/serial-port.md) (serial, or SSH if
 you've set that up) or remotely via `pvcontrol`:
 
 ```bash

--- a/docs/getting-started/how-to-install/docker.md
+++ b/docs/getting-started/how-to-install/docker.md
@@ -12,10 +12,11 @@ reflashing device storage.
 > engine prototyping, development, and testing rather than production
 > deployments.
 
-For full requirements and installation options see:
-**[docs.pantahub.com/requirements-appengine](https://docs.pantahub.com/requirements-appengine/)**
-
-To build the tarball yourself, see [get-started.md](../../overview/get-started.md) — build target `pantavisor-appengine-distro`.
+There's no pre-built AppEngine tarball to download — build one yourself via
+[Get Started](../../overview/get-started.md) (this repo's Yocto/BitBake
+toolchain, build target `pantavisor-appengine-distro`), then continue below.
+For additional background beyond this page, see
+[docs.pantahub.com/requirements-appengine](https://docs.pantahub.com/requirements-appengine/).
 
 ## First-time system setup
 

--- a/docs/getting-started/start/index.md
+++ b/docs/getting-started/start/index.md
@@ -27,8 +27,7 @@ boot it, and ship your first update.
   no-hardware path.
 - A laptop or desktop to download and flash the image.
 - Optional but recommended: a USB-to-TTL serial adapter for console access —
-  check its logic-level voltage matches the board (see [Serial
-  Console](/meta-pantavisor/getting-started/operate/device-access/serial-port)).
+  check its logic-level voltage matches the board (see [Serial Console](/meta-pantavisor/getting-started/operate/device-access/serial-port)).
 
 ## Next steps
 

--- a/docs/overview/get-started.md
+++ b/docs/overview/get-started.md
@@ -3,6 +3,8 @@ sidebar_position: 4
 ---
 # Get Started
 
+Building your own image runs through this layer's Yocto/BitBake tooling (`kas`, `bitbake`, recipes, layers — see the [glossary](/meta-pantavisor/overview/glossary) if any of that's unfamiliar). Coming from a different build system? [Pantavisor vs Buildroot](/meta-pantavisor/getting-started/benchmarks/vs-buildroot) covers what changes and what doesn't before you commit to this path.
+
 ## Prerequisites
 
 - Docker installed and running

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -22,6 +22,12 @@ according to its `auto_recovery` settings (retries, delay, backoff); if a new
 revision never reaches its status goals, the device rolls back to the last
 good revision. See [what is Pantavisor](../../pantavisor/overview/index.md).
 
+### BitBake
+
+The lower-level build engine that `kas` wraps — executes recipes (`.bb`
+files) to fetch, compile, and package components. Roughly analogous to
+`make` sitting under a higher-level orchestrator.
+
 ### BSP (board support package)
 
 The hardware part of a revision — kernel, device trees, firmware, and kernel
@@ -54,17 +60,58 @@ Named startup groups that order container boot (and carry roles such as
 management). Defined in the state's `groups.json`; inspect them with
 `pvcontrol groups ls`.
 
+### kas
+
+The YAML-based build-configuration and orchestration tool this layer's
+`kas/` fragments are written for. Wraps BitBake so a multi-layer build is
+one `kas-container build <config>` command instead of manually sourcing
+environment scripts. See [github.com/siemens/kas](https://github.com/siemens/kas).
+
+### Layer
+
+A self-contained, composable directory of BitBake recipes, classes, and
+configuration — `meta-pantavisor` is itself one. Layers combine and
+override each other via `bblayers.conf`/KAS config, not automatic merging;
+a higher-priority layer's recipe wins.
+
+### LXC
+
+Linux Containers — the upstream OS-level container project
+([linuxcontainers.org](https://linuxcontainers.org/lxc/introduction/)) that
+Pantavisor's own containers run under, via a Pantavisor-specific fork
+(`lxc-pv`). Not a Pantavisor invention. See [Container](#container).
+
+### Machine
+
+The Yocto/BitBake target-hardware identifier (the `MACHINE` variable), set
+per board via this layer's `kas/machines/<machine>.yml`. Roughly the Yocto
+equivalent of choosing a Buildroot `defconfig`.
+
 ### Object
 
 A content-addressed file blob, named by its SHA-256 hash. Revisions reference
 objects rather than containing them, so unchanged files are stored and
 transferred exactly once.
 
+### OpenEmbedded
+
+The build-system core (metadata format, class mechanism, package tooling)
+that the Yocto Project packages and supports. These docs use "Yocto" and
+"OpenEmbedded" interchangeably — meta-pantavisor targets the combined
+stack, not a distinction readers need to track.
+
 ### Pantahub
 
 The optional cloud backend (also branded **Pantacor Hub**) at
 [hub.pantacor.com](https://hub.pantacor.com): device claiming, fleet
 management, remote updates, and log streaming. Devices work fully without it.
+
+### Pseudo
+
+The fakeroot-style tool BitBake uses during builds to track file ownership
+and permissions without real root. A "pseudo database corruption" error
+means its ownership database and the actual build output disagree —
+usually fixed by cleaning the affected recipe's `sstate`.
 
 ### pv-ctrl
 
@@ -95,6 +142,12 @@ Pantavisor's on-device update-transaction tool: begin a transaction, add
 parts, commit — atomically. It also serves the device web UI on port 12368
 (`/app`). See the [pvtx web UI](/meta-pantavisor/getting-started/operate/device-access/pvtx-ui).
 
+### Recipe
+
+A single `.bb` file describing how to fetch, build, and package one
+component — roughly a Buildroot package `.mk` equivalent. This layer's
+`recipes-pv/` directories hold one recipe per component.
+
 ### Restart policy
 
 Per-container update behavior: `system` containers require a reboot to
@@ -106,6 +159,13 @@ non-reboot transition.
 A numbered, immutable snapshot of the complete device state — BSP and all
 containers. Revision 0 is the factory state; updates create new revisions and
 the device can atomically run or roll back to any of them.
+
+### sstate (shared state cache)
+
+BitBake's per-task build-output cache (`SSTATE_DIR`), keyed by task/input
+hash — a task whose inputs haven't changed reuses its cached output instead
+of rebuilding. Distinct from `DL_DIR`, which caches fetched upstream
+sources.
 
 ### State (state JSON)
 
@@ -124,6 +184,12 @@ not committed and the device rolls back.
 
 The ordered history of a device's revisions — `trails/` on the device's
 storage, mirrored per device on Pantahub.
+
+### WIC / WKS
+
+`wic` is Yocto's disk-image partitioning tool; a `.wks` file (see this
+layer's `wic/` directory) describes the partition layout it produces —
+roughly the Yocto equivalent of a `genimage` config plus a partition table.
 
 ### xconnect
 

--- a/docs/overview/images.md
+++ b/docs/overview/images.md
@@ -33,8 +33,7 @@ paid in flash size either — squashfs container volumes run 50–70% smaller th
 equivalent plain rootfs, and the Pantavisor runtime itself is a ~1 MB PID 1 with no
 daemon overhead. What you get for that: a single Python app update becomes a 2–5
 minute container update instead of a 30–60 minute full-image rebuild-and-reflash,
-with automatic health-gated rollback if it fails. See [Reduce firmware
-size](/meta-pantavisor/getting-started/solutions/firmware-size) for the full
+with automatic health-gated rollback if it fails. See [Reduce firmware size](/meta-pantavisor/getting-started/solutions/firmware-size) for the full
 footprint breakdown and [Pantavisor vs Yocto](/meta-pantavisor/getting-started/benchmarks/vs-yocto)
 for the update-cost comparison against a monolithic image.
 
@@ -133,7 +132,7 @@ Authoring a container to add here is covered in
 | `pantavisor-bsp.bb` | BSP pvrexport (kernel + initramfs + modules + firmware); mixed into every pvroot image |
 | `pantavisor-initramfs.bb` | The Pantavisor-as-init initramfs the BSP wraps |
 | `empty-image.bb` | Empty proto rootfs used as a BSP modules/firmware source |
-| `pantavisor-appengine` | Docker-based image for local appengine testing (not a flashable device image) |
+| `pantavisor-appengine` | A Docker container image (a different sense of "image" than the flashable disk images above) for local appengine testing on a workstation — not something you flash to a device |
 | `pv-flash-bundle.bb` | Factory flash archive (UUU) wrapping this image for boards without native `.wic` flashing — see [pv-flash-bundle](pv-flash-bundle.md) |
 
 ## Related

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -15,10 +15,12 @@ This section covers the project structure, build system architecture, and how
 the layer is organized. Start here, then follow the build guide below.
 
 **Just want to deploy your own container onto an existing device?** Skip the
-build guide — grab a ready-made image via [Starter Image](images.md) /
-[Flashing Images](flashing-images.md) and go straight to [Develop
-applications](../getting-started/develop/index.md). The build guide below is
+build guide — grab a ready-made image via [Starter Image](images.md) / [Flashing Images](flashing-images.md) and go straight to [Develop applications](../getting-started/develop/index.md). The build guide below is
 for building your own custom image from source.
+
+**Coming from Buildroot, Mender, RAUC, or another build/update system?** See
+[Benchmarks](../getting-started/benchmarks) for a direct comparison before
+committing to the Yocto/BitBake build guide below.
 
 ## Topics
 


### PR DESCRIPTION
## Origin

Draft fix for findings across all three docs-eval reports for persona 02
(Buildroot engineer, no Yocto, no containers), run 2026-08-04:

- [`answers/02-buildroot-no-yocto-no-containers/2026-08-04-promptA-...md`](https://github.com/pantavisor/docs-framework/blob/master/answers/02-buildroot-no-yocto-no-containers/2026-08-04-promptA-claude-sonnet-5-development.md)
- [`.../2026-08-04-promptB-...md`](https://github.com/pantavisor/docs-framework/blob/master/answers/02-buildroot-no-yocto-no-containers/2026-08-04-promptB-claude-sonnet-5-development.md)
- [`.../2026-08-04-promptC-...md`](https://github.com/pantavisor/docs-framework/blob/master/answers/02-buildroot-no-yocto-no-containers/2026-08-04-promptC-claude-sonnet-5-development.md)

## Worst finding (prompt A)

The "first build" page (`overview/get-started.md`) never states the
toolchain is Yocto/BitBake or mentions Buildroot at all — the reader has to
infer it from two incidental "Yocto" mentions buried in git-worktree
paragraphs, then closes the tab having pieced together the answer rather
than been told it. Added a framing sentence up front plus a link to the
existing `vs-buildroot` comparison page.

## Biggest fix: the missing Yocto/BitBake glossary vocabulary

The glossary defines Pantavisor's own vocabulary well, but had **zero**
entries for the Yocto/BitBake vocabulary the whole `meta-pantavisor`
section assumes — flagged repeatedly across all three reports: `sstate`,
`layer`, `recipe`, `machine`, `kas`, `BitBake`, `OpenEmbedded`, `LXC`,
`WIC`/`WKS`, `pseudo`. Added all ten, alphabetized alongside the existing
entries, matching their terse one-paragraph style.

## Other fixes

- `benchmarks/vs-buildroot.md` — links "LXC" to its new glossary entry; the
  exact sentence answering "can I skip Yocto" leaned on the term undefined.
- `how-to-install/docker.md` — "For full requirements... see
  docs.pantahub.com" sent readers off-domain with no in-scope alternative;
  now states plainly there's no pre-built tarball and building one requires
  this repo's Yocto toolchain, keeping the external link as supplementary
  background only.
- `overview/images.md` — the appengine table row distinguished a Docker
  container image from the disk images above only by a negative
  parenthetical ("not a flashable device image"); added a positive
  explanation of what it actually is.
- `overview/index.md` — added a pointer to the benchmarks/comparison pages
  for readers evaluating from another build or update system, previously
  reachable only three hops deep from a Starter Image aside.

## Bonus: a rendering bug found while making the above edits

Five links added across three earlier PRs (#443, #445, #446) had their link
text wrapped across a line break — e.g. `[Reduce firmware\nsize]` — which
this site's markdown export does not treat as a soft break, silently
breaking the link. Rejoined all five onto single lines. (One new link added
in *this* PR made the identical mistake and was caught in the same pass.)

Two more pre-existing instances of the same pattern exist in
`getting-started/migrate/index.md` and
`how-to-install/boards/imx8mm-var-dart.md`, untouched by any finding so
far — flagging for whoever picks this up next rather than fixing here, to
keep this PR scoped to persona 02's actual findings.

## Re-verified against current source, not fixed (already correct)

- Prompt B's "go straight to Develop applications" was in fact the line-wrap
  bug above (from PR #443) — now fixed.
- Prompt A's "Install on hardware" link on `download-and-flash.md` is
  already valid, single-line markdown in source; the report's evidence
  ("seeInstall on hardware") looks like the same live-site export artifact
  seen in prior runs, not a repo defect.

## Not fixed here

Prompt B's request for a real byte-count example on the update-wire
mechanism is this repo's page, but the actual number belongs to the
runtime side — see the paired `pantavisor`-repo PR for what's fixable there
without fabricating a measurement.

## Status

**This is a draft for human review** — opened from an automated docs-eval
fix pass.