### PR TITLE
recipes-pv: manual srcrev update

### DIFF
--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,3 +1,3 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
-PANTAVISOR_SRCREV = "13b0829fc3a5444200a6cf82408d75dc209ef673"
+PANTAVISOR_SRCREV = "3bfaa42b8b81c79a7290f22618817f582d0f18a4"


### PR DESCRIPTION
Updating pantavisor in ./recipes-pv/pantavisor/pantavisor.inc:
  13b0829fc3a5444200a6cf82408d75dc209ef673 -> 3bfaa42b8b81c79a7290f22618817f582d0f18a4
    * 3bfaa42 docs(appengine): add appengine basic info to docs overview
    * 8a3cd4d feat(appengine): manual mode; named pvtx installed initial revision; signal handling; exit code management
    * 48709a5 chore(appengine): set appengine config with common env from meta-pantavisor pvtest
    * 3d77555 feat(pvtest): add volatile and persistent models to runner
    * 5de3d57 feat(tools): PVTEST_EXEC env to allow exec prefixes to pvcontrol and pventer
    * 0f1fcac chore(config): set PH_UPDATER_INTERVAL default from 60 to 5
    * fb0025e docs(overview): point remote-control's object-download step at a size example
    * 1709293 changelogs(029): autoadd changelog