### PR TITLE
docs: add onboarding stories (repo-managed layers, app-to-container routes)

### DIFF
--- a/docs/getting-started/develop/application/add-application.md
+++ b/docs/getting-started/develop/application/add-application.md
@@ -1,0 +1,110 @@
+---
+title: Add Your Application
+sidebar_position: 21
+description: Two ways to turn an application into a Pantavisor container — pull an existing OCI image with pvr, or bake it into the BSP as a Yocto recipe.
+---
+
+Every Pantavisor app is an LXC container with a `run.json` manifest,
+versioned in the device's [revision trail](../../../overview/glossary.md#revision).
+There are two ways to get your application into that shape, and which one
+you want depends on what you're starting from.
+
+## Which route do I need?
+
+| | Already have a Docker/OCI image | Building the BSP image itself |
+|---|---|---|
+| **Route** | Pull it with `pvr` | Wrap it as a Yocto recipe |
+| **Needs Yocto?** | No | Yes |
+| **Speed** | Minutes | A full BitBake build |
+| **Where it lives** | Added to a device's revision trail directly | Part of the reproducible BSP build, tracked in this layer's git history |
+| **Use when** | You're deploying to a device you already have running | You're building/customizing images for a fleet, or the app must ship inside the initial image |
+
+<div style="display: flex; justify-content: center;">
+
+<pre>
+                     Have an application?
+                              │
+            ┌─────────────────┴─────────────────┐
+            │                                    │
+  Already an OCI/Docker image             Building the BSP image
+            │                                    │
+  pvr app add --from &lt;image&gt;          inherit core-image
+    --platform &lt;arch&gt;                   container-pvrexport
+            │                                    │
+  pvr add . && pvr commit             kas-container build --target &lt;recipe&gt;
+            │                                    │
+  pvr post &lt;device&gt;                      pvr inspect *.pvrexport.tgz
+            │                                    │
+            └─────────────────┬──────────────────┘
+                              │
+              Running container in the device's
+                         revision trail
+</pre>
+
+</div>
+
+## Route 1 — Pull an existing OCI image
+
+If your application already builds as a Docker/OCI image (Docker Hub, GHCR,
+a private registry — any OCI-compatible host), `pvr app add` pulls it,
+converts it to a SquashFS container, and stages it as a new device
+revision. No Yocto toolchain involved.
+
+```bash
+pvr clone http://<device-ip>:12368/cgi-bin mydevice
+cd mydevice
+pvr app add myapp --from registry.example.com/team/myapp:v1 --platform linux/arm64
+pvr add . && pvr commit -m "add myapp container"
+pvr post http://<device-ip>:12368
+```
+
+Full walkthrough, including scanning for the device, private-registry auth,
+and verifying the deploy: [Install with the pvr CLI](./install/local-pvr.md).
+
+## Route 2 — Bake it into the BSP as a Yocto recipe
+
+If you're building this layer's images and want the app shipped as part of
+the reproducible BSP build (not added to a device after the fact), wrap it
+as an OE recipe using the same pattern as
+`recipes-containers/pv-examples/`:
+
+```bitbake
+SUMMARY = "My App Container"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit core-image container-pvrexport
+
+IMAGE_BASENAME = "pv-myapp"
+PVRIMAGE_AUTO_MDEV = "0"
+IMAGE_INSTALL += "myapp-package"
+SRC_URI += "file://${PN}.args.json"
+PVR_APP_ADD_EXTRA_ARGS += "--config=Entrypoint=/usr/bin/myapp"
+PVR_APP_ADD_GROUP = "app"
+```
+
+`inherit core-image container-pvrexport` is what turns a normal OE image
+recipe into a Pantavisor-importable container; `args.json` (and
+`services.json`, if your app talks to other containers) wire it into the
+[xconnect](../../../overview/glossary.md#xconnect) service mesh.
+`PVR_APP_ADD_GROUP = "app"` gets you restart-on-failure auto-recovery for
+free.
+
+Build it and inspect the result:
+
+```bash
+./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+    --target pv-myapp
+
+pvr inspect build/tmp-scarthgap/deploy/images/docker-x86_64/pv-myapp.pvrexport.tgz
+```
+
+Full recipe reference, `services.json`/`args.json` details, and the
+complete add-a-container workflow:
+[Container Development](../../../overview/container-development.md).
+
+## After either route
+
+- [Configure](./configure.md) — overlay files or edit `run.json` post-deploy.
+- [`pvcontrol`](../cli-tools/pvcontrol.md) — verify the container's runtime
+  state (`pvcontrol container ls`) after it's live.

--- a/docs/getting-started/develop/application/index.md
+++ b/docs/getting-started/develop/application/index.md
@@ -10,6 +10,7 @@ Containers are versioned as part of the device's **revision trail** (the `trails
 
 This section covers the complete lifecycle of managing applications on a Pantavisor device:
 
+*   **[Add Your Application](./add-application.md)**: Pick a path — pull an existing OCI image with `pvr`, or bake it into the BSP as a Yocto recipe.
 *   **[Install Applications](./install/)**: Add containerized services to your device using the `pvr` CLI directly, through the pvtx local web UI, or remotely via Pantahub.
 *   **[Configure Applications](./configure/)**: Customize container behaviour by editing the `_config/<container>/` overlay tree in your local `pvr` repository, then deploying the new revision.
 *   **[View Applications](./view/)**: Monitor running containers, inspect health and auto-recovery state, and stream logs — on-device with `pvcontrol` and `lxc-ls`, or through the pvtx web UI.

--- a/docs/getting-started/develop/index.md
+++ b/docs/getting-started/develop/index.md
@@ -15,6 +15,7 @@ difference.
 
 ## Manage applications
 
+- [Add your application](./application/add-application.md) — pick a path: pull an existing OCI image with `pvr`, or bake it into the BSP as a Yocto recipe
 - [Install apps](./application/install/index.md) — add [containers](../../overview/glossary.md#container) with the `pvr` CLI, the pvtx web UI, or remotely via [Pantahub](./application/install/remote-pantahub.md)
 - [Configure](./application/configure.md) — overlay files and runtime manifests through the [revision](../../overview/glossary.md#revision) workflow
 - [View](./application/view.md) — container status, logs, and the pvtx web UI

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -34,12 +34,13 @@ committing to the Yocto/BitBake build guide below.
 ## Build Guide
 
 7. [Get Started](get-started.md) — prerequisites, repository setup, git worktrees, and your first KAS build
-8. [Supported Devices](supported-device.md) — machines supported and built by CI
-9. [Pantavisor Development](pantavisor-development.md) — build against a local pantavisor source checkout using the workspace overlay
-10. [Container Development](container-development.md) — author and iterate on app containers: recipe structure, pvrexport, and local testing
-11. [Manifest Audit](manifest-audit.md) — audit rootfs content with `pv-manifest-audit` and enforce strict mode
-12. [Component Docs](component-docs.md) — generate per-component documentation tarballs from the build
-13. [Bootchartd](bootchartd.md) — enable boot performance profiling with bootchartd in Pantavisor images
+8. [Managing Layers with repo](repo-manifest.md) — fold meta-pantavisor into an existing `repo`/`manifest.xml` multi-layer workflow
+9. [Supported Devices](supported-device.md) — machines supported and built by CI
+10. [Pantavisor Development](pantavisor-development.md) — build against a local pantavisor source checkout using the workspace overlay
+11. [Container Development](container-development.md) — author and iterate on app containers: recipe structure, pvrexport, and local testing
+12. [Manifest Audit](manifest-audit.md) — audit rootfs content with `pv-manifest-audit` and enforce strict mode
+13. [Component Docs](component-docs.md) — generate per-component documentation tarballs from the build
+14. [Bootchartd](bootchartd.md) — enable boot performance profiling with bootchartd in Pantavisor images
 
 ## Continuous Integration
 

--- a/docs/overview/repo-manifest.md
+++ b/docs/overview/repo-manifest.md
@@ -1,0 +1,111 @@
+---
+title: "Managing Layers with repo"
+sidebar_position: 4.5
+---
+# Managing Layers with `repo`
+
+**Who this is for**: a systems/integration engineer who already manages a
+fleet of Yocto layers and products through Google's
+[`repo`](https://gerrit.googlesource.com/git-repo/) multi-manifest tool
+(`repo init` / `repo sync` against a `manifest.xml`), and wants to add
+meta-pantavisor as one more project rather than switching workflows.
+
+This is optional. meta-pantavisor's own CI and the default
+[Get Started](get-started.md) guide use a plain `git clone` of
+meta-pantavisor, with `kas` fetching `poky`, `meta-openembedded`, and the
+rest declaratively per build config. `repo` is not required to build this
+layer — it's a way to fold meta-pantavisor into a manifest you already
+maintain for other layers/products.
+
+## Why this works: `_source_dir`
+
+Every build config in `kas/build-configs/` sets `_source_dir: .` — meaning
+kas resolves all layer checkouts relative to the meta-pantavisor repo root,
+not inside `build/`. You can see the exact layout kas expects by dumping any
+config:
+
+```bash
+kas dump --resolve-refs kas/build-configs/release/docker-x86_64-scarthgap.yaml
+```
+
+For the `docker-x86_64-scarthgap` target, this resolves to:
+
+| Repo | Path (relative to meta-pantavisor root) |
+|------|------------------------------------------|
+| `meta-pantavisor` | `.` |
+| `poky` | `layers/poky` |
+| `meta-openembedded` | `layers/meta-openembedded` |
+| `meta-virtualization` | `layers/meta-virtualization` |
+
+If a `repo sync` already populates exactly these paths, `kas build` finds
+the layers in place and updates them in-tree instead of cloning fresh — no
+extra kas config needed on top of the normal build-config file.
+
+## A manifest.xml for meta-pantavisor
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="pantavisor" fetch="https://github.com/pantavisor" />
+  <remote name="yocto" fetch="https://git.yoctoproject.org" />
+  <remote name="oe" fetch="https://github.com/openembedded" />
+
+  <default remote="pantavisor" revision="scarthgap" sync-j="4" />
+
+  <project name="meta-pantavisor" path="." revision="scarthgap" />
+  <project name="poky" remote="yocto" path="layers/poky" revision="scarthgap" />
+  <project name="meta-openembedded" remote="oe" path="layers/meta-openembedded" revision="scarthgap" />
+  <project name="meta-virtualization" remote="yocto" path="layers/meta-virtualization" revision="scarthgap" />
+</manifest>
+```
+
+`revision` can track a branch (`scarthgap`, as above, matching
+`defaults.repos.branch` in `kas/scarthgap.yaml`) or pin an exact commit for
+reproducible builds — use the `commit:` values from `kas dump
+--resolve-refs` (shown in the table above) if you want the manifest to lock
+to the same revisions this layer's own CI builds against.
+
+Host this `manifest.xml` in its own git repo (the usual `repo` convention),
+then:
+
+```bash
+mkdir my-workspace && cd my-workspace
+repo init -u <url-to-your-manifest-repo> -m manifest.xml
+repo sync
+```
+
+This lays out `meta-pantavisor` at the workspace root and the other layers
+under `layers/`, matching the table above exactly.
+
+## Building from the repo-managed checkout
+
+From the workspace root (where `repo sync` placed `meta-pantavisor`):
+
+```bash
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml
+```
+
+No `_source_dir` override is needed — the build config already points kas
+at the layers your manifest just synced. Add your own layers (internal
+forks, additional BSPs) to the manifest and to a KAS config's `repos:`
+block the same way; see [Build System](build-system.md) for how KAS
+configuration fragments compose.
+
+## What `repo` does not replace
+
+- `bblayers.conf` composition, `MACHINE`/`DISTRO` selection, and
+  multiconfig are still `kas`'s job — `repo` only pins and checks out
+  source trees.
+- `repo` manages *your* manifest repo's revisions; it doesn't know about
+  meta-pantavisor's KAS patches (e.g. the `poky` patches wired up in
+  `kas/scarthgap.yaml`) — those still apply through the normal kas build,
+  after `repo sync` has placed the source.
+
+## See also
+
+- [Get Started](get-started.md) — the default single-repo path (plain
+  `git clone` + kas-fetched layers) if you don't already use `repo`.
+- [Build System](build-system.md) — KAS configuration hierarchy and how
+  fragments combine.
+- [Glossary](glossary.md) — definitions for `kas`, layer, and other terms
+  used above.


### PR DESCRIPTION
## Summary
- Adds `docs/overview/repo-manifest.md`: folding meta-pantavisor into an existing `repo`/`manifest.xml` multi-layer workflow, for integration engineers who already manage several Yocto layers/products that way instead of a plain `git clone`. Verified the layer layout kas expects (`layers/poky`, `layers/meta-openembedded`, etc. under `_source_dir: .`) against `kas dump --resolve-refs`.
- Adds `docs/getting-started/develop/application/add-application.md`: a decision guide comparing the two ways to turn an app into a Pantavisor container — pulling an existing OCI image with `pvr app add`, or baking it into the BSP as a Yocto recipe via `container-pvrexport` — with a centered ASCII diagram of both flows converging on the device's revision trail.
- Wires both new pages into existing navigation (`docs/overview/index.md`'s Build Guide list, `docs/getting-started/develop/index.md` and `application/index.md`'s "Manage applications" lists).

## Test plan
- [ ] Docs-only change; no build/test suite applies.
- [x] Verified every relative link in the two new pages resolves to a real file.
- [x] Verified the `kas`/`repo` layer-layout claims in `repo-manifest.md` by running `kas dump --resolve-refs` locally against `kas/build-configs/release/docker-x86_64-scarthgap.yaml`.
- [ ] Check rendering on the published docs preview once CI builds it (draft PR — promote with `gh pr ready` to trigger the build/test matrix).