### PR TITLE
feat(pantavisor): auto-derive PV from nearest stable release tag

### DIFF
--- a/.github/scripts/update-components.sh
+++ b/.github/scripts/update-components.sh
@@ -97,6 +97,40 @@ for ENTRY in "${COMPONENTS[@]}"; do
     else
         echo "  Error: Could not find SRCREV or rev= in $RECIPE"
     fi
+
+    # pantavisor tracks a moving branch (master), so its PV must be derived
+    # from the nearest stable release tag reachable from that branch's head
+    # rather than bumped in lockstep with SRCREV. RC tags (e.g. "029-rc4")
+    # are ignored; format is always "<release>+git0" (e.g. "029" -> "029+git0").
+    if [ "$COMPONENT" = "pantavisor" ] && grep -q '^PV = "' "$RECIPE"; then
+        TAG_TEMP_DIR=$(mktemp -d)
+        git clone -q --filter=blob:none --no-checkout "$FULL_URL" "$TAG_TEMP_DIR" 2>/dev/null
+        NEAREST_TAG=$(git -C "$TAG_TEMP_DIR" describe --tags --abbrev=0 --match '[0-9][0-9][0-9]' "$REMOTE_SHA" 2>/dev/null || true)
+        rm -rf "$TAG_TEMP_DIR"
+
+        NEW_PV=""
+        if [[ "$NEAREST_TAG" =~ ^([0-9]+)$ ]]; then
+            NEW_PV="${NEAREST_TAG}+git0"
+        fi
+
+        if [ -n "$NEW_PV" ]; then
+            CURRENT_PV=$(grep -oP '^PV = "\K[^"]+' "$RECIPE")
+            echo "  Current PV: $CURRENT_PV / nearest tag: $NEAREST_TAG"
+            if [ "$CURRENT_PV" != "$NEW_PV" ]; then
+                echo "  PV UPDATE FOUND: $NEW_PV"
+                sed -i "s|^PV = \"$CURRENT_PV\"|PV = \"$NEW_PV\"|" "$RECIPE"
+
+                echo "Updating $COMPONENT PV in $RECIPE:" >> "$COMMIT_MSG_FILE"
+                echo "  $CURRENT_PV -> $NEW_PV" >> "$COMMIT_MSG_FILE"
+                echo "" >> "$COMMIT_MSG_FILE"
+                UPDATES_FOUND=1
+            else
+                echo "  PV up to date."
+            fi
+        else
+            echo "  Warning: Could not derive PV from nearest tag '$NEAREST_TAG'"
+        fi
+    fi
     echo ""
 done
 

--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,3 +1,5 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
 PANTAVISOR_SRCREV = "4b00ba422d26ad6ddc002f493a9804770a28ca71"
+
+PV = "029+git0"

--- a/recipes-pv/pantavisor/pantavisor_git.bb
+++ b/recipes-pv/pantavisor/pantavisor_git.bb
@@ -36,7 +36,6 @@ SRC_URI = "${PANTAVISOR_URI};branch=${PANTAVISOR_BRANCH} \
 SRCREV = "${PANTAVISOR_SRCREV}"
 
 PE = "1"
-PV = "029+git0"
 PKGV = "${PV}+${GITPKGV}"
 
 PACKAGES =+ "${PN}-hooks-mdev ${PN}-pvtx ${PN}-pvtx-static ${PN}-config ${PN}-pvtest ${PN}-pvcontrol ${PN}-pvcurl ${PN}-debug-hooks"


### PR DESCRIPTION
## Summary
- Move `PV` out of `pantavisor_git.bb` and into `pantavisor.inc` (already the recipe `update-components.sh` targets for the `pantavisor` component per `components.json`).
- Teach `update-components.sh` to resolve the nearest stable release tag reachable from `pantavisor`'s `master` head (via a blobless clone + `git describe --match '[0-9][0-9][0-9]'`) and write `PV` as `"<release>+git0"`. RC tags are ignored — PV only tracks stable releases.
- Update `pantavisor.inc`'s current `PV` to `"029+git0"`, matching what the automation resolves right now (verified live against `github.com/pantavisor/pantavisor`).

## Test plan
- [x] `bash -n .github/scripts/update-components.sh`
- [x] Verified live: `master`'s current head resolves to nearest stable tag `029` via `git describe --tags --abbrev=0 --match '[0-9][0-9][0-9]'`
- [x] Run `schedule-updates.yaml` (or `update-components.sh` locally) end-to-end and confirm the generated commit/PR bumps `PV` correctly on a real version change