### PR TITLE
ci: publish latest docs from unpinned master branches

### DIFF
--- a/.github/workflows/build-docs-latest.yaml
+++ b/.github/workflows/build-docs-latest.yaml
@@ -1,0 +1,98 @@
+name: "build: latest (unpinned) docs tarball"
+
+# Assembles the same docs tarball layout as build-docs-scarthgap.yaml
+# (index.md + meta-pantavisor/ + pantavisor/ + pvr/, see
+# classes/pantavisor-docs.bbclass) but WITHOUT a bitbake build: pantavisor and
+# pvr are cloned straight off their master branches instead of the SRCREV/PV
+# pinned in this layer's recipes (recipes-pv/pantavisor/pantavisor.inc,
+# recipes-pv/pvr/pvr_<PV>.bb). Used by docs-scarthgap.yaml to publish
+# always-current "latest" docs. Release docs (tag-docs-scarthgap.yaml) must
+# keep using the pinned bitbake build in build-docs-scarthgap.yaml instead —
+# those need to match what was actually shipped in that release.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or commit SHA) of meta-pantavisor to build docs from'
+        required: true
+        type: string
+      artifact_name:
+        description: 'Name for the uploaded docs tarball artifact'
+        required: true
+        type: string
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout meta-pantavisor
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: meta-pantavisor
+
+      - name: Checkout pantavisor (master)
+        uses: actions/checkout@v4
+        with:
+          repository: pantavisor/pantavisor
+          ref: master
+          path: pantavisor
+          sparse-checkout: docs
+
+      - name: Checkout pvr (master)
+        run: |
+          git clone --depth 1 --branch master --no-checkout \
+            https://gitlab.com/pantacor/pvr.git pvr
+          git -C pvr sparse-checkout set docs
+          git -C pvr checkout master
+
+      - name: Assemble docs staging
+        run: |
+          staging="$RUNNER_TEMP/pantacor-docs-staging"
+          rm -rf "$staging"
+
+          install -d "$staging/meta-pantavisor"
+          cp -r meta-pantavisor/docs/. "$staging/meta-pantavisor/"
+
+          if [ -d pantavisor/docs ]; then
+            install -d "$staging/pantavisor"
+            cp -r pantavisor/docs/. "$staging/pantavisor/"
+          else
+            echo "::warning::pantavisor/docs not found, skipping"
+          fi
+
+          if [ -d pvr/docs ]; then
+            install -d "$staging/pvr"
+            cp -r pvr/docs/. "$staging/pvr/"
+          else
+            echo "::warning::pvr/docs not found, skipping"
+          fi
+
+          {
+            printf '# Pantavisor Documentation\n\n'
+            printf 'This archive bundles reference documentation shipped alongside the build artefacts.\n\n'
+            [ -d "$staging/pantavisor" ] && \
+              printf -- '- **[Pantavisor](pantavisor/)** — the embedded Linux runtime that manages\n  the device lifecycle: booting containers, applying atomic OTA updates, and\n  exposing a REST API for local and cloud control.\n\n'
+            [ -d "$staging/pvr" ] && \
+              printf -- '- **[PVR](pvr/)** — the Pantavisor command-line utility for creating,\n  managing, and deploying containerized applications to Pantavisor devices.\n\n'
+            [ -d "$staging/meta-pantavisor" ] && \
+              printf -- '- **[meta-pantavisor](meta-pantavisor/)** — the Yocto/OpenEmbedded layer\n  used to build Pantavisor-based BSP images. Covers the build system, KAS\n  configurations, BitBake recipes, and the CI/release pipeline.\n\n'
+            [ -d "$staging/meta-pantavisor" ] && \
+              printf 'Start with [meta-pantavisor/index.md](meta-pantavisor/index.md) for a guided\nreading order, or jump straight into either section above.\n'
+          } > "$staging/index.md"
+
+          echo "STAGING=$staging" >> "$GITHUB_ENV"
+
+      - name: Build docs tarball
+        run: |
+          mkdir -p docs-out
+          tar -C "$STAGING" --use-compress-program=zstd \
+            -cf docs-out/pantavisor-starter-latest.rootfs.docs.tar.zst .
+          ls -l docs-out
+
+      - name: upload docs tarball artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: docs-out/*.rootfs.docs.tar.zst

--- a/.github/workflows/docs-scarthgap.yaml
+++ b/.github/workflows/docs-scarthgap.yaml
@@ -1,5 +1,11 @@
 name: "generate latest docs on docs/ changes"
 
+# Publishes always-current "latest" docs: meta-pantavisor's own docs/ as of
+# this ref, plus pantavisor and pvr docs pulled straight from THEIR master
+# branches (unpinned — see build-docs-latest.yaml). This intentionally does
+# not go through the SRCREV/PV pins in recipes-pv/pantavisor/pantavisor.inc
+# and recipes-pv/pvr/pvr_<PV>.bb. Release docs use tag-docs-scarthgap.yaml
+# instead, which builds via bitbake and does follow those pins.
 on:
   push:
     branches:
@@ -10,11 +16,10 @@ on:
 
 jobs:
   build-docs:
-    uses: ./.github/workflows/build-docs-scarthgap.yaml
+    uses: ./.github/workflows/build-docs-latest.yaml
     with:
       ref: master
       artifact_name: docs-tarball-latest
-    secrets: inherit
 
   publish-docs:
     needs: build-docs


### PR DESCRIPTION
## Summary
- `docs-scarthgap.yaml` is meant to publish always-current "latest" docs, but was calling `build-docs-scarthgap.yaml`, which builds via bitbake and pulls pantavisor at `PANTAVISOR_SRCREV` and pvr at its recipe-pinned tag -- whatever this layer's recipes currently pin, not those repos' actual master branches.
- Add `build-docs-latest.yaml`: assembles the same tarball layout (`index.md` + `meta-pantavisor/` + `pantavisor/` + `pvr/`, per `classes/pantavisor-docs.bbclass`) by cloning pantavisor and pvr `docs/` directly off master, no bitbake build involved.
- `docs-scarthgap.yaml` now calls this new workflow instead.
- `tag-docs-scarthgap.yaml` (release docs) is unchanged -- it already builds via bitbake and correctly follows each component's pinned SRCREV/PV, which is what release docs should do.

## Test plan
- [ ] Trigger `docs-scarthgap.yaml` via `workflow_dispatch` and confirm the produced tarball contains current pantavisor/pvr master docs (not the pinned recipe versions)
- [ ] Confirm `latest.json` on S3 still updates correctly (publish-docs job is unchanged)
- [ ] Confirm `tag-docs-scarthgap.yaml` / release docs behavior is unaffected