### PR TITLE
fix(rockchip): scope meta-rockchip bbappends to the JeffyCN platform

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -27,8 +27,13 @@ BBFILES_DYNAMIC += "\
 	variscite-bsp:${LAYERDIR}/dynamic-layers/meta-variscite-bsp/recipes-*/*/*.bbappend \
 	toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/recipes-*/*/*.bbappend \
 	rockchip:${LAYERDIR}/dynamic-layers/meta-rockchip-mainline/recipes-*/*/*.bbappend \
-	rockchip:${LAYERDIR}/dynamic-layers/meta-rockchip/recipes-*/*/*.bbappend \
 "
+
+# dynamic-layers/meta-rockchip/ targets the JeffyCN meta-rockchip recipe names
+# (u-boot-rockchip, linux-rockchip). The radxa fork registers the same
+# "rockchip" collection but ships different recipes, so gating it here would
+# dangle those bbappends on radxa builds. Wired up in kas/platforms/rockchip.yaml
+# instead.
 
 IMAGE_CLASSES += "image_types_vfat"
 INHERIT += "pvbase"

--- a/kas/build-configs/release/rockchip-orangepi-5b-scarthgap.yaml
+++ b/kas/build-configs/release/rockchip-orangepi-5b-scarthgap.yaml
@@ -41,6 +41,12 @@ repos:
             meta-python:
         path: layers/meta-openembedded
         url: https://github.com/openembedded/meta-openembedded.git
+bblayers_conf_header:
+    platform-rockchip: |
+        # Scoped to this platform: the radxa fork (kas/platforms/radxa.yaml) also
+        # registers the "rockchip" collection but has no u-boot-rockchip /
+        # linux-rockchip recipes for these bbappends to extend.
+        BBFILES_DYNAMIC += " rockchip:${META_PANTAVISOR_BASE}/dynamic-layers/meta-rockchip/recipes-*/*/*.bbappend"
 local_conf_header:
     platform-rockchip: |
         PV_UBOOT_AUTOFDT = "1"

--- a/kas/platforms/rockchip.yaml
+++ b/kas/platforms/rockchip.yaml
@@ -19,6 +19,13 @@ repos:
       meta-arm:
       meta-arm-toolchain:
 
+bblayers_conf_header:
+  platform-rockchip: |
+    # Scoped to this platform: the radxa fork (kas/platforms/radxa.yaml) also
+    # registers the "rockchip" collection but has no u-boot-rockchip /
+    # linux-rockchip recipes for these bbappends to extend.
+    BBFILES_DYNAMIC += " rockchip:${META_PANTAVISOR_BASE}/dynamic-layers/meta-rockchip/recipes-*/*/*.bbappend"
+
 local_conf_header:
   platform-rockchip: |
     PV_UBOOT_AUTOFDT = "1"


### PR DESCRIPTION
## Problem

`6ec1f321` (Orange Pi 5B support) added `dynamic-layers/meta-rockchip/` with bbappends for the **JeffyCN** recipe names `u-boot-rockchip` and `linux-rockchip`, gated on the `rockchip` `BBFILE_COLLECTIONS` in `conf/layer.conf`.

The **radxa fork** of meta-rockchip (`kas/platforms/radxa.yaml`, used by `radxa-rock5a`) registers that *same* collection name but ships different recipes (`u-boot_%.bbappend`, `linux-yocto*`, `linux-torvalds-next`). Both bbappends dangled there and bitbake aborted at parse time:

```
ERROR: No recipes in default available for:
  .../dynamic-layers/meta-rockchip/recipes-bsp/u-boot/u-boot-rockchip.bbappend
  .../dynamic-layers/meta-rockchip/recipes-kernel/linux/linux-rockchip_%.bbappend
```

`radxa-rock5a` is in the `onpush` / `release` matrices, so this broke those builds.

## Fix

- Move the `rockchip:.../dynamic-layers/meta-rockchip/...` `BBFILES_DYNAMIC` entry out of `conf/layer.conf` and into `kas/platforms/rockchip.yaml`'s `bblayers_conf_header`, so it only applies on the JeffyCN platform. Uses `${META_PANTAVISOR_BASE}` (set in `conf/layer.conf`, expanded late) rather than the `${LAYERDIR}` form `kas/platforms/ti.yaml` uses, which relies on layer parse order.
- The shared `meta-rockchip-mainline` entry (`u-boot_%.bbappend`, a recipe both forks provide) stays in `conf/layer.conf`.
- Regenerate `kas/build-configs/release/rockchip-orangepi-5b-scarthgap.yaml` (flattened `kas dump` — does not re-read the platform fragment) so CI's orangepi-5b build carries the new `bblayers_conf_header`. Pinned revs preserved; diff is just the 6-line block.

## Test plan

- `radxa-rock5a`: `bitbake -p` clean (0 errors); **full `pantavisor-starter` image build succeeds** (5966 tasks, 0 errors) — produces `pantavisor-starter-rock-5a.rootfs.wic`.
- `orangepi-5b` (regenerated release config): `bitbake -p` clean; `bitbake -e` confirms the bbappends still apply — u-boot `SRC_URI` carries the 4 `pv` boot patches, `linux` `SRC_URI` carries `0001-arm64-dts-rockchip-add-orangepi-5b.patch`.