### PR TITLE
recipes-pv: automated srcrev update

### DIFF
--- a/recipes-pv/pantavisor/pantavisor.inc
+++ b/recipes-pv/pantavisor/pantavisor.inc
@@ -1,5 +1,5 @@
 PANTAVISOR_BRANCH ??= "master"
 PANTAVISOR_URI = "git://github.com/pantavisor/pantavisor.git;protocol=https"
-PANTAVISOR_SRCREV = "439d5b4eafe3b76c7effc61590dd6526ff6daf04"
+PANTAVISOR_SRCREV = "c228d1ea5d879f543639e9952635e9db3b84001c"
 
 PV = "029+git0"


### PR DESCRIPTION
Updating pantavisor in ./recipes-pv/pantavisor/pantavisor.inc:
  439d5b4eafe3b76c7effc61590dd6526ff6daf04 -> c228d1ea5d879f543639e9952635e9db3b84001c
    * c228d1e Merge pull request #793 from pantavisor/fix/update-sysinfo
    * 0e64629 fix(metadata): set devmeta change thresholds to the measured noise floor
    * 5a4d35e fix(metadata): report uptime and idle with two decimals
    * 4925923 feat(pantahub): push devmeta on significant change with a heartbeat floor
    * d525292 fix(metadata): report sysinfo, time and storage as live measurements
    * 9d5ab55 fix(metadata): update devmeta's sysinfo on each request