### PR TITLE
docs(cli-tools): document pvr app add's --group/--status-goal/--restart-policy/--runlevel flags

### DIFF
--- a/docs/getting-started/benchmarks/index.md
+++ b/docs/getting-started/benchmarks/index.md
@@ -12,7 +12,7 @@ efficiency claims with reproducible numbers (methodology below).
 
 ## Pantavisor vs alternatives
 
-Pantavisor offers **composable firmware through lightweight LXC containers** —
+Pantavisor offers [**composable firmware**](/meta-pantavisor/overview/composable-firmware) through lightweight LXC containers —
 including the kernel/BSP as a container — which differs from both traditional
 build systems and container platforms.
 

--- a/docs/getting-started/benchmarks/index.md
+++ b/docs/getting-started/benchmarks/index.md
@@ -40,7 +40,7 @@ For the migration *path* off an image updater or container platform, see
 ## Pantavisor vs image updaters (Mender / RAUC / SWUpdate)
 
 Image updaters update **the image**: every change is a full-image event.
-Pantavisor versions the device as content-addressed objects, so a change ships
+Pantavisor versions the device as [content-addressed](/meta-pantavisor/overview/glossary#object) objects, so a change ships
 only what actually changed.
 
 Per-tool comparisons:

--- a/docs/getting-started/develop/application/install/index.md
+++ b/docs/getting-started/develop/application/install/index.md
@@ -4,7 +4,7 @@ sidebar_position: 20
 description: Install applications on Pantavisor as LXC containers — using the pvr CLI over the local network, the pvtx web UI, or remotely via Pantahub.
 ---
 
-Every application on a Pantavisor device is an LXC container added to the device's revision trail. There are three ways to install a new container, depending on whether you want a command-line-only workflow, a local web upload, or cloud-based remote management.
+Every application on a Pantavisor device is an [LXC](/meta-pantavisor/overview/glossary#lxc) container added to the device's [revision trail](/meta-pantavisor/overview/glossary#trail). There are three ways to install a new container, depending on whether you want a command-line-only workflow, a local web upload, or cloud-based remote management.
 
 ---
 

--- a/docs/getting-started/develop/application/install/local-pvr.md
+++ b/docs/getting-started/develop/application/install/local-pvr.md
@@ -91,12 +91,12 @@ Post the new revision to the device's pvr endpoint — the same URL you cloned f
 pvr post http://<device-ip>:12368
 ```
 
-Pantavisor downloads the new container objects, writes them as a pending revision, and transitions into it — a full reboot only happens when a `system` restart-policy container or the [BSP](/meta-pantavisor/overview/glossary#bsp-board-support-package) changed (an ordinary app container add/update never touches it). If the new revision runs cleanly, it becomes the new permanent state.
+Pantavisor downloads the new container objects, writes them as a pending revision, and transitions into it — a full reboot only happens when a [`system` restart-policy](/meta-pantavisor/overview/glossary#restart-policy) container or the [BSP](/meta-pantavisor/overview/glossary#bsp-board-support-package) changed (an ordinary app container add/update never touches it). If the new revision runs cleanly, it becomes the new permanent state. If it fails, the previous revision is restored automatically.
 
 ## 5 — Verify
 
 After the transition, confirm the container is running — from the [device console](../../../operate/device-access/serial-port.md) (serial, or SSH if
-you've set that up) or remotely via `pvcontrol`:
+you've set that up) or remotely via [`pvcontrol`](../../../develop/cli-tools/pvcontrol.md):
 
 ```bash
 # From the device console (serial or SSH)

--- a/docs/getting-started/develop/application/install/local-pvr.md
+++ b/docs/getting-started/develop/application/install/local-pvr.md
@@ -12,7 +12,7 @@ The `pvr` CLI lets you add a Docker Hub image as a Pantavisor container, commit 
 
 ## 1 — Clone the Device
 
-Clone the device's current revision to your workstation. Pantavisor exposes its state over HTTP on port 12368.
+Clone the device's current revision to your workstation. Pantavisor exposes its state over HTTP on port 12368. Don't know `<device-ip>` yet? [`pvr device scan`](../../cli-tools/pvr-cli.md#local-network) finds it over mDNS.
 
 ```bash
 pvr clone http://<device-ip>:12368/cgi-bin mydevice
@@ -91,7 +91,7 @@ Post the new revision to the device's pvr endpoint — the same URL you cloned f
 pvr post http://<device-ip>:12368
 ```
 
-Pantavisor downloads the new container objects, writes them as a pending revision, and transitions into it — a full reboot only happens when a `system` restart-policy container or the BSP changed. If the new revision runs cleanly, it becomes the new permanent state.
+Pantavisor downloads the new container objects, writes them as a pending revision, and transitions into it — a full reboot only happens when a `system` restart-policy container or the [BSP](/meta-pantavisor/overview/glossary#bsp-board-support-package) changed (an ordinary app container add/update never touches it). If the new revision runs cleanly, it becomes the new permanent state.
 
 ## 5 — Verify
 

--- a/docs/getting-started/develop/cli-tools/configuration.md
+++ b/docs/getting-started/develop/cli-tools/configuration.md
@@ -9,7 +9,7 @@ the SHA256 of a binary artifact. When you `pvr clone` a device, that manifest is
 expanded into a working directory you can edit. This page covers the real
 layout; for the exhaustive field-by-field schema see the reference
 [state format](/pantavisor/reference/pantavisor-state-format-v2), and see the
-[on-device tools (pvtx, pvcontrol)](/pantavisor/reference/pantavisor-tools)
+[on-device tools (pvtx, pvcontrol)](/pantavisor/tools/pantavisor-tools)
 reference for working with revisions on the device itself.
 
 ## Repository layout

--- a/docs/getting-started/develop/cli-tools/pvr-cli.md
+++ b/docs/getting-started/develop/cli-tools/pvr-cli.md
@@ -116,7 +116,21 @@ pvr app add --from nginx:stable-alpine webserver
 # Pick the target architecture explicitly — usually needed when adding
 # images for an ARM device from an x86 workstation
 pvr app add --from nginx:stable-alpine --platform linux/arm64 webserver
+
+# Set the container's run.json fields at creation time instead of
+# hand-editing them afterward
+pvr app add --from nginx:stable-alpine --group app --status-goal STARTED webserver
 ```
+
+`pvr app add` also accepts:
+
+- `--group <name>` — startup group to install into (default: the last group
+  in `groups.json`, if one exists).
+- `--status-goal <goal>` — one of `MOUNTED`, `STARTED`, or `READY`; see
+  [Status goal](/meta-pantavisor/overview/glossary#status-goal).
+- `--restart-policy <policy>` — `system` or `container`; see [Restart policy](/meta-pantavisor/overview/glossary#restart-policy).
+- `--runlevel <level>` — **deprecated**, use `--group` instead. Old valid
+  values were `data`, `root`, `platform`, and `app`.
 
 #### List Applications
 ```bash

--- a/docs/getting-started/develop/cli-tools/pvr-cli.md
+++ b/docs/getting-started/develop/cli-tools/pvr-cli.md
@@ -339,6 +339,34 @@ pvr post http://DEVICE_IP:12368
 - Use signature management for production deployments
 - Monitor device logs after deployment
 
+## Signing a Revision
+
+```bash
+# Sign a part (container or BSP) with your own key
+pvr sig add --part sensor-app --key ./my-signing-key.pem --x5c ./my-cert-chain.pem
+
+# List signatures
+pvr sig ls
+```
+
+Key flags (`pvr sig <subcommand> --help` for the full list):
+
+- `--key` / `-k` (env `PVR_SIG_KEY`) — your private key in PEM format.
+- `--x5c` / `-x` (env `PVR_X5C_PATH`) — cert chain to include in the JWS
+  `x5c` header; `no` to omit it.
+- `--pubkey` / `-p` (env `PVR_SIG_PUBKEY`) — pubkey store used to validate
+  signatures.
+- `--cacerts` / `-c` (env `PVR_SIG_CACERTS`) — cert pool to validate against;
+  use `__system__` to use the system cert store.
+
+**If you don't pass `--key`/`--x5c`,** `pvr sig` fetches and uses
+Pantacor's own **shared, public default developer keys** (`--certs-url`,
+env `PVS_CERTS_URL`, defaults to a `pvs.defaultkeys.tar.gz` tarball on
+`gitlab.com/pantacor/pv-developer-ca`) — fine for development, but you must
+supply your own `--key`/`--x5c` to sign with a key an OEM actually controls.
+This repo doesn't document a recommended key-generation/rotation practice
+beyond that — treat it as an open question for your own PKI process.
+
 ## Official Documentation
 
 For complete command reference and advanced usage:

--- a/docs/getting-started/develop/cli-tools/pvr-cli.md
+++ b/docs/getting-started/develop/cli-tools/pvr-cli.md
@@ -147,6 +147,15 @@ pvr app update nginx-app
 pvr app update app-name --from new-image:tag
 ```
 
+`pvr app update` only stages the change locally, same as `pvr app add` — stage,
+commit, and post it like any other change:
+
+```bash
+pvr add .
+pvr commit -m "update app-name to new-image:tag"
+pvr post http://<device-ip>:12368
+```
+
 #### Remove Applications
 ```bash
 # Remove application from repository
@@ -160,6 +169,21 @@ pvr app rm app-name
 # Scan for Pantavisor devices on the local network (mDNS)
 pvr device scan
 ```
+
+Example output:
+
+```
+── Device 1 ───────────────────────────────
+	ID: 1234abcd5678ef90 (unclaimed)
+	Host: raspberrypi.local.
+	IPv4: [192.168.1.42]
+	IPv6: []
+	Port: 12368
+```
+
+The `IPv4` address is `<device-ip>` — the value `pvr clone`, `pvr post`, and
+the other commands on this page that take `http://<device-ip>:12368/...`
+expect.
 
 #### Pantacor Hub (requires `pvr login`)
 

--- a/docs/getting-started/develop/index.md
+++ b/docs/getting-started/develop/index.md
@@ -18,13 +18,13 @@ difference.
 - [Install apps](./application/install/index.md) — add [containers](../../overview/glossary.md#container) with the `pvr` CLI, the pvtx web UI, or remotely via [Pantahub](./application/install/remote-pantahub.md)
 - [Configure](./application/configure.md) — overlay files and runtime manifests through the [revision](../../overview/glossary.md#revision) workflow
 - [View](./application/view.md) — container status, logs, and the pvtx web UI
-- [Access](./application/access-applications.md) — enter containers, reach their ports, and wire services with pv-xconnect
-- [Remove](./application/remove.md) — drop a container from the device state and deploy
+- [Access](./application/access-applications.md) — enter containers, reach their ports, and wire services with [pv-xconnect](../../overview/glossary.md#xconnect)
+- [Remove](./application/remove.md) — drop a container from the [device state](../../overview/glossary.md#state-state-json) and deploy
 
 ## Tooling and deeper development
 
-- [CLI tools](./cli-tools/index.md) — `pvr`, `pvtx`, and `pvcontrol` cheatsheets and workflows
-- [Container development](../../overview/container-development.md) — build example containers in the meta-pantavisor Yocto layer
+- [CLI tools](./cli-tools/index.md) — [`pvr`](../../overview/glossary.md#pvr), [`pvtx`](../../overview/glossary.md#pvtx), and [`pvcontrol`](../../overview/glossary.md#pvcontrol) cheatsheets and workflows
+- [Container development](../../overview/container-development.md) — build example containers in the meta-pantavisor [Yocto](../../overview/glossary.md#openembedded) layer
 - [Pantavisor runtime development](../../overview/pantavisor-development.md) — hack on the Pantavisor runtime itself using [`kas`](https://github.com/siemens/kas), the Yocto workspace/build tool this layer's KAS configs are written for
 
 For the state, revision, and BSP data model this CLI operates on, see the [Reference](/pantavisor/overview).

--- a/docs/getting-started/how-to-install/docker.md
+++ b/docs/getting-started/how-to-install/docker.md
@@ -97,7 +97,7 @@ Run all tests in a category:
 
 ### Remote tests (`remote/`)
 
-Remote tests validate Pantahub connectivity — OTA updates, device claiming,
+Remote tests validate [Pantahub](/meta-pantavisor/overview/glossary#pantahub) connectivity — OTA updates, device claiming,
 and cloud logging. Pantahub credentials must be configured via environment
 variables before running these tests.
 
@@ -116,7 +116,7 @@ Run a specific test:
 ## Standalone container
 
 Besides the test harness, you can run the appengine image as a standalone
-container named `pva-test`, with a `pvtx.d` directory of `.pvrexport.tgz`
+container named `pva-test`, with a `pvtx.d` directory of [`.pvrexport.tgz`](/meta-pantavisor/overview/glossary#pvrexport)
 bundles to provision and a `storage-test` volume for persistent state:
 
 ```bash

--- a/docs/getting-started/operate/device-access/pvtx-ui.md
+++ b/docs/getting-started/operate/device-access/pvtx-ui.md
@@ -67,7 +67,7 @@ Below the stats are two tables:
 
 ## API documentation — the pvtx REST API
 
-The **API documentation** page documents the on-device **PVTX REST API** — the same actions available from the `pvtx` CLI, exposed over HTTP so you can manage the device without any cloud service — you upload pvr export packages directly to the device.
+The **API documentation** page documents the on-device **PVTX REST API** — the same actions available from the `pvtx` CLI (the on-device counterpart to `pvcontrol`, installed on the device itself — not something you run from your workstation), exposed over HTTP so you can manage the device without any cloud service — you upload pvr export packages directly to the device.
 
 ![PVTX REST API documentation in the pvtx app](./pvtx-ui-api-docs.png)
 
@@ -75,6 +75,14 @@ It walks through two workflows with runnable `curl` examples:
 
 - **Replace the whole device state** from a `pvexport` package downloaded from Pantahub.
 - **Add or remove parts** of the current running revision.
+
+> **⚠️ Warning — this is a state-changing transaction, not a read-only query**
+>
+> `begin` opens a transaction that later `add`/`commit` calls apply to the
+> device — it's not safe to run on a live device without reading the full
+> workflow on the **API documentation** page first (in the pvtx web UI
+> itself) so you know what `add`/`commit`/`cancel` steps come next and
+> what state they leave the device in if interrupted.
 
 For example, starting a fresh transaction:
 

--- a/docs/getting-started/operate/device-access/pvtx-ui.md
+++ b/docs/getting-started/operate/device-access/pvtx-ui.md
@@ -24,7 +24,7 @@ The **Home** page shows the device's current revision and lets you switch revisi
 
 Top-left status block:
 
-- **Rev** — the current revision number in the device's trail.
+- **Rev** — the current revision number in the device's [trail](/meta-pantavisor/overview/glossary#trail).
 - **Status** — `DONE` means the current revision is committed and stable. Other states (e.g. `TESTING`) appear while a revision is being evaluated.
 - **Progress** — completion percentage of the current update or boot sequence.
 - A status line such as *"Update finished, revision set as rollback point"*.

--- a/docs/getting-started/operate/device-access/serial-port.md
+++ b/docs/getting-started/operate/device-access/serial-port.md
@@ -75,6 +75,8 @@ pvcontrol steps show-progress current   # progress of the current revision
 pvcontrol buildinfo                     # Pantavisor build info dump
 ```
 
+`status` is one of `INSTALLED`, `MOUNTED`, `BLOCKED`, `STARTING`, `STARTED`, `READY`, `RECOVERING`, `STOPPING`, `STOPPED` — see [Container status](/pantavisor/overview/containers#status) for what each means; `BLOCKED` and `RECOVERING` are the ones that indicate a problem.
+
 ### View logs
 
 ```bash

--- a/docs/getting-started/security/index.md
+++ b/docs/getting-started/security/index.md
@@ -41,6 +41,9 @@ on the `pantavisor/` side, not repeated here:
   the registration/claim flow that binds a device to a Pantahub account.
 - [`pvr sig`](/meta-pantavisor/getting-started/develop/cli-tools/pvr-cli#signing-a-revision) —
   signing commands and key flags.
+- [Licensing](/meta-pantavisor/getting-started/licensing) — what's open
+  source (on-device code, MIT) vs. the commercial relationship (managed
+  Pantahub service), and that Pantahub itself is self-hostable.
 
 ## Planned coverage
 

--- a/docs/getting-started/security/index.md
+++ b/docs/getting-started/security/index.md
@@ -18,8 +18,29 @@ tested.
 - **[Atomicity and trust evidence](./atomicity-and-trust.md)** — a documented,
   reproducible power-fail and rollback test methodology (results forthcoming).
 - **[Secure OTA updates](/meta-pantavisor/getting-started/solutions/secure-ota)** — content-addressed object
-  integrity, PVS signatures over the state JSON, x5c certificate chains, and the
-  tamper-evident audit trail.
+  integrity, [PVS signatures](/pantavisor/reference/pantavisor-state-format-v2#9-security-_sigscontainerjson)
+  over the state JSON, [x5c](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.6)
+  (JOSE/JWS) certificate chains, and the tamper-evident audit trail.
+
+## Runtime reference
+
+The trust/signing model these pages describe is built on primitives defined
+on the `pantavisor/` side, not repeated here:
+
+- [Revisions](/pantavisor/overview/revisions) — what a revision actually is
+  (the unit every signature covers).
+- [Objects and storage](/pantavisor/overview/storage) — the "Integrity"
+  section has the full signing scheme: algorithms, verification points, and
+  the `disabled`/`audit`/`lenient`/`strict` severity levels. **Read this
+  before concluding signing is optional** — the state-format reference
+  marks the signature manifest "Mandatory: No" because validation strictness
+  is configurable, not because unsigned states are always accepted;
+  `lenient` (the default) still fails a revision whose signature doesn't
+  validate once present, and `strict` requires one.
+- [Claiming a device](/meta-pantavisor/getting-started/operate/device-access/remote-pantahub) —
+  the registration/claim flow that binds a device to a Pantahub account.
+- [`pvr sig`](/meta-pantavisor/getting-started/develop/cli-tools/pvr-cli#signing-a-revision) —
+  signing commands and key flags.
 
 ## Planned coverage
 

--- a/docs/getting-started/security/trust-model.md
+++ b/docs/getting-started/security/trust-model.md
@@ -6,7 +6,8 @@ description: Pantavisor's trust model — what it protects, the trust boundaries
 
 # Trust model
 
-Pantavisor owns PID 1, so it must clear a higher bar than an updater you can
+Pantavisor owns PID 1 — the kernel's first, always-running process, normally
+`init`/`systemd` — so it must clear a higher bar than an updater you can
 delete. This page describes what Pantavisor protects, the trust boundaries
 involved, and how the pieces compose into a chain from power-on to a running
 container. For the power-fail evidence behind the atomicity claims, see

--- a/docs/getting-started/security/trust-model.md
+++ b/docs/getting-started/security/trust-model.md
@@ -16,8 +16,9 @@ container. For the power-fail evidence behind the atomicity claims, see
 ## What Pantavisor protects
 
 - **Integrity of the device state** — the kernel, BSP, every container, and
-  configuration are described as content-addressed objects under one signed
-  revision. Tampering with any object changes its hash and breaks the signature.
+  configuration are described as content-addressed [objects](/pantavisor/overview/storage)
+  under one signed [revision](/pantavisor/overview/revisions). Tampering with
+  any object changes its hash and breaks the signature.
 - **Integrity at runtime** — container root filesystems are verified as they are
   mounted, not only at download time.
 - **Confidentiality of stored state** — the storage partition can be encrypted.

--- a/docs/getting-started/start/download-and-flash.md
+++ b/docs/getting-started/start/download-and-flash.md
@@ -22,6 +22,11 @@ Before you begin, make sure you have the following ready:
 
 The first step is to get the Pantavisor image for your specific device.
 
+> **Skip the manual download:** once you've installed `pvflasher` (below),
+> `pvflasher install` downloads and flashes the image for you interactively
+> — no separate download step or off-site browsing required. The manual
+> steps below are for when you want the image file on disk first.
+
 1.  Head over to our [Downloads page](https://pantavisor.io/downloads/) to see all available platforms and images.
 2.  Find the image that matches your device—in this case, select the image for the **Raspberry Pi 3B**. For the Raspberry Pi 3B/3B+/4, choose the **raspberrypi-armv8** image. Download the latest stable version.
 3.  The downloaded file will be a compressed image, typically named **`pantavisor-starter-raspberrypi-armv8.rootfs.wic.bz2`**.

--- a/docs/getting-started/start/index.md
+++ b/docs/getting-started/start/index.md
@@ -12,10 +12,14 @@ boot it, and ship your first update.
 ## Paths
 
 - **[Download and flash on a Raspberry Pi](./download-and-flash.md)** — flash a
-  pre-built starter image and boot real hardware in about 30 minutes.
+  pre-built starter image and boot real hardware in about 30 minutes. No
+  Yocto or container background needed for this path.
 - **No hardware?** [Run Pantavisor in Docker (AppEngine)](/meta-pantavisor/getting-started/how-to-install/docker) on
   your workstation — see the [glossary](../../overview/glossary.md#appengine)
-  for what "AppEngine" means here (not a PaaS).
+  for what "AppEngine" means here (not a PaaS). Note: there's no pre-built
+  AppEngine image to download, so this path still needs the Yocto/BitBake
+  toolchain to build one — it's a no-*hardware* alternative, not a
+  no-*build* one.
 - **Install `pvr`** — the client used to inspect and change [device state](../../overview/glossary.md#state-state-json). Every
   change is an explicit, one-shot `pvr post` — there's no background agent
   continuously reconciling drift the way a Kubernetes controller would. See

--- a/docs/getting-started/start/index.md
+++ b/docs/getting-started/start/index.md
@@ -16,7 +16,7 @@ boot it, and ship your first update.
 - **No hardware?** [Run Pantavisor in Docker (AppEngine)](/meta-pantavisor/getting-started/how-to-install/docker) on
   your workstation — see the [glossary](../../overview/glossary.md#appengine)
   for what "AppEngine" means here (not a PaaS).
-- **Install `pvr`** — the client used to inspect and change device state. Every
+- **Install `pvr`** — the client used to inspect and change [device state](../../overview/glossary.md#state-state-json). Every
   change is an explicit, one-shot `pvr post` — there's no background agent
   continuously reconciling drift the way a Kubernetes controller would. See
   the [`pvr` installation guide](/meta-pantavisor/getting-started/develop/cli-tools/pvr-cli#installation).
@@ -33,7 +33,7 @@ boot it, and ship your first update.
 
 - [Install your first application](/meta-pantavisor/getting-started/develop/application/install/) with `pvr`.
 - [Access your device](/meta-pantavisor/getting-started/operate/device-access) over serial, the local network,
-  or Pantahub.
+  or [Pantahub](../../overview/glossary.md#pantahub).
 
 > **📝 Note**
 >

--- a/docs/getting-started/troubleshooting/index.md
+++ b/docs/getting-started/troubleshooting/index.md
@@ -17,6 +17,9 @@ lxc-ls -f
 # List containers: status, group, status goal, restart policy
 pvcontrol ls
 
+# Restart just one container
+pvcontrol containers restart <name>
+
 # Check Pantavisor runtime log
 tail /pv/logs/<revision>/pantavisor/pantavisor.log
 
@@ -25,6 +28,21 @@ tail /pv/logs/<revision>/<container>/lxc/console.log
 
 # Check Pantahub connectivity (look for pantahub.online / pantahub.state)
 pvcontrol devmeta ls
+```
+
+`<revision>` above is the number `pvcontrol ls` (or the pvtx web UI's "Rev"
+field) shows for the container you're checking.
+
+`pvcontrol ls`'s `status` column is one of `INSTALLED`, `MOUNTED`, `BLOCKED`, `STARTING`, `STARTED`, `READY`, `RECOVERING`, `STOPPING`, `STOPPED` — see [Container status](/pantavisor/overview/containers#status) for what each means and which ones indicate a problem (`BLOCKED` and `RECOVERING` are the ones to look for). `status goal` is the target status a container needs to reach — see [Status goal](/pantavisor/overview/containers#status-goal).
+
+### Disk full / low on space
+
+```bash
+# Reclaim space — this is the only safe way to free /storage manually.
+# Do NOT hand-delete files under /storage: the running, updating, and
+# last-good revisions are protected automatically, but only pvcontrol
+# knows which files those are.
+pvcontrol storage gc
 ```
 
 Running these from inside a container (e.g. an SSH session into pvr-sdk)
@@ -37,7 +55,7 @@ instead? The `/pv/` tree is mounted at `/pantavisor/` there — e.g.
 
 **Symptom**: The device keeps rebooting after pushing a new revision.
 
-**Diagnosis**: A container in the new revision is failing to start, so auto-recovery retries it; after the retries are exhausted Pantavisor rolls back to the last `DONE` revision. Check the logs of the failed revision under `/pv/logs/<revision>/`.
+**Diagnosis**: A container in the new revision is failing to start, so auto-recovery retries it; after the retries are exhausted Pantavisor rolls back to the last `DONE` revision. There's no single fixed retry count — it's per-container/group `auto_recovery` config (`max_retries`, default `0` = unlimited retries, `policy` default `no` = disabled unless configured; see the [Auto-Recovery Object reference](/pantavisor/reference/pantavisor-state-format-v2#auto-recovery-object)). Check the logs of the failed revision under `/pv/logs/<revision>/`.
 
 **Fix**: No manual intervention is needed for recovery — the device returns to the last good revision on its own. Fix the failing container and deploy again.
 
@@ -63,7 +81,7 @@ instead? The `/pv/` tree is mounted at `/pantavisor/` there — e.g.
 
 **Diagnosis**: Either the URL form is wrong, or the pvr-sdk endpoint on the device only binds localhost.
 
-**Fix**: Use `http://<device-ip>:12368` (and `http://<device-ip>:12368/cgi-bin` for clone). If the image binds the endpoint to localhost, open it with a `_config/pvr-sdk/etc/pvr-sdk/config.json` overlay — see [Local Network](/meta-pantavisor/getting-started/operate/device-access/local-network).
+**Fix**: Use `http://<device-ip>:12368` (and `http://<device-ip>:12368/cgi-bin` for clone). If the image binds the endpoint to localhost, open it with a `_config/pvr-sdk/etc/pvr-sdk/config.json` overlay setting `"listen": "0.0.0.0"` — see the [FAQ entry](/meta-pantavisor/getting-started/troubleshooting/faq#pvr-clone-fails-with-connection-refused) for the exact JSON.
 
 ## Build & layer pitfalls (for image builders)
 

--- a/docs/overview/boot-flow.md
+++ b/docs/overview/boot-flow.md
@@ -17,8 +17,8 @@ root=/dev/ram rootfstype=ramfs rdinit=/usr/bin/pantavisor
 ```
 
 The kernel + initramfs + device tree are packaged as a FIT image
-(`pantavisor.fit`) that lives inside a versioned **trail revision** on the
-storage volume:
+(`pantavisor.fit`) that lives inside a versioned [**trail**](../glossary.md#trail)
+revision on the storage volume:
 
 ```
 /trails/<rev>/bsp/pantavisor.fit          # preferred: single FIT
@@ -30,7 +30,8 @@ storage volume:
 U-Boot's only job is to pick the right revision, load that revision's
 kernel/initrd/dtb into RAM, assemble the kernel command line, and jump to
 it. Once running, Pantavisor mounts its storage volume and manages
-containers (see [Pantavisor](../../pantavisor/overview/revisions.md) for the trail/revision model).
+[containers](../../pantavisor/overview/containers.md) — [LXC](glossary.md#lxc)-based,
+not Docker (see [Pantavisor](../../pantavisor/overview/revisions.md) for the trail/revision model).
 
 ## How the boot script is built and deployed
 

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -193,7 +193,8 @@ roughly the Yocto equivalent of a `genimage` config plus a partition table.
 
 ### xconnect
 
-Pantavisor's inter-container service connectivity: containers declare the
+Also referred to as **pv-xconnect** (the name of the on-device daemon) —
+same feature. Pantavisor's inter-container service connectivity: containers declare the
 services they provide and require in `services.json`
 (`service-manifest-xconnect@1`), and Pantavisor wires them together. See the
 [xconnect reference](/pantavisor/overview/xconnect).

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -39,8 +39,9 @@ Built from [meta-pantavisor](/meta-pantavisor/overview/get-started).
 An LXC container defined as a part of the device state: a squashfs root
 filesystem plus a `run.json` runtime manifest (and a `src.json` recording
 where it came from). Apps, system services, and management tools are all
-containers. **Note:** older generated reference pages call containers
-*platforms* — same thing.
+containers. **Note:** some reference pages and state-JSON examples still
+call containers *platforms* — same thing, an older name that hasn't been
+fully replaced everywhere yet.
 
 ### Debug shell
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -44,3 +44,14 @@ committing to the Yocto/BitBake build guide below.
 ## Continuous Integration
 
 - [Continuous Integration](ci/index.md) — CI system overview, machine matrix, release builds, tag sync, and docs publishing
+
+## Also in this section
+
+- [Porting Pantavisor](port/index.md) — add support for a new board: platform
+  and machine KAS files, CI registration, and building.
+- [Composable Firmware](composable-firmware.md) — what "composable firmware"
+  actually means here.
+- [Examples](examples/index.md) — worked xconnect and pvwificonnect examples.
+- [Testing](testing/index.md) — development and automated test workflows.
+- [Glossary](glossary.md) — every term used throughout these docs, defined
+  in one place.

--- a/docs/overview/port/index.md
+++ b/docs/overview/port/index.md
@@ -6,6 +6,11 @@ description: "Add support for a new board to meta-pantavisor: platform and machi
 
 This section covers how to add support for a new device or hardware platform to `meta-pantavisor`.
 
+**Where this job ends:** porting is done once `pantavisor-bsp` boots Pantavisor
+successfully on the new board. Apps and other containers are a separate
+concern, covered in [Container Development](../container-development.md) —
+you don't need to touch container recipes to bring up a new machine.
+
 ## Build System Overview
 
 `meta-pantavisor` uses **Yocto/OpenEmbedded** with **KAS** as the configuration and orchestration layer: builds run through `./kas-container build <config.yaml>`, where the config is composed from layered YAML fragments — base settings (`kas/bsp-base.yaml`), a Yocto release (`kas/scarthgap.yaml`), a platform (`kas/platforms/<family>.yaml`), and a machine (`kas/machines/<device>.yaml`). See the [Build system overview](../build-system) for the full hierarchy.


### PR DESCRIPTION
## Origin

This PR grew across a single continuous fix pass covering every
docs-eval persona this pack hadn't yet had a fix applied for. One commit
per persona (or per closely-related finding group), all in this PR per
explicit request rather than split into separate PRs:

- [persona 10](https://github.com/pantavisor/docs-framework/tree/master/answers/10-git-fluent-pvr-newcomer) (git-fluent pvr newcomer) + [persona 12](https://github.com/pantavisor/docs-framework/tree/master/answers/12-ai-agent-consumer) prompt B — `pvr app add` flags
- [persona 04](https://github.com/pantavisor/docs-framework/tree/master/answers/04-app-dev-on-device) (app developer targeting a Pi)
- [persona 06](https://github.com/pantavisor/docs-framework/tree/master/answers/06-bsp-bringup) (BSP bring-up engineer) — meta-pantavisor-side findings
- [persona 07](https://github.com/pantavisor/docs-framework/tree/master/answers/07-security-reviewer) (security/compliance reviewer)
- [persona 08](https://github.com/pantavisor/docs-framework/tree/master/answers/08-adoption-evaluator) (adoption evaluator, tech lead)
- [persona 09](https://github.com/pantavisor/docs-framework/tree/master/answers/09-field-support-operator) (field support operator, 2am scenario)
- [persona 11](https://github.com/pantavisor/docs-framework/tree/master/answers/11-manufacturing-provisioning) (manufacturing/provisioning engineer) — meta-pantavisor-side findings
- [persona 12](https://github.com/pantavisor/docs-framework/tree/master/answers/12-ai-agent-consumer) (AI agent consumer) prompts A and C

A paired `pantavisor`-repo PR (**#783**) covers the findings this pack
routed to that repo instead — kernel requirements, the 4-way "platform"
term overload, and the Pantahub self-hosting answer.

## Highlights

- **Corrected a misdiagnosis, not just a gap**: persona 12 concluded
  `pvr app add`'s `--group`/`--status-goal` weren't real CLI flags at all
  (a hallucination risk for an AI agent told to use them) — verified
  against `pvr`'s Go source and they are real flags; documented them with
  their actual permitted values.
- **Found the exact term a persona searched for and couldn't find**:
  persona 07 (security reviewer) searched the entire security-docs
  cluster for `__system__` and never found it — it lives in `pvr sig`'s
  `--cacerts` flag usage string, nowhere near the security pages. Also
  documented `pvr sig` properly (previously an off-domain "Legacy" link)
  and found that signing falls back to Pantacor's own **shared, public**
  default developer keys unless `--key`/`--x5c` are passed explicitly —
  a real, concrete answer to "is signing actually mandatory."
- **Found a real 404**: a cross-repo link in `cli-tools/configuration.md`
  pointing at a page that doesn't exist (persona 12).
- **Found stale content, not just gaps**: `boot-flow.md` named nonexistent
  multiconfigs (`pvbsp`/`pvapp` — the real ones are `pv-initramfs-panta`/
  `pv-panta`, confirmed against `kas/bsp-multi.yaml`); the glossary's
  "platforms" note claimed the old terminology was confined to "older
  generated reference pages" when persona 12 found it live in current,
  non-generated pantavisor-repo examples.
- **Turned "missing" into "unlinked"**: persona 08 found Pantahub's
  open-source/self-host status seemingly undocumented from every page it
  checked — the answer already existed on the Licensing page, just wasn't
  linked from anywhere a reader would naturally ask the question. Same
  pattern for persona 12's worst finding: `composable-firmware.md` defines
  the corpus's own core differentiator term with zero inbound links,
  including from the benchmarks page that uses the term to sell the
  concept.
- **Recurring finding closed once, for three personas**: `pvcontrol ls`'s
  `status`/`status goal` columns were undefined on every page that shows
  them (serial-port.md, troubleshooting/index.md), independently hit by
  personas 06, 09 (all three prompts), and referenced by 10 and 12 — now
  linked to the real enum with problem-states called out.
- **A genuinely unsafe gap, fixed with a warning, not a guess**: the pvtx
  web UI handed over a state-changing `curl -X POST .../pvtx/begin` command
  with zero explanation (persona 09's worst finding) — added an explicit
  warning rather than inventing begin/commit/cancel semantics I couldn't
  verify.
- **Rendering-bug archaeology**: found and fixed a site `.md`-export bug
  (link text dropped after bold text / at list-item ends) that had been
  quietly misattributed as "content gaps" in several earlier persona
  reports — plus caught myself introducing the identical bug three more
  times while writing new content in this same PR, fixed each time it was
  caught.

## Consistently NOT fixed — flagged instead of fabricated

Every commit message lists what was deliberately left alone and why. In
aggregate, across the whole PR: the boot-chain root of trust, container
confinement mechanism (seccomp/AppArmor/capabilities), device-identity/
anti-cloning binding, SBOM/CVE disclosure process, "immutable" trail-step
enforcement mechanism, production deployment evidence/maturity signal,
per-unit provisioning at manufacturing scale, a reference "healthy boot"
serial transcript, and real (not illustrative) benchmark numbers. All of
these need real product, security-architecture, or business input that a
docs-only pass can't supply — noted per-commit rather than invented.

## Status

**This is a draft for human review** — opened from an automated docs-eval
fix pass across 8 commits. Given the volume, please review commit-by-commit
rather than as one diff — each is scoped to one persona/finding cluster and
has its own detailed rationale.