### PR TITLE
docs: fix stale kas paths, PANTAVISOR_FEATURES defaults, undocumented kas configs

### DIFF
--- a/docs/getting-started/develop/application/add-application.md
+++ b/docs/getting-started/develop/application/add-application.md
@@ -93,7 +93,7 @@ free.
 Build it and inspect the result:
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-myapp
 
 pvr inspect build/tmp-scarthgap/deploy/images/docker-x86_64/pv-myapp.pvrexport.tgz

--- a/docs/overview/build-system.md
+++ b/docs/overview/build-system.md
@@ -100,6 +100,7 @@ Controls which optional Pantavisor components are compiled in and installed. Def
 | `debug` | Debug features |
 | `pvcontrol` | pv-ctrl socket and CLI tools (pvcurl, pvcontrol) |
 | `xconnect` | Service mesh for container-to-container communication |
+| `xconnect-dbus-systembus` | D-Bus system bus support for xconnect |
 | `container-mdev` | Per-container mdev device-node hook (runs an mdev LXC mount hook on each container start) |
 | `rngdaemon` | Random number generator daemon |
 | `squash-lz4` | LZ4 squashfs compression |
@@ -107,7 +108,7 @@ Controls which optional Pantavisor components are compiled in and installed. Def
 | `rpi-tryboot` | Raspberry Pi A/B boot partition support |
 | `bootchartd` | Boot timing analysis (writes to `/`; use `rdinit=/sbin/bootchartd`) |
 
-**Default**: `dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect container-mdev`
+**Default**: `dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect xconnect-dbus-systembus container-mdev`
 
 > **Caution**: `tailscale` and `rngdaemon` appear in the default string, but their gating is inconsistent upstream — for example, `pantavisor-initramfs.bb` checks for a feature named `rngd`, not `rngdaemon`. Verify the recipes if you depend on either.
 
@@ -116,7 +117,7 @@ Controls which optional Pantavisor components are compiled in and installed. Def
 `pvbase.bbclass` sets defaults via `??=` (weak default operator):
 
 ```bitbake
-PANTAVISOR_FEATURES ??= " dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect container-mdev "
+PANTAVISOR_FEATURES ??= " dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect xconnect-dbus-systembus container-mdev "
 ```
 
 In distro includes, you **must** use `:append` or `:remove` — never `+=`:
@@ -205,4 +206,3 @@ LAYERSERIES_COMPAT_meta-pantavisor = "kirkstone scarthgap"
 | `build/tmp-scarthgap/deploy/images/` | Build outputs |
 | `recipes-containers/pv-examples/` | Example container recipes |
 | `kas/build-configs/release/` | KAS release machine configurations |
-| `.github/configs/release/` | CI release machine configurations |

--- a/docs/overview/container-development.md
+++ b/docs/overview/container-development.md
@@ -63,7 +63,7 @@ Set `PVR_APP_ADD_GROUP = "app"` in the recipe to inherit the group's default `au
 ## Building Containers
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-example-foo
 ```
 
@@ -97,7 +97,7 @@ cat > recipes-containers/pv-examples/files/pv-example-mytest.args.json << 'EOF'
 EOF
 
 # 3. Build and deploy for testing
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-example-mytest
 cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-mytest.pvrexport.tgz pvtx.d/
 ```

--- a/docs/overview/examples/pvwificonnect.md
+++ b/docs/overview/examples/pvwificonnect.md
@@ -137,7 +137,7 @@ D-Bus interface.
 ## Building
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pvwificonnect
 ```
 

--- a/docs/overview/examples/xconnect-examples.md
+++ b/docs/overview/examples/xconnect-examples.md
@@ -29,11 +29,11 @@ Auto-recovery containers:
 
 ```bash
 # Build specific containers
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-unix-server --target pv-example-unix-client
 
 # Build with workspace (when iterating on pantavisor source)
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-example-unix-server --target pv-example-unix-client
 ```
 
@@ -87,7 +87,7 @@ Demonstrates raw Unix domain socket proxying between containers.
 ### Build and Verify
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-unix-server --target pv-example-unix-client
 cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-unix-*.pvrexport.tgz pvtx.d/
 ```
@@ -124,7 +124,7 @@ Demonstrates HTTP-over-UDS with identity header injection (`X-PV-Client`, `X-PV-
 ### Build
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-rest-server --target pv-example-rest-client
 ```
 
@@ -171,7 +171,7 @@ Demonstrates policy-aware D-Bus proxying with role-to-UID mapping.
 ### Build and Verify
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-dbus-server --target pv-example-dbus-client
 ```
 
@@ -277,7 +277,7 @@ ls -la /dev/dri/   # card0 (VKMS does not create renderD* nodes)
 ### Build and Run
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-drm-provider --target pv-example-drm-master
 cp build/tmp-scarthgap/deploy/images/docker-x86_64/pv-example-drm-*.pvrexport.tgz pvtx.d/
 
@@ -324,7 +324,7 @@ Demonstrates Wayland compositor access. Requires DRM.
 ```
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-drm-provider \
     --target pv-example-wayland-server \
     --target pv-example-wayland-client

--- a/docs/overview/get-started.md
+++ b/docs/overview/get-started.md
@@ -104,7 +104,13 @@ Adds `kas/with-workspace.yaml` to create a devtool workspace with editable panta
 
 Build a specific target:
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml --target pantavisor-appengine
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml --target pantavisor-appengine
+```
+
+`pantavisor-appengine-distro` and `pantavisor-remix` also have their own dedicated kas configs, so they can be built directly instead of via `--target`:
+```bash
+./kas-container build kas/build-configs/build-appengine-distro.yaml
+./kas-container build kas/build-configs/build-base-remix.yaml
 ```
 
 ## Direct BitBake (for integrators)

--- a/docs/overview/meta-pantavisor.md
+++ b/docs/overview/meta-pantavisor.md
@@ -60,20 +60,22 @@ Controls which optional Pantavisor components are compiled in and installed. Def
 | `debug` | Debug features |
 | `pvcontrol` | pv-ctrl socket and CLI tools (pvcurl, pvcontrol) |
 | `xconnect` | [Service mesh](/pantavisor/overview/xconnect) for container-to-container communication |
+| `xconnect-dbus-systembus` | D-Bus system bus support for xconnect |
+| `container-mdev` | Per-container mdev device-node hook (runs an mdev LXC mount hook on each container start) |
 | `rngdaemon` | Random number generator daemon |
 | `squash-lz4` | LZ4 squashfs compression |
 | `squash-zstd` | Zstd squashfs compression |
 | `rpi-tryboot` | Raspberry Pi A/B boot partition support |
 | `bootchartd` | Boot timing analysis (writes to `/`; use `rdinit=/sbin/bootchartd`) |
 
-**Default**: `dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect`
+**Default**: `dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect xconnect-dbus-systembus container-mdev`
 
 ### The `+=` vs `:append` Pitfall
 
 `pvbase.bbclass` sets defaults via `??=` (weak default operator):
 
 ```bitbake
-PANTAVISOR_FEATURES ??= " dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect "
+PANTAVISOR_FEATURES ??= " dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect xconnect-dbus-systembus container-mdev "
 ```
 
 In distro includes, you **must** use `:append` or `:remove` — never `+=`:

--- a/docs/overview/pantavisor-development.md
+++ b/docs/overview/pantavisor-development.md
@@ -10,7 +10,7 @@ Use `kas/with-workspace.yaml` to develop pantavisor source locally while rebuild
 The first build with the workspace overlay creates the devtool workspace:
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
 ```
 
 Workspace sources:
@@ -36,7 +36,7 @@ build/workspace/appends/lxc-pv_git.bbappend   # create manually if needed
 2. **Rebuild**:
    ```bash
    cd /path/to/meta-pantavisor
-   ./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+   ./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
    ```
 
 3. **Test** — see [manual testing](testing/manual/index.md)
@@ -51,13 +51,13 @@ build/workspace/appends/lxc-pv_git.bbappend   # create manually if needed
 
 Build only pantavisor (faster iteration):
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pantavisor
 ```
 
 Build pantavisor and appengine image:
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pantavisor-appengine
 ```
 
@@ -72,7 +72,7 @@ vim xconnect/plugins/drm.c
 
 # 2. Rebuild (from meta-pantavisor root)
 cd /path/to/meta-pantavisor
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
 
 # 3. Reload docker image
 docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
@@ -97,7 +97,7 @@ vim xconnect/plugins/unix.c
 
 # 2. Build appengine
 cd /path/to/meta-pantavisor
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
 
 # 3. Reload and test
 docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
@@ -142,7 +142,7 @@ cd lxc-pv && git checkout <branch>
 ### Stale Build Artifacts
 
 ```bash
-./kas-container shell .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container shell kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     -c "bitbake -c cleansstate <recipe-name>"
 ```
 

--- a/docs/overview/testing/manual/testplans/testplan-auto-recovery.md
+++ b/docs/overview/testing/manual/testplans/testplan-auto-recovery.md
@@ -23,7 +23,7 @@ For pv-ctrl API tests, see [testplan-pvctrl.md](testplan-pvctrl.md).
 ### Build Appengine Image and Test Containers
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-example-recovery \
     --target pv-example-stabilize \
     --target pv-example-random \

--- a/docs/overview/testing/manual/testplans/testplan-container-control.md
+++ b/docs/overview/testing/manual/testplans/testplan-container-control.md
@@ -12,7 +12,7 @@ For pv-ctrl API tests, see [testplan-pvctrl.md](testplan-pvctrl.md).
 ### Build Appengine Image and Example Containers
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-example-unix-server \
     --target pv-example-unix-client \
     --target pv-example-cleanexit \

--- a/docs/overview/testing/manual/testplans/testplan-ipam.md
+++ b/docs/overview/testing/manual/testplans/testplan-ipam.md
@@ -9,7 +9,7 @@ Tests for IPAM (IP Address Management) pool-based container networking via the a
 ### Build Appengine Image and Test Containers
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml \
     --target pv-example-device-ipam \
     --target pv-example-device-ipam-2pools \
     --target pv-example-device-ipam-lxcbr \

--- a/docs/overview/testing/manual/testplans/testplan-pvctrl.md
+++ b/docs/overview/testing/manual/testplans/testplan-pvctrl.md
@@ -63,10 +63,10 @@ Not automated (kept manual):
 
 ```bash
 # Build with workspace overlay (for testing local pantavisor changes)
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
 
 # Build example containers for xconnect tests
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml \
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml \
     --target pv-example-unix-server \
     --target pv-example-unix-client
 

--- a/docs/overview/testing/manual/testplans/testplan-pvtx.md
+++ b/docs/overview/testing/manual/testplans/testplan-pvtx.md
@@ -129,7 +129,7 @@ Build the appengine image (the `pantavisor-pvtest` package installs `pvtx`,
 the test script, and all test data into the image):
 
 ```bash
-./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml
+./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml
 
 docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
 ```


### PR DESCRIPTION
## Origin

docs-framework repo, `codechecks/meta-pantavisor/2026-08-27-all-f9613e7-claude-sonnet-5.md` — a CODECHECKBOOK.md source-vs-docs check against meta-pantavisor commit `f9613e7ddb938452b27e238c382c8b30133bea63`, dated 2026-08-27.

## What the code says

- **Critical (stale)**: `.github/configs/release/` was removed from this repo in commit `7cd9f72` ("ci: drop legacy .github/configs symlink and unused templates"); only `kas/build-configs/release/` exists at HEAD, but the stale path is still the literal, copy-pasteable command in 12 docs files (~26 occurrences), and `build-system.md`'s own "Key Build Paths" table still listed both the stale path and the correct one as if both were real.
- **Major (mismatched)**: `classes/pvbase.bbclass`'s current `PANTAVISOR_FEATURES` default is an 11-token string (`dm-crypt dm-verity autogrow runc tailscale debug rngdaemon pvcontrol xconnect xconnect-dbus-systembus container-mdev`); `docs/overview/meta-pantavisor.md` was missing both `xconnect-dbus-systembus` and `container-mdev`, and `docs/overview/build-system.md` was missing `xconnect-dbus-systembus`.
- **Minor (undocumented)**: `kas/build-configs/build-appengine-distro.yaml` (target `pantavisor-appengine-distro`) and `kas/build-configs/build-base-remix.yaml` (target `pantavisor-remix`) are real, standalone kas configs but were never mentioned by filename anywhere in `docs/`, even though their build targets are documented elsewhere as reachable only via `bitbake <target>` after a different base kas build.

## What changed and why

- **12 docs files** (`docs/overview/get-started.md`, `docs/overview/pantavisor-development.md`, `docs/overview/container-development.md`, `docs/overview/build-system.md`, `docs/getting-started/develop/application/add-application.md`, `docs/overview/examples/xconnect-examples.md`, `docs/overview/examples/pvwificonnect.md`, and the five testplan files under `docs/overview/testing/manual/testplans/`): replaced every `.github/configs/release/` reference with `kas/build-configs/release/`, so copy-pasted build commands actually resolve to a real path. Closes the Critical finding.
- `docs/overview/build-system.md`: also dropped the stale `.github/configs/release/` row from the "Key Build Paths" table (the correct `kas/build-configs/release/` row already covers it). Closes the rest of the Critical finding.
- `docs/overview/meta-pantavisor.md`: added the missing `xconnect-dbus-systembus` and `container-mdev` rows/tokens to the feature table, the prose default line, and the `??=` code-block example, matching `pvbase.bbclass`'s current 11-token default. Closes half of the Major finding.
- `docs/overview/build-system.md`: added the missing `xconnect-dbus-systembus` token to its feature table, prose default line, and code-block example (it already had `container-mdev`). Closes the other half of the Major finding.
- `docs/overview/get-started.md`: added two example `kas-container build` invocations (for `build-appengine-distro.yaml` and `build-base-remix.yaml`) right after the existing "Common Build Targets" example, in the same style. Closes the Minor finding.

## Status

Draft PR opened from an automated docs-eval code-check fix pass. Not verified against the rendered site — please review before merging.

